### PR TITLE
Fix challenge quiz score inflation on repeated clicks

### DIFF
--- a/src/pages/challenges/challenge1.tsx
+++ b/src/pages/challenges/challenge1.tsx
@@ -184,7 +184,9 @@ const DataStructuresQuiz: React.FC = () => {
   }, [timeLeft]);
 
   // Handle option selection
-  const handleOptionSelect = (option:string) => {
+  const handleOptionSelect = (option: string) => {
+    if (userAnswers[currentQuestionIndex] !== undefined) return;
+
     setSelectedOption(option);
     if (option === questions[currentQuestionIndex].answer) {
       setCorrectAnswers(correctAnswers + 1);

--- a/src/pages/challenges/challenge1.tsx
+++ b/src/pages/challenges/challenge1.tsx
@@ -185,7 +185,7 @@ const DataStructuresQuiz: React.FC = () => {
 
   // Handle option selection
   const handleOptionSelect = (option: string) => {
-    if (userAnswers[currentQuestionIndex] !== undefined) return;
+    if (userAnswers[currentQuestionIndex] !== undefined || selectedOption) return;
 
     setSelectedOption(option);
     if (option === questions[currentQuestionIndex].answer) {

--- a/src/pages/challenges/challenge2.tsx
+++ b/src/pages/challenges/challenge2.tsx
@@ -206,7 +206,9 @@ const DataStructuresQuiz = () => {
   }, [timeLeft]);
 
   // Handle option selection
-  const handleOptionSelect = (option:string) => {
+  const handleOptionSelect = (option: string) => {
+    if (userAnswers[currentQuestionIndex] !== undefined) return;
+
     setSelectedOption(option);
     if (option === questions[currentQuestionIndex].answer) {
       setCorrectAnswers(correctAnswers + 1);

--- a/src/pages/challenges/challenge2.tsx
+++ b/src/pages/challenges/challenge2.tsx
@@ -207,7 +207,7 @@ const DataStructuresQuiz = () => {
 
   // Handle option selection
   const handleOptionSelect = (option: string) => {
-    if (userAnswers[currentQuestionIndex] !== undefined) return;
+    if (userAnswers[currentQuestionIndex] !== undefined || selectedOption) return;
 
     setSelectedOption(option);
     if (option === questions[currentQuestionIndex].answer) {

--- a/src/pages/challenges/challenge3.tsx
+++ b/src/pages/challenges/challenge3.tsx
@@ -293,7 +293,7 @@ const DataStructuresQuiz = () => {
 
   // Handle option selection
   const handleOptionSelect = (option: string) => {
-    if (userAnswers[currentQuestionIndex] !== undefined) return;
+    if (userAnswers[currentQuestionIndex] !== undefined || selectedOption) return;
 
     setSelectedOption(option);
     if (option === questions[currentQuestionIndex].answer) {

--- a/src/pages/challenges/challenge3.tsx
+++ b/src/pages/challenges/challenge3.tsx
@@ -292,7 +292,9 @@ const DataStructuresQuiz = () => {
   }, [timeLeft]);
 
   // Handle option selection
-  const handleOptionSelect = (option:string) => {
+  const handleOptionSelect = (option: string) => {
+    if (userAnswers[currentQuestionIndex] !== undefined) return;
+
     setSelectedOption(option);
     if (option === questions[currentQuestionIndex].answer) {
       setCorrectAnswers(correctAnswers + 1);


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR fixes a score inflation issue in the challenge quizzes where repeatedly clicking the correct answer for the same question would increase the score multiple times.

The issue occurred because the score state was updated on every click without checking whether the current question had already been answered.

### Changes Made
 - Added a guard condition inside handleOptionSelect()
 - Prevented users from re-answering the same question after the first selection
### Applied the fix to:
 - challenge1.tsx
 - challenge2.tsx
 - challenge3.tsx

Fixes #2135 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
