### PR TITLE
feat: add question progress indicator in all challenge pages

### DIFF
--- a/src/pages/challenges/challenge1.tsx
+++ b/src/pages/challenges/challenge1.tsx
@@ -268,6 +268,7 @@ const DataStructuresQuiz: React.FC = () => {
             <h3 className="text-center text-rose-900">Time Left: {formatTime(timeLeft)}</h3>{" "}
             {/* Show running timer */}
             <div className="rounded-2xl p-4">
+              <p className="text-center text-gray-600 mb-2">Question {currentQuestionIndex + 1} of {questions.length}</p>
               <h3>{questions[currentQuestionIndex].question}</h3>
               <div>
                 {questions[currentQuestionIndex].options.map(

--- a/src/pages/challenges/challenge2.tsx
+++ b/src/pages/challenges/challenge2.tsx
@@ -290,6 +290,7 @@ const DataStructuresQuiz = () => {
             <h3 className="text-center text-rose-900">Time Left: {formatTime(timeLeft)}</h3>{" "}
             {/* Show running timer */}
             <div className="bg-gray-100 text-neutral-800 rounded-2xl p-4">
+              <p className="text-center text-gray-600 mb-2">Question {currentQuestionIndex + 1} of {questions.length}</p>
               <h3>{questions[currentQuestionIndex].question}</h3>
               <div>
                 {questions[currentQuestionIndex].options.map(

--- a/src/pages/challenges/challenge3.tsx
+++ b/src/pages/challenges/challenge3.tsx
@@ -375,6 +375,7 @@ const DataStructuresQuiz = () => {
             <h3 className="text-center text-rose-900">Time Left: {formatTime(timeLeft)}</h3>{" "}
             {/* Show running timer */}
             <div className="bg-gray-100 text-neutral-800 rounded-2xl p-4">
+              <p className="text-center text-gray-600 mb-2">Question {currentQuestionIndex + 1} of {questions.length}</p>
               <h3>{questions[currentQuestionIndex].question}</h3>
               <div>
                 {questions[currentQuestionIndex].options.map(


### PR DESCRIPTION
## 📥 Pull Request

### Description
Added a "Question X of Y" progress indicator above the question text in all three challenge pages, so users can track their progress during timed challenges.

Fixes #2093 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
