### PR TITLE
fix(prism): correct PHP language identifier casing

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -217,7 +217,7 @@ const config = {
           "latex",
           "haskell",
           "matlab",
-          "PHp",
+          "php",
           "powershell",
           "bash",
           "diff",


### PR DESCRIPTION
## Problem
The Prism syntax highlighter configuration in Docusaurus had an incorrect casing for the PHP language identifier, declared as `'PHp'` instead of the standard `'php'`. Because Prism language identifiers are case-sensitive, this casing mismatch silently broke syntax highlighting for standard PHP code blocks inside `.mdx` and `.md` documentation files, causing them to render as plain text.

## Proposed Solution
Correct the casing configuration inside `docusaurus.config.js` to standard, lowercase `'php'` to restore beautiful, dynamic syntax highlighting.

## Implementation Details
- Modified [docusaurus.config.js](file:///c:/Users/HP/OneDrive/Desktop/Padhai/OpenSource/WorkingOnCurrently/Not%20Easy%20to%20Contribute/algo/docusaurus.config.js) to update `'PHp'` to `'php'` inside the `themeConfig.prism.additionalLanguages` array.

Closes #2314
