### PR TITLE
fix: update challenge3 timer from 30 to 60 minutes

### DIFF
--- a/src/pages/challenges/challenge3.tsx
+++ b/src/pages/challenges/challenge3.tsx
@@ -273,7 +273,7 @@ const DataStructuresQuiz = () => {
   const [selectedOption, setSelectedOption] = useState("");
   const [correctAnswers, setCorrectAnswers] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [timeLeft, setTimeLeft] = useState(1800); // 30 minutes in seconds
+  const [timeLeft, setTimeLeft] = useState(3600); // 60 minutes in seconds
   const [timerId, setTimerId] = useState(null);
   const [timeSpent, setTimeSpent] = useState(0); // To store the time spent on solving the quiz
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
@@ -313,7 +313,7 @@ const DataStructuresQuiz = () => {
   // Function to finish the quiz
   const handleFinishQuiz = () => {
     clearInterval(timerId); // Stop the timer when the quiz is finished
-    setTimeSpent(1800 - timeLeft); // Calculate time spent
+    setTimeSpent(3600 - timeLeft); // Calculate time spent
     setShowResult(true);
   };
 


### PR DESCRIPTION
## 📥 Pull Request

### Description
Updated challenge3 timer from 1800 seconds (30 min) to 3600 seconds (60 min) to match the time limit shown on the challenges listing page.

Fixes #2092 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
