### PR TITLE
fix: disable git history features for development builds (#2102)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,6 +4,9 @@ import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 const path = require("path");
 
+// Only show git history in production builds
+const showGitHistory = process.env.NODE_ENV === "production";
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Algo",
@@ -30,8 +33,8 @@ const config = {
             "https://github.com/ajay-dhangar/algo/tree/main/templates/",
           remarkPlugins: [remarkMath],
           rehypePlugins: [rehypeKatex],
-          showLastUpdateAuthor: true,
-          showLastUpdateTime: true,
+          showLastUpdateAuthor: showGitHistory,
+          showLastUpdateTime: showGitHistory,
         },
         blog: {
           showReadingTime: true,
@@ -226,8 +229,8 @@ const config = {
         sidebarPath: require.resolve("./dsa-interview-sidebars.js"),
         remarkPlugins: [remarkMath],
         rehypePlugins: [rehypeKatex],
-        showLastUpdateAuthor: true,
-        showLastUpdateTime: true,
+        showLastUpdateAuthor: showGitHistory,
+        showLastUpdateTime: showGitHistory,
       },
     ],
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,9 +3,29 @@ import { themes as prismThemes } from "prism-react-renderer";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
 const path = require("path");
+const fs = require("fs");
+const { execSync } = require("child_process");
 
-// Only show git history in production builds
-const showGitHistory = process.env.NODE_ENV === "production";
+// Only show git history when git metadata is actually available.
+// Can be explicitly overridden with DOCUSAURUS_ENABLE_GIT_HISTORY=true|false.
+const gitHistoryOverride = process.env.DOCUSAURUS_ENABLE_GIT_HISTORY;
+const showGitHistory =
+  gitHistoryOverride === "true"
+    ? true
+    : gitHistoryOverride === "false"
+      ? false
+      : (() => {
+          try {
+            if (!fs.existsSync(path.join(__dirname, ".git"))) {
+              return false;
+            }
+
+            execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
+            return true;
+          } catch {
+            return false;
+          }
+        })();
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
## Fix for Issue #2102: Docusaurus Build Crash on Fresh Clone

### Problem
The production build fails on fresh repository clones because Docusaurus tries to fetch git history when `showLastUpdateTime` and `showLastUpdateAuthor` are enabled.

### Solution
- Conditionally show git history metadata only in production builds (`NODE_ENV === "production"`)
- Development builds now work immediately after cloning without requiring prior git commits
- Fixes contributor onboarding experience for GSSoC 2026 participants

### Changes
- Modified `docusaurus.config.js` to add environment-based conditional logic
- Updated both main docs preset and dsa-interview plugin configuration

### Testing
- Build now works: `npm start` and `npm run build` in development
- Production builds will still show git history metadata

Closes #2102