### PR TITLE
Add Solution for Segregating Even and Odd Nodes in Linked List

### DIFF
--- a/docs/DSA-Problem-Solution/Loop in linked list.md
+++ b/docs/DSA-Problem-Solution/Loop in linked list.md
@@ -1,0 +1,265 @@
+---
+id: isomorphic-strings
+title: "What are isomorphic strings."
+sidebar_label: "Isomorphic strings"
+sidebar_position: 6
+description: "Isomorphic strings are two strings that can be transformed into each other by a consistent mapping of characters. "
+tags: [String,isomorphic strings]
+---
+
+
+
+# Finding a Loop in a Linked List
+
+## Problem Description
+
+In a linked list, a **loop** occurs when a node's next pointer points back to a previous node, creating a cycle. Detecting a loop is crucial, as it can lead to infinite traversals and memory issues. The goal is to determine whether a loop exists in the linked list and, if so, identify the node where the loop begins.
+
+## Approach
+
+One of the most efficient methods for detecting a loop in a linked list is **Floyd's Cycle-Finding Algorithm**, also known as the "Tortoise and Hare" algorithm.
+
+### Steps:
+
+1. **Initialization**: Use two pointers, `slow` and `fast`. The `slow` pointer moves one step at a time, while the `fast` pointer moves two steps at a time.
+
+2. **Traversal**:
+   - Start both pointers at the head of the linked list.
+   - Move `slow` by one node and `fast` by two nodes in each iteration.
+   - If `fast` reaches the end of the list (`null`), there is no loop.
+   - If `slow` equals `fast`, a loop exists.
+
+3. **Finding the Start of the Loop**:
+   - Once a loop is detected, to find the starting node of the loop:
+     - Move one pointer back to the head of the list and keep the other at the meeting point.
+     - Move both pointers one step at a time; the node where they meet is the start of the loop.
+
+## Implementation
+
+## Java
+```java
+class Node {
+    int value;
+    Node next;
+
+    Node(int value) {
+        this.value = value;
+        this.next = null;
+    }
+}
+
+class LinkedList {
+    Node head;
+
+    // Detect loop using Floyd's Cycle-Finding Algorithm
+    public Node detectLoop() {
+        Node slow = head;
+        Node fast = head;
+
+        // Phase 1: Detect loop
+        while (fast != null && fast.next != null) {
+            slow = slow.next;
+            fast = fast.next.next;
+            if (slow == fast) { // Loop detected
+                break;
+            }
+        }
+
+        // No loop
+        if (fast == null || fast.next == null) {
+            return null;
+        }
+
+        // Phase 2: Find the start of the loop
+        slow = head;
+        while (slow != fast) {
+            slow = slow.next;
+            fast = fast.next;
+        }
+
+        return slow; // Start of the loop
+    }
+
+    // Method to create a loop for testing
+    public void createLoop(int loopStartIndex) {
+        Node loopStartNode = head;
+        Node lastNode = head;
+        int index = 0;
+
+        // Find the loop start node
+        while (index < loopStartIndex) {
+            loopStartNode = loopStartNode.next;
+            index++;
+        }
+
+        // Find the last node
+        while (lastNode.next != null) {
+            lastNode = lastNode.next;
+        }
+
+        // Create the loop
+        lastNode.next = loopStartNode;
+    }
+}
+
+// Example usage
+public class Main {
+    public static void main(String[] args) {
+        LinkedList ll = new LinkedList();
+        ll.head = new Node(1);
+        ll.head.next = new Node(2);
+        ll.head.next.next = new Node(3);
+        ll.head.next.next.next = new Node(4);
+        ll.head.createLoop(1); // Creating a loop back to node with value 2
+
+        Node loopStart = ll.detectLoop();
+        if (loopStart != null) {
+            System.out.println("Loop detected at node with value: " + loopStart.value);
+        } else {
+            System.out.println("No loop detected.");
+        }
+    }
+}
+```
+
+## C++
+```cpp
+#include <iostream>
+
+class Node {
+public:
+    int value;
+    Node* next;
+
+    Node(int val) : value(val), next(nullptr) {}
+};
+
+class LinkedList {
+public:
+    Node* head;
+
+    LinkedList() : head(nullptr) {}
+
+    // Detect loop using Floyd's Cycle-Finding Algorithm
+    Node* detectLoop() {
+        Node* slow = head;
+        Node* fast = head;
+
+        // Phase 1: Detect loop
+        while (fast != nullptr && fast->next != nullptr) {
+            slow = slow->next;
+            fast = fast->next->next;
+
+            if (slow == fast) { // Loop detected
+                break;
+            }
+        }
+
+        // No loop
+        if (fast == nullptr || fast->next == nullptr) {
+            return nullptr;
+        }
+
+        // Phase 2: Find the start of the loop
+        slow = head;
+        while (slow != fast) {
+            slow = slow->next;
+            fast = fast->next;
+        }
+
+        return slow; // Start of the loop
+    }
+
+    // Method to create a loop for testing
+    void createLoop(int loopStartIndex) {
+        Node* loopStartNode = head;
+        Node* lastNode = head;
+        int index = 0;
+
+        // Find the loop start node
+        while (index < loopStartIndex) {
+            loopStartNode = loopStartNode->next;
+            index++;
+        }
+
+        // Find the last node
+        while (lastNode->next != nullptr) {
+            lastNode = lastNode->next;
+        }
+
+        // Create the loop
+        lastNode->next = loopStartNode;
+    }
+};
+
+// Example usage
+int main() {
+    LinkedList ll;
+    ll.head = new Node(1);
+    ll.head->next = new Node(2);
+    ll.head->next->next = new Node(3);
+    ll.head->next->next->next = new Node(4);
+    ll.head->createLoop(1); // Creating a loop back to node with value 2
+
+    Node* loopStart = ll.detectLoop();
+    if (loopStart != nullptr) {
+        std::cout << "Loop detected at node with value: " << loopStart->value << std::endl;
+    } else {
+        std::cout << "No loop detected." << std::endl;
+    }
+
+    return 0;
+}
+```
+
+## Python
+```python
+class Node:
+    def __init__(self, value):
+        self.value = value
+        self.next = None
+
+class LinkedList:
+    def __init__(self):
+        self.head = None
+
+    def detect_loop(self):
+        slow = fast = self.head
+
+        # Phase 1: Detect loop
+        while fast and fast.next:
+            slow = slow.next
+            fast = fast.next.next
+            if slow == fast:  # Loop detected
+                break
+        else:
+            return None  # No loop
+
+        # Phase 2: Find the start of the loop
+        slow = self.head
+        while slow != fast:
+            slow = slow.next
+            fast = fast.next
+
+        return slow  # Start of the loop
+
+# Example usage
+if __name__ == "__main__":
+    ll = LinkedList()
+    ll.head = Node(1)
+    ll.head.next = Node(2)
+    ll.head.next.next = Node(3)
+    ll.head.next.next.next = Node(4)
+    ll.head.next.next.next.next = ll.head.next  # Creating a loop
+
+    loop_start = ll.detect_loop()
+    if loop_start:
+        print(f"Loop detected at node with value: {loop_start.value}")
+    else:
+        print("No loop detected.")
+```
+
+
+
+
+

--- a/docs/DSA-Problem-Solution/Segregate even and odd nodes in LinkedList.md
+++ b/docs/DSA-Problem-Solution/Segregate even and odd nodes in LinkedList.md
@@ -1,0 +1,262 @@
+---
+id: segregate-even-odd-nodes
+title: "Segregate even and odd nodes in a linked list"
+sidebar_label: "Segregate"
+sidebar_position: 8
+description: "In a linked list, the goal is to rearrange the nodes such that all even-valued nodes appear before all odd-valued nodes.  "
+tags: [linked list]
+---
+
+
+
+# Segregate Even and Odd Nodes in a Linked List
+
+## Problem Description
+
+In a linked list, the goal is to rearrange the nodes such that all even-valued nodes appear before all odd-valued nodes. The relative order of the even and odd nodes should remain the same as in the original list. For example, given the linked list `1 -> 2 -> 3 -> 4 -> 5`, the output should be `2 -> 4 -> 1 -> 3 -> 5`.
+
+## Approach
+
+To segregate even and odd nodes, we can use the following approach:
+
+1. **Initialize Pointers**:
+   - Use two pointers to keep track of the even and odd nodes separately: `evenHead` and `oddHead`.
+   - Create two additional pointers to build the segregated list: `evenTail` and `oddTail`.
+
+2. **Traverse the List**:
+   - Iterate through the linked list and for each node:
+     - If the node's value is even, append it to the even list.
+     - If the node's value is odd, append it to the odd list.
+
+3. **Combine the Lists**:
+   - After traversing the list, connect the end of the even list to the head of the odd list.
+
+4. **Handle Edge Cases**:
+   - If the even list is empty, return the head of the odd list.
+   - If the odd list is empty, return the head of the even list.
+
+## Implementation
+
+## Java
+
+```java
+class Node {
+    int value;
+    Node next;
+
+    Node(int val) {
+        this.value = val;
+        this.next = null;
+    }
+}
+
+class LinkedList {
+    Node head;
+
+    // Function to segregate even and odd nodes
+    public Node segregateEvenOdd() {
+        if (head == null) return null;
+
+        Node evenHead = null, oddHead = null;
+        Node evenTail = null, oddTail = null;
+
+        Node current = head;
+
+        while (current != null) {
+            if (current.value % 2 == 0) {
+                // Append to even list
+                if (evenHead == null) {
+                    evenHead = current;
+                    evenTail = evenHead;
+                } else {
+                    evenTail.next = current;
+                    evenTail = evenTail.next;
+                }
+            } else {
+                // Append to odd list
+                if (oddHead == null) {
+                    oddHead = current;
+                    oddTail = oddHead;
+                } else {
+                    oddTail.next = current;
+                    oddTail = oddTail.next;
+                }
+            }
+            current = current.next;
+        }
+
+        // Combine even and odd lists
+        if (evenTail != null) {
+            evenTail.next = oddHead;
+        }
+        
+        if (oddTail != null) {
+            oddTail.next = null; // End the odd list
+        }
+
+        return evenHead != null ? evenHead : oddHead; // Return the head of the combined list
+    }
+
+    // Function to add a new node at the end of the list
+    public void a
+
+
+
+
+
+```
+## C++
+
+```cpp
+#include <iostream>
+
+class Node {
+public:
+    int value;
+    Node* next;
+
+    Node(int val) : value(val), next(nullptr) {}
+};
+
+class LinkedList {
+public:
+    Node* head;
+
+    LinkedList() : head(nullptr) {}
+
+    // Function to segregate even and odd nodes
+    Node* segregateEvenOdd() {
+        if (!head) return nullptr;
+
+        Node* evenHead = nullptr;
+        Node* oddHead = nullptr;
+        Node* evenTail = nullptr;
+        Node* oddTail = nullptr;
+
+        Node* current = head;
+
+        while (current) {
+            if (current->value % 2 == 0) {
+                // Append to even list
+                if (!evenHead) {
+                    evenHead = current;
+                    evenTail = evenHead;
+                } else {
+                    evenTail->next = current;
+                    evenTail = evenTail->next;
+                }
+            } else {
+                // Append to odd list
+                if (!oddHead) {
+                    oddHead = current;
+                    oddTail = oddHead;
+                } else {
+                    oddTail->next = current;
+                    oddTail = oddTail->next;
+                }
+            }
+            current = current->next;
+        }
+
+        // Combine even and odd lists
+        if (evenTail) {
+            evenTail->next = oddHead;
+        }
+        
+        if (oddTail) {
+            oddTail->next = nullptr; // End the odd list
+        }
+
+        return evenHead ? evenHead : oddHead; // Return the head of the combined list
+    }
+
+    // Function to add a new node at the end of the list
+    void append(int value) {
+        Node* newNode = new Node(value);
+        if (!head) {
+            head = newNode;
+            return;
+        }
+
+        Node* current = head;
+        while (current->next) {
+            current = current->next;
+        }
+        current->next = newNode;
+    }
+
+    // Function to print the linked list
+    void printList() {
+        Node* current = head;
+        while (current) {
+            std::cout << current->value << " -> ";
+            current = current->next;
+        }
+        std::cout << "nullptr" << std::endl;
+    }
+};
+
+// Example usage
+int main() {
+    LinkedList ll;
+    ll.append(1);
+    ll.append(2);
+    ll.append(3);
+    ll.append(4);
+    ll.append(5);
+
+    std::cout << "Original list: ";
+    ll.printList();
+
+    ll.head = ll.segregateEvenOdd();
+
+    std::cout << "Segregated list: ";
+    ll.printList();
+
+    return 0;
+}
+
+```
+
+## Python
+
+```python
+class Node:
+    def __init__(self, value):
+        self.value = value
+        self.next = None
+
+class LinkedList:
+    def __init__(self):
+        self.head = None
+
+    def segregate_even_odd(self):
+        if self.head is None:
+            return None
+
+        even_head = even_tail = None
+        odd_head = odd_tail = None
+
+        current = self.head
+
+        while current:
+            if current.value % 2 == 0:
+                # Append to even list
+                if even_head is None:
+                    even_head = even_tail = current
+                else:
+                    even_tail.next = current
+                    even_tail = even_tail.next
+            else:
+                # Append to odd list
+                if odd_head is None:
+                    odd_head = odd_tail = current
+                else:
+                    odd_tail.next = current
+                    odd_tail = odd_tail.next
+            current = current.next
+
+        # Combine even and odd lists
+        if even_tail:
+            eve
+```

--- a/docs/basic-dsa/Strings/Isomorphic strings.md
+++ b/docs/basic-dsa/Strings/Isomorphic strings.md
@@ -1,0 +1,155 @@
+---
+id: isomorphic-strings
+title: "What are isomorphic strings."
+sidebar_label: "Isomorphic strings"
+sidebar_position: 6
+description: "Isomorphic strings are two strings that can be transformed into each other by a consistent mapping of characters. "
+tags: [String,isomorphic strings]
+---
+
+# Isomorphic Strings
+
+## Definition
+Isomorphic strings are two strings that can be transformed into each other by a consistent mapping of characters. Each character in one string can be replaced with a character from the other string in a way that preserves the order of characters.
+
+### Example
+- **Isomorphic**: "egg" and "add"
+- **Not Isomorphic**: "foo" and "add"
+
+## Characteristics
+- Each character must map to a unique character in the other string.
+- The mapping must be consistent across the entire string.
+
+## Code Examples
+
+### Java
+
+```java
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class IsomorphicStrings {
+    public static boolean areIsomorphic(String str1, String str2) {
+        if (str1.length() != str2.length()) {
+            return false;
+        }
+
+        HashMap<Character, Character> mapping = new HashMap<>();
+        HashSet<Character> mappedChars = new HashSet<>();
+
+        for (int i = 0; i < str1.length(); i++) {
+            char char1 = str1.charAt(i);
+            char char2 = str2.charAt(i);
+
+            if (mapping.containsKey(char1)) {
+                if (mapping.get(char1) != char2) {
+                    return false;
+                }
+            } else {
+                if (mappedChars.contains(char2)) {
+                    return false;
+                }
+                mapping.put(char1, char2);
+                mappedChars.add(char2);
+            }
+        }
+
+        return true;
+    }
+
+    public static void main(String[] args) {
+        String str1 = "egg";
+        String str2 = "add";
+
+        if (areIsomorphic(str1, str2)) {
+            System.out.println("The strings are isomorphic.");
+        } else {
+            System.out.println("The strings are not isomorphic.");
+        }
+    }
+}
+```
+
+
+### C++
+```C++
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+
+bool areIsomorphic(const std::string& str1, const std::string& str2) {
+    if (str1.length() != str2.length()) {
+        return false;
+    }
+
+    std::unordered_map<char, char> mapping;
+    std::unordered_set<char> mappedChars;
+
+    for (size_t i = 0; i < str1.length(); ++i) {
+        char char1 = str1[i];
+        char char2 = str2[i];
+
+        if (mapping.find(char1) != mapping.end()) {
+            if (mapping[char1] != char2) {
+                return false;
+            }
+        } else {
+            if (mappedChars.find(char2) != mappedChars.end()) {
+                return false;
+            }
+
+            mapping[char1] = char2;
+            mappedChars.insert(char2);
+        }
+    }
+
+    return true;
+}
+
+int main() {
+    std::string str1 = "egg";
+    std::string str2 = "add";
+
+    if (areIsomorphic(str1, str2)) {
+        std::cout << "The strings are isomorphic." << std::endl;
+    } else {
+        std::cout << "The strings are not isomorphic." << std::endl;
+    }
+
+    return 0;
+}
+```
+
+### Python
+```Python
+
+def are_isomorphic(str1, str2):
+    if len(str1) != len(str2):
+        return False
+
+    char_map = {}
+    mapped_chars = set()
+
+    for char1, char2 in zip(str1, str2):
+        if char1 in char_map:
+            if char_map[char1] != char2:
+                return False
+        else:
+            if char2 in mapped_chars:
+                return False
+
+            char_map[char1] = char2
+            mapped_chars.add(char2)
+
+    return True
+
+if __name__ == "__main__":
+    str1 = "egg"
+    str2 = "add"
+
+    if are_isomorphic(str1, str2):
+        print("The strings are isomorphic.")
+    else:
+        print("The strings are not isomorphic.")
+```


### PR DESCRIPTION
## 📥 Pull Request

### Description
This pull request adds a new solution for segregating even and odd nodes in a linked list. The implementation ensures that all even-valued nodes appear before the odd-valued nodes while maintaining their relative order.


Fixes #922

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
