### PR TITLE
feat: add floating scroll buttons to all pages via Root.js

### DIFF
--- a/src/components/Scroller/BottomToTop/BottomToTop.tsx
+++ b/src/components/Scroller/BottomToTop/BottomToTop.tsx
@@ -6,13 +6,7 @@ const ScrollBottomToTop: React.FC = () => {
     const [showButton, setShowButton] = useState<boolean>(false);
 
     const scrollToTop = () => {
-        const scrollStep = -window.scrollY / (500 / 15);
-        const scrollInterval = setInterval(() => {
-            if (window.scrollY === 0) {
-                clearInterval(scrollInterval);
-            }
-            window.scrollBy(0, scrollStep);
-        }, 15);
+        window.scrollTo({ top: 0, behavior: "smooth" });
     };
 
     const handleScroll = () => {

--- a/src/components/Scroller/TopToBottom/TopToBottom.tsx
+++ b/src/components/Scroller/TopToBottom/TopToBottom.tsx
@@ -6,16 +6,7 @@ const ScrollTopToBottom: React.FC = () => {
     const [showButton, setShowButton] = useState<boolean>(false);
 
     const scrollToBottom = () => {
-        const totalHeight = document.documentElement.scrollHeight;
-        const currentScroll = window.scrollY;
-        const scrollStep = (totalHeight - currentScroll) / (500 / 15);
-        const scrollInterval = setInterval(() => {
-            const newScroll = window.scrollY + scrollStep;
-            window.scrollTo(0, newScroll);
-            if (window.scrollY >= totalHeight - window.innerHeight) {
-                clearInterval(scrollInterval);
-            }
-        }, 15);
+        window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
     };
 
     const handleScroll = () => {

--- a/src/components/Scroller/TopToBottom/TopToBottom.tsx
+++ b/src/components/Scroller/TopToBottom/TopToBottom.tsx
@@ -6,7 +6,7 @@ const ScrollTopToBottom: React.FC = () => {
     const [showButton, setShowButton] = useState<boolean>(false);
 
     const scrollToBottom = () => {
-        window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
+        window.scrollTo({ top: document.documentElement.scrollHeight, behavior: "smooth" });
     };
 
     const handleScroll = () => {

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,13 +1,15 @@
 import React, { useState, useCallback } from "react";
 import { useLocation } from "@docusaurus/router";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import KeyboardShortcutsModal from "../components/KeyboardShortcutsModal";
 import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
-import BottomToTop from "../components/Scroller/BottomToTop/BottomToTop.tsx";
-import TopToBottom from "../components/Scroller/TopToBottom/TopToBottom.tsx";
+import BottomToTop from "../components/Scroller/BottomToTop/BottomToTop";
+import TopToBottom from "../components/Scroller/TopToBottom/TopToBottom";
 
 export default function Root({ children }) {
   const location = useLocation();
-  const isHomepage = location.pathname === "/";
+  const { siteConfig } = useDocusaurusContext();
+  const isHomepage = location.pathname === siteConfig.baseUrl;
 
   const onOpenHelp = useCallback(() => setShowKeyboardModal(true), []);
   const onCloseHelp = useCallback(() => setShowKeyboardModal(false), []);

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,12 +1,17 @@
 import React, { useState, useCallback } from "react";
+import { useLocation } from "@docusaurus/router";
 import KeyboardShortcutsModal from "../components/KeyboardShortcutsModal";
 import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
+import BottomToTop from "../components/Scroller/BottomToTop/BottomToTop.tsx";
+import TopToBottom from "../components/Scroller/TopToBottom/TopToBottom.tsx";
 
 export default function Root({ children }) {
+  const location = useLocation();
+  const isHomepage = location.pathname === "/";
+
   const onOpenHelp = useCallback(() => setShowKeyboardModal(true), []);
   const onCloseHelp = useCallback(() => setShowKeyboardModal(false), []);
-  const [showKeyboardModal, setShowKeyboardModal] =
-    useState(false);
+  const [showKeyboardModal, setShowKeyboardModal] = useState(false);
 
   useKeyboardShortcuts({
     onOpenHelp,
@@ -16,11 +21,12 @@ export default function Root({ children }) {
   return (
     <>
       {children}
-
       <KeyboardShortcutsModal
         isOpen={showKeyboardModal}
         onClose={onCloseHelp}
       />
+      {!isHomepage && <BottomToTop />}
+      {!isHomepage && <TopToBottom />}
     </>
   );
 }


### PR DESCRIPTION
## 📥 Pull Request

GSSoC'26 Contribution

### Description
Fixes the missing floating scroll navigation buttons on all pages except the homepage.

- Injected `BottomToTop` and `TopToBottom` scroll components globally via `src/theme/Root.js` so they appear on all pages
- Added homepage check (`location.pathname === "/"`) to avoid duplicate buttons since homepage already includes them in `index.js`
- Fixed janky scroll animation in `BottomToTop.tsx` by replacing `setInterval` logic with `window.scrollTo({ top: 0, behavior: "smooth" })`
- Fixed janky scroll animation in `TopToBottom.tsx` by replacing `setInterval` logic with `window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" })`


Fixes #2307 

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## Pages Affected
All pages now have scroll buttons: `/docs`, `/blog`, `/faq`, `/contributors`, `/dsa-roadmap`, and others.

## Testing
https://github.com/user-attachments/assets/3a634511-a10d-411c-a123-fa786ad715b5

- Verified buttons appear on all non-homepage pages 
- Verified no duplicate buttons on homepage 
- Verified smooth scroll animation without shaking 

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code