### PR TITLE
fix: prevent quiz navigation without answer selection

### DIFF
--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -163,7 +163,7 @@ int main()
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -244,6 +244,8 @@ int main()
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -362,7 +364,12 @@ int main()
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -111,7 +111,7 @@ const BTree: React.FC = () => {
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -192,6 +192,8 @@ const BTree: React.FC = () => {
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -312,7 +314,12 @@ const BTree: React.FC = () => {
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -28,7 +28,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -109,6 +109,8 @@ const BinarySearchTreeQuiz: React.FC = () => {
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -226,7 +228,12 @@ const BinarySearchTreeQuiz: React.FC = () => {
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -96,7 +96,7 @@ const BinaryTreeQuiz: React.FC = () => {
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -177,6 +177,8 @@ const BinaryTreeQuiz: React.FC = () => {
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -297,7 +299,12 @@ const BinaryTreeQuiz: React.FC = () => {
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/queue.tsx
+++ b/src/pages/quizzes/queue.tsx
@@ -170,7 +170,7 @@ void delete(Q){
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -251,6 +251,8 @@ void delete(Q){
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -370,7 +372,12 @@ void delete(Q){
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/queues.tsx
+++ b/src/pages/quizzes/queues.tsx
@@ -118,7 +118,7 @@ enqueue(30);`}
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -199,6 +199,8 @@ enqueue(30);`}
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -318,7 +320,12 @@ enqueue(30);`}
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -153,7 +153,7 @@ const RedBlackTreeQuiz: React.FC = () => {
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -234,6 +234,8 @@ const RedBlackTreeQuiz: React.FC = () => {
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -351,7 +353,12 @@ const RedBlackTreeQuiz: React.FC = () => {
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -202,7 +202,7 @@ print "balanced"`}
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [userAnswers, setUserAnswers] = useState<(string | null)[]>([]);
+  const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -283,6 +283,8 @@ print "balanced"`}
   };
 
   const nextQuestion = () => {
+    if (selectedOption === null) return;
+
     setUserAnswers((prev) => [...prev, selectedOption]);
 
     if (selectedOption === questions[currentQuestion].answer) {
@@ -402,7 +404,12 @@ print "balanced"`}
               </div>
               <button
                 onClick={nextQuestion}
-                className="mt-6 py-2 px-4 bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 text-white rounded-lg w-full transition-colors duration-300 border-none cursor-pointer font-semibold"
+                disabled={selectedOption === null}
+                className={`mt-6 py-2 px-4 text-white rounded-lg w-full transition-colors duration-300 border-none font-semibold ${
+                  selectedOption === null
+                    ? "bg-gray-400 cursor-not-allowed opacity-60"
+                    : "bg-blue-600 hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400 cursor-pointer"
+                }`}
               >
                 Next Question
               </button>


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR prevents users from moving to the next quiz question without selecting an answer.

Previously, users could skip questions by clicking the "Next Question" button without choosing an option, which caused inconsistent quiz flow and incomplete answer tracking.

### Changes made:
- Added validation guard in `nextQuestion` to block navigation when no option is selected
- Disabled the "Next Question" button if `selectedOption === null`
- Added disabled button for better UX
- Reverted unnecessary nullable answer array types back to `string[]`
- Applied the fix consistently across all affected quiz pages

Fixes #2233 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules