### PR TITLE
Footer-'Tutorials' link redirects to  the tutorial section ,bug resolved

### DIFF
--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -90,7 +90,7 @@ const Footer = () => {
               </li>
               <li className="list-none">
                 <Link
-                  to="#"
+                  to="/docs/"
                   className="text-gray-400 hover:text-[#61dafb] transition-colors duration-300"
                 >
                   Tutorials


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR fixes a bug in the footer where the "Tutorials" link under Resources redirects users to the top of the page instead of the intended tutorial section. The link behavior has been updated to ensure users are taken directly to the tutorial section, providing a consistent navigation experience similar to the navbar.

Fixes #1018

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Bug Details
- **Issue**: Clicking the "Tutorials" link in the footer does not navigate to the tutorial section, leading users to the top of the page instead.
- **Expected Behavior**: The link should scroll the page directly to the tutorial section, similar to how it functions from the navbar.

### Steps to Reproduce
1. Scroll to any part of the page.
2. Click on the "Tutorials" link in the footer under Resources.
3. Observe that the page scrolls to the top instead of the tutorial section.

### Changes Made
- Updated the link behavior in the footer to correctly navigate to the tutorial section.

### Testing
- Verified that the "Tutorials" link now correctly scrolls to the tutorial section without redirecting to the top of the page.

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
