### PR TITLE
feat: add keyboard shortcuts accessibility support

### DIFF
--- a/src/components/KeyboardShortcutsModal.jsx
+++ b/src/components/KeyboardShortcutsModal.jsx
@@ -56,6 +56,8 @@ export default function KeyboardShortcutsModal({
     >
       <div
         onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
         style={{
           background: "#ffffff",
           color: "#111827",
@@ -98,6 +100,7 @@ export default function KeyboardShortcutsModal({
 
           <button
             onClick={onClose}
+            aria-label="Close"
             style={{
               border: "none",
               background: "#f3f4f6",

--- a/src/components/KeyboardShortcutsModal.jsx
+++ b/src/components/KeyboardShortcutsModal.jsx
@@ -1,0 +1,145 @@
+import React from "react";
+
+const ShortcutRow = ({ action, shortcut }) => (
+  <div
+    style={{
+      display: "flex",
+      justifyContent: "space-between",
+      alignItems: "center",
+      padding: "0.75rem 0",
+      borderBottom: "1px solid #e5e7eb",
+    }}
+  >
+    <span
+      style={{
+        fontSize: "0.95rem",
+        fontWeight: 500,
+      }}
+    >
+      {action}
+    </span>
+
+    <kbd
+      style={{
+        background: "#f3f4f6",
+        padding: "6px 10px",
+        borderRadius: "8px",
+        fontSize: "0.85rem",
+        fontWeight: 600,
+        border: "1px solid #d1d5db",
+      }}
+    >
+      {shortcut}
+    </kbd>
+  </div>
+);
+
+export default function KeyboardShortcutsModal({
+  isOpen,
+  onClose,
+}) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(0, 0, 0, 0.65)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 9999,
+        padding: "1rem",
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "#ffffff",
+          color: "#111827",
+          width: "100%",
+          maxWidth: "500px",
+          padding: "2rem",
+          borderRadius: "18px",
+          boxShadow: "0 25px 60px rgba(0,0,0,0.35)",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: "1.5rem",
+          }}
+        >
+          <div>
+            <h2
+              style={{
+                margin: 0,
+                fontSize: "1.5rem",
+                fontWeight: 700,
+              }}
+            >
+              Keyboard Shortcuts
+            </h2>
+
+            <p
+              style={{
+                marginTop: "0.4rem",
+                color: "#6b7280",
+                fontSize: "0.95rem",
+              }}
+            >
+              Navigate Algo faster with keyboard shortcuts
+            </p>
+          </div>
+
+          <button
+            onClick={onClose}
+            style={{
+              border: "none",
+              background: "#f3f4f6",
+              width: "40px",
+              height: "40px",
+              borderRadius: "10px",
+              cursor: "pointer",
+              fontSize: "1.2rem",
+              fontWeight: 700,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div>
+          <ShortcutRow
+            action="Open shortcuts help"
+            shortcut="Shift + /"
+          />
+
+          <ShortcutRow
+            action="Close modal"
+            shortcut="Esc"
+          />
+
+          <ShortcutRow
+            action="Focus search"
+            shortcut="/"
+          />
+
+          <ShortcutRow
+            action="Go to Home"
+            shortcut="g + h"
+          />
+
+          <ShortcutRow
+            action="Go to Docs"
+            shortcut="g + d"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -1,70 +1,84 @@
 import { useEffect, useRef } from "react";
 import { useHistory } from "@docusaurus/router";
 
-export default function useKeyboardShortcuts({
-  onOpenHelp,
-  onCloseHelp,
-}) {
+// 1. Keep configurations out of the core logic for cleaner readability
+const SEQUENTIAL_SHORTCUTS = {
+  gh: "/",
+  gd: "/docs",
+};
+
+const SEARCH_SELECTORS = [
+  ".DocSearch-Input",
+  'input[type="search"]',
+];
+
+export default function useKeyboardShortcuts({ onOpenHelp, onCloseHelp }) {
   const history = useHistory();
   const keyBuffer = useRef([]);
+  const timeoutRef = useRef(null);
 
   useEffect(() => {
-    const handler = (e) => {
+    const handler = (event) => {
       const active = document.activeElement;
 
+      // 2. Enhanced check to prevent stealing focus from rich text editors
       const isTyping =
         active &&
-        ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName);
+        (["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName) ||
+          active.isContentEditable);
 
       if (isTyping) return;
 
-      // Open shortcuts modal
-      if (e.shiftKey && e.key === "?") {
-        e.preventDefault();
+      const { key, shiftKey } = event;
+
+      // 3. Simple Single-key Map Matchers
+      if (shiftKey && key === "?") {
+        event.preventDefault();
         onOpenHelp();
         return;
       }
 
-      // Close modal
-      if (e.key === "Escape") {
-        e.preventDefault();
+      if (key === "Escape") {
+        event.preventDefault();
         onCloseHelp();
         keyBuffer.current = [];
         return;
       }
 
-      // Focus search
-      if (e.key === "/") {
-        e.preventDefault();
-
-        const searchInput =
-          document.querySelector(".DocSearch-Input") ||
-          document.querySelector('input[type="search"]');
-
-        if (searchInput) {
-          searchInput.focus();
-        }
-
+      if (key === "/") {
+        event.preventDefault();
+        // Look for the first matching search bar element
+        const searchInput = SEARCH_SELECTORS.reduce(
+          (el, selector) => el || document.querySelector(selector),
+          null
+        );
+        searchInput?.focus();
         return;
       }
 
-      // Navigation shortcuts
-      keyBuffer.current.push(e.key.toLowerCase());
+      // 4. Sequential Combo Handling with a smart timeout reset
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
 
+      keyBuffer.current.push(key.toLowerCase());
+
+      // Limit buffer to maximum required combo length (2 keys)
       if (keyBuffer.current.length > 2) {
         keyBuffer.current.shift();
       }
 
       const combo = keyBuffer.current.join("");
 
-      if (combo === "gh") {
-        history.push("/");
+      // Check if the current typed combo matches any route configuration
+      if (SEQUENTIAL_SHORTCUTS[combo]) {
+        history.push(SEQUENTIAL_SHORTCUTS[combo]);
         keyBuffer.current = [];
-      }
-
-      if (combo === "gd") {
-        history.push("/docs");
-        keyBuffer.current = [];
+      } else {
+        // Clear the buffer if the user stalls for more than 1 second mid-combo
+        timeoutRef.current = setTimeout(() => {
+          keyBuffer.current = [];
+        }, 1000);
       }
     };
 
@@ -72,6 +86,7 @@ export default function useKeyboardShortcuts({
 
     return () => {
       document.removeEventListener("keydown", handler);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
   }, [history, onOpenHelp, onCloseHelp]);
 }

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from "react";
+import { useHistory } from "@docusaurus/router";
+
+export default function useKeyboardShortcuts({
+  onOpenHelp,
+  onCloseHelp,
+}) {
+  const history = useHistory();
+  const keyBuffer = useRef([]);
+
+  useEffect(() => {
+    const handler = (e) => {
+      const active = document.activeElement;
+
+      const isTyping =
+        active &&
+        ["INPUT", "TEXTAREA", "SELECT"].includes(active.tagName);
+
+      if (isTyping) return;
+
+      // Open shortcuts modal
+      if (e.shiftKey && e.key === "?") {
+        e.preventDefault();
+        onOpenHelp();
+        return;
+      }
+
+      // Close modal
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCloseHelp();
+        keyBuffer.current = [];
+        return;
+      }
+
+      // Focus search
+      if (e.key === "/") {
+        e.preventDefault();
+
+        const searchInput =
+          document.querySelector(".DocSearch-Input") ||
+          document.querySelector('input[type="search"]');
+
+        if (searchInput) {
+          searchInput.focus();
+        }
+
+        return;
+      }
+
+      // Navigation shortcuts
+      keyBuffer.current.push(e.key.toLowerCase());
+
+      if (keyBuffer.current.length > 2) {
+        keyBuffer.current.shift();
+      }
+
+      const combo = keyBuffer.current.join("");
+
+      if (combo === "gh") {
+        history.push("/");
+        keyBuffer.current = [];
+      }
+
+      if (combo === "gd") {
+        history.push("/docs");
+        keyBuffer.current = [];
+      }
+    };
+
+    document.addEventListener("keydown", handler);
+
+    return () => {
+      document.removeEventListener("keydown", handler);
+    };
+  }, [history, onOpenHelp, onCloseHelp]);
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -3,12 +3,14 @@ import KeyboardShortcutsModal from "../components/KeyboardShortcutsModal";
 import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
 
 export default function Root({ children }) {
+  const onOpenHelp = useCallback(() => setShowKeyboardModal(true), []);
+  const onCloseHelp = useCallback(() => setShowKeyboardModal(false), []);
   const [showKeyboardModal, setShowKeyboardModal] =
     useState(false);
 
   useKeyboardShortcuts({
-    onOpenHelp: () => setShowKeyboardModal(true),
-    onCloseHelp: () => setShowKeyboardModal(false),
+    onOpenHelp,
+    onCloseHelp,
   });
 
   return (

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,6 +1,24 @@
-import React from 'react';
+import React, { useState } from "react";
+import KeyboardShortcutsModal from "../components/KeyboardShortcutsModal";
+import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
 
-// Default implementation, that you can customize
-export default function Root({children}) {
-  return <>{children}</>;
+export default function Root({ children }) {
+  const [showKeyboardModal, setShowKeyboardModal] =
+    useState(false);
+
+  useKeyboardShortcuts({
+    onOpenHelp: () => setShowKeyboardModal(true),
+    onCloseHelp: () => setShowKeyboardModal(false),
+  });
+
+  return (
+    <>
+      {children}
+
+      <KeyboardShortcutsModal
+        isOpen={showKeyboardModal}
+        onClose={() => setShowKeyboardModal(false)}
+      />
+    </>
+  );
 }

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import KeyboardShortcutsModal from "../components/KeyboardShortcutsModal";
 import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
 

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -17,7 +17,7 @@ export default function Root({ children }) {
 
       <KeyboardShortcutsModal
         isOpen={showKeyboardModal}
-        onClose={() => setShowKeyboardModal(false)}
+        onClose={onCloseHelp}
       />
     </>
   );


### PR DESCRIPTION
## Overview
Closes #2234

This PR adds keyboard accessibility and productivity enhancements to improve navigation and usability across the Algo platform.

The feature introduces global keyboard shortcuts that help users navigate the documentation faster while improving accessibility for keyboard-first users.

## Features Added

### Keyboard Shortcuts
Implemented the following shortcuts:

- **Shift + /** → Open keyboard shortcuts help modal
- **Esc** → Close shortcuts modal
- **/** → Focus search input instantly
- **g + h** → Navigate to Home
- **g + d** → Navigate to Docs

### Accessibility Improvements
- Prevents shortcuts from triggering while typing in input, textarea, or select fields
- Added globally accessible shortcuts via Docusaurus Root wrapper
- Added reusable keyboard shortcut hook for cleaner architecture and future extensibility
- Added a polished keyboard shortcuts modal for discoverability

## Files Added / Modified

### Added
- `src/hooks/useKeyboardShortcuts.js`
- `src/components/KeyboardShortcutsModal.jsx`

### Modified
- `src/theme/Root.js`

## Why This Matters
This improves:

- accessibility for keyboard-only users
- faster navigation for developers/students
- discoverability of productivity shortcuts
- overall user experience across the documentation platform

Since Algo is a developer/student-focused educational platform, keyboard navigation significantly enhances usability.

## Screenshots
Added working implementation screenshots below.
<img width="3840" height="2160" alt="Screenshot (143)" src="https://github.com/user-attachments/assets/b22995be-7630-4ba4-b649-0fae67b33c6d" />
