### PR TITLE
fix: correct challenge names in challenge2 and challenge3

### DIFF
--- a/src/pages/challenges/challenge2.tsx
+++ b/src/pages/challenges/challenge2.tsx
@@ -260,7 +260,7 @@ const DataStructuresQuiz = () => {
       description="Test your knowledge of data structures with this quiz."
     >
       <div className="bg-blue-100 text-sky-800 max-w-2xl mx-auto rounded-2xl my-10 rounded-3xl p-10">
-        <h2 className="text-center text-blue-600">Data Structures Challenge-1</h2>
+        <h2 className="text-center text-blue-600">Data Structures Challenge-2</h2>
         {showResult ? (
           <div>
             <h2>

--- a/src/pages/challenges/challenge3.tsx
+++ b/src/pages/challenges/challenge3.tsx
@@ -345,7 +345,7 @@ const DataStructuresQuiz = () => {
       description="Test your knowledge of data structures with this quiz."
     >
       <div className="bg-blue-100 text-sky-800 max-w-2xl mx-auto rounded-2xl my-10 rounded-3xl p-10">
-        <h2 className="text-center text-blue-600">Data Structures Challenge-1</h2>
+        <h2 className="text-center text-blue-600">Advanced Data Structures</h2>
         {showResult ? (
           <div>
             <h2>


### PR DESCRIPTION
## 📥 Pull Request

### Description
Fixed incorrect challenge titles displayed during test and result page:
- challenge2.tsx: Updated title to "Data Structures Challenge-2"
- challenge3.tsx: Updated title to "Advanced Data Structures"

Fixes #2091

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
