### PR TITLE
fix: markdown formatting consistency in coding patterns blog

### DIFF
--- a/blog/20-most-important-coding-pattern.md
+++ b/blog/20-most-important-coding-pattern.md
@@ -239,7 +239,7 @@ Let's go through each pattern one by one.
   - Comprehensive: Ensures that you consider all possible combinations of elements.
   - Versatile: Can be used to solve a variety of problems, including generating power sets, combinations, and permutations.
 - **Cons**:
-  - Time Complexity: Can lead to exponential time complexity, as the number of subsets of a set is 2^N.
+  - Time Complexity: Can lead to exponential time complexity, as the number of subsets of a set is $2^N$.
   - Space Complexity: Requires additional space to store all the subsets.
 
 **Example Problems from Grokking the Coding Interview**:


### PR DESCRIPTION
## Summary
fix: markdown formatting in coding patterns blog

This PR fixes markdown formatting inconsistencies in `blog/20-most-important-coding-pattern.md`.

## Changes Made

* Replaced `O(...)` with `$O(...)$` for proper markdown/LaTeX consistency
* Replaced `2^N` with `$2^N$` for correct mathematical formatting
* Removed incorrect or duplicated headings like `## Time Complexity` inside bullet points
* Improved readability and consistency across complexity explanations

## Scope

* This PR contains changes to **only one file** as requested:
* Fixes #2107

  * `blog/20-most-important-coding-pattern.md`

## Note

Apologies for the earlier confusion with additional file changes. This PR has been cleaned and restricted to only the required updates.

---
