### PR TITLE
Fix: Exclude "$" Symbol When Copying Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ This website is built using [Docusaurus 3](https://docusaurus.io/), a modern sta
 ## Installation
 
 ```bash
-$ npm install
+ npm install
 ```
 
 ## Local Development
 
 ```bash
-$ npm start
+ npm start
 ```
 
 This command starts a local development server and opens a browser window. Most changes are reflected live without having to restart the server.
@@ -124,7 +124,7 @@ This command starts a local development server and opens a browser window. Most 
 ## Build
 
 ```bash
-$ npm run build
+ npm run build
 ```
 
 This command generates static content into the `build` directory, which can be served using any static content hosting service.
@@ -134,13 +134,13 @@ This command generates static content into the `build` directory, which can be s
 ### Using SSH:
 
 ```bash
-$ USE_SSH=true npm run deploy
+ USE_SSH=true npm run deploy
 ```
 
 ### Not using SSH:
 
 ```bash
-$ GIT_USER=<Your GitHub username> npm run deploy
+ GIT_USER=<Your GitHub username> npm run deploy
 ```
 
 If you are using GitHub Pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR resolves the issue where the "$" symbol is included when copying commands from the documentation, causing terminal errors.

# Bug Fix:
Modified command blocks in README to exclude the "$" symbol from copied text

# Fixes #1040 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

# Screenshot

# Before 💥💥
![image](https://github.com/user-attachments/assets/d0e0bd86-89e7-4626-9df1-069449f47523)

# After 💥💥
![image](https://github.com/user-attachments/assets/a2e0c4d4-f945-4973-b003-c68eeaa4881d)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
