### PR TITLE
fix(config): correct Prism PHP identifier casing and expand footer links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -193,11 +193,57 @@ const config = {
         style: "dark",
         links: [
           {
-            title: "Docs",
+            title: "Learn",
             items: [
               {
                 label: "Tutorial",
                 to: "/docs/",
+              },
+              {
+                label: "Blog",
+                to: "/blog",
+              },
+              {
+                label: "DSA Roadmap",
+                to: "/dsa-roadmap",
+              },
+              {
+                label: "Practice",
+                to: "/practice",
+              },
+            ],
+          },
+          {
+            title: "Community",
+            items: [
+              {
+                label: "Contributors",
+                to: "/contributors",
+              },
+              {
+                label: "Challenges",
+                to: "/challenges",
+              },
+              {
+                label: "GitHub",
+                href: "https://github.com/ajay-dhangar/algo",
+              },
+            ],
+          },
+          {
+            title: "Resources",
+            items: [
+              {
+                label: "Playground",
+                to: "/playground",
+              },
+              {
+                label: "Quizzes",
+                to: "/quizzes",
+              },
+              {
+                label: "FAQ",
+                to: "/faq",
               },
             ],
           },
@@ -217,7 +263,7 @@ const config = {
           "latex",
           "haskell",
           "matlab",
-          "PHp",
+          "php",
           "powershell",
           "bash",
           "diff",


### PR DESCRIPTION
# 🔧 Fix Case Casing for PHP Highlight & Expand Footer Navigation Links

### 📋 Overview
This Pull Request resolves a syntax-highlighting bug for PHP code blocks and improves footer navigation on the site by adding comprehensive links matching the top navigation bar.

---

### 🔴 Bug Fix: Prism 'PHp' Casing Correction (Issue #2314)
- **Problem**: In `docusaurus.config.js` (line 220), the Prism syntax-highlighter's `additionalLanguages` array contained `'PHp'` with incorrect, non-standard casing. Because Prism language identifiers are case-sensitive, this casing mismatch caused PHP code blocks inside documentation `.mdx` files to render without syntax highlighting.
- **Proposed Solution**: Changed `'PHp'` to `'php'` (all lowercase) to match standard Prism conventions.
- **Result**: PHP code blocks now render with dynamic syntax highlighting.

---

### 🟢 Enhancement: Expand Footer Link Sections (Issue #2315)
- **Problem**: The footer links block was underbuilt and contained only a single link group (`Docs` -> `Tutorial`). Contributors scrolling through long docs pages lacked easy navigation pathways to other key sections (such as Blog, Playground, FAQ, Quizzes, Challenges, etc.).
- **Proposed Solution**: Added 3 distinct, organized link groups in the footer to match the top navigation structure:
  1. **Learn**: Tutorial, Blog, DSA Roadmap, Practice
  2. **Community**: Contributors, Challenges, GitHub Repository
  3. **Resources**: Playground, Quizzes, FAQ
- **Result**: Drastically improves user experience, provides comprehensive site routing, and aids search engines with better SEO discovery indices.

---

### 🛠️ Key Implementation Details
- **Affected File**: `docusaurus.config.js`
- **Modifications**:
  - Corrected Prism casing from `'PHp'` to `'php'`.
  - Replaced the single `'Docs'` link section in `footer.links` with detailed `'Learn'`, `'Community'`, and `'Resources'` link categories mapping core routes.

Closes #2314
Closes #2315
