### PR TITLE
Remove redundant quiz link click handlers

### DIFF
--- a/src/pages/quizzes/index.tsx
+++ b/src/pages/quizzes/index.tsx
@@ -43,7 +43,6 @@ const Quizes: React.FC = () => {
               <Link
                 to="/algo/quizzes/arrays"
                 className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/arrays"}
               >
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
@@ -65,7 +64,6 @@ const Quizes: React.FC = () => {
               <Link
                 to="/algo/quizzes/stack"
                 className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/stack"}
               >
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
@@ -88,7 +86,6 @@ const Quizes: React.FC = () => {
               <Link
                 to="/algo/quizzes/queues"
                 className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/queues"}
               >
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
@@ -109,8 +106,7 @@ const Quizes: React.FC = () => {
               </p>
               <Link
                 to="/algo/quizzes/binary-tree"
-                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/binary-tree"}>
+                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none">
 
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
@@ -131,8 +127,7 @@ const Quizes: React.FC = () => {
               </p>
               <Link
                 to="/algo/quizzes/binary-search-tree"
-                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/binary-search-tree"}>
+                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none">
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
               </Link>
@@ -153,7 +148,6 @@ const Quizes: React.FC = () => {
               <Link
                 to="/algo/quizzes/avl-tree"
                 className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/avl-tree"}
               >
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
@@ -174,8 +168,7 @@ const Quizes: React.FC = () => {
               </p>
               <Link
                 to="/algo/quizzes/red-black-tree"
-                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/red-black-tree"}>
+                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none">
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
               </Link>
@@ -195,8 +188,7 @@ const Quizes: React.FC = () => {
               </p>
               <Link
                 to="/algo/quizzes/b-tree"
-                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none"
-                onClick={() => window.location.href = "/algo/quizzes/b-tree"}>
+                className="mt-4 bg-blue-600 text-white px-4 py-2 rounded-lg flex items-center space-x-2 hover:bg-blue-700 transition duration-300 border-none">
                 <FaPlayCircle className="w-5 h-5" />
                 <span>Start Quiz</span>
               </Link>
@@ -209,4 +201,3 @@ const Quizes: React.FC = () => {
 };
 
 export default Quizes;
-


### PR DESCRIPTION
## 📥 Pull Request

### Description
Removed redundant `onClick` handlers from quiz links in `src/pages/quizzes/index.tsx`.

The quiz cards already use Docusaurus `Link` components with the `to` prop, so manually assigning `window.location.href` is unnecessary and can bypass client-side navigation behavior.

Fixes #2289

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / code cleanup

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules