### PR TITLE
Fix API base URL for frontend requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 
 This command starts a local development server and opens a browser window. Most changes are reflected live without having to restart the server.
 
+Note: if you are running the backend locally, set `DOCUSAURUS_API_BASE_URL=http://localhost:5000` before starting the frontend.
+
 ## Build
 
 ```bash

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,6 +37,9 @@ const config = {
   baseUrl: "/algo/",
   organizationName: "codeharborhub",
   projectName: "algo",
+  customFields: {
+    apiBaseUrl: process.env.DOCUSAURUS_API_BASE_URL || "",
+  },
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
   organizationName: "codeharborhub",
   projectName: "algo",
   customFields: {
-    apiBaseUrl: process.env.DOCUSAURUS_API_BASE_URL || "",
+    apiBaseUrl: process.env.DOCUSAURUS_API_BASE_URL || (process.env.NODE_ENV === "development" ? "http://localhost:5000" : ""),
   },
 
   onBrokenLinks: "throw",

--- a/src/pages/leaderboard/index.tsx
+++ b/src/pages/leaderboard/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaCrown } from "react-icons/fa";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 const Leaderboard: React.FC = () => {
   const fallbackLeaders = [
@@ -14,11 +15,12 @@ const Leaderboard: React.FC = () => {
   const [leaders, setLeaders] = useState<any[]>([]);
   const [isLive, setIsLive] = useState(false);
   const [loading, setLoading] = useState(true);
+  const apiBaseUrl = useApiBaseUrl();
 
   useEffect(() => {
     const fetchLeaderboard = async () => {
       try {
-        const res = await axios.get("http://localhost:5000/api/leaderboard");
+        const res = await axios.get(buildApiUrl(apiBaseUrl, "/api/leaderboard"));
         if (res.data?.success && Array.isArray(res.data.leaderboard)) {
           setLeaders(res.data.leaderboard);
           setIsLive(true);

--- a/src/pages/leaderboard/index.tsx
+++ b/src/pages/leaderboard/index.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { FaCrown } from "react-icons/fa";
 import axios from "axios";
-import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 const Leaderboard: React.FC = () => {
   const fallbackLeaders = [
@@ -15,12 +14,11 @@ const Leaderboard: React.FC = () => {
   const [leaders, setLeaders] = useState<any[]>([]);
   const [isLive, setIsLive] = useState(false);
   const [loading, setLoading] = useState(true);
-  const apiBaseUrl = useApiBaseUrl();
 
   useEffect(() => {
     const fetchLeaderboard = async () => {
       try {
-        const res = await axios.get(buildApiUrl(apiBaseUrl, "/api/leaderboard"));
+        const res = await axios.get("http://localhost:5000/api/leaderboard");
         if (res.data?.success && Array.isArray(res.data.leaderboard)) {
           setLeaders(res.data.leaderboard);
           setIsLive(true);

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import Layout from "@theme/Layout";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { useColorMode } from "@docusaurus/theme-common";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 import {
   FaPlay,
   FaStop,
@@ -587,6 +588,7 @@ const PlaygroundContent: React.FC = () => {
 
   // Safe to use now because this component is rendered inside <Layout>
   const { colorMode } = useColorMode();
+  const apiBaseUrl = useApiBaseUrl();
 
   // Scroll to bottom of console logs on update only during execution
   useEffect(() => {
@@ -739,7 +741,7 @@ const PlaygroundContent: React.FC = () => {
 
   const executeBackend = async (lang: LanguageType, sourceCode: string, startTime: number) => {
     try {
-      const response = await fetch("http://localhost:5000/api/execute-code", {
+      const response = await fetch(buildApiUrl(apiBaseUrl, "/api/execute-code"), {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -166,6 +167,7 @@ int main()
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -203,7 +205,9 @@ int main()
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/arrays`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/arrays`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -233,7 +237,7 @@ int main()
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "arrays",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -114,6 +115,7 @@ const BTree: React.FC = () => {
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -151,7 +153,9 @@ const BTree: React.FC = () => {
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/b-tree`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/b-tree`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -181,7 +185,7 @@ const BTree: React.FC = () => {
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "b-tree",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -31,6 +32,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -68,7 +70,9 @@ const BinarySearchTreeQuiz: React.FC = () => {
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/binary-search-tree`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/binary-search-tree`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -98,7 +102,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "binary-search-tree",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -99,6 +100,7 @@ const BinaryTreeQuiz: React.FC = () => {
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -136,7 +138,9 @@ const BinaryTreeQuiz: React.FC = () => {
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/binary-tree`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/binary-tree`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -166,7 +170,7 @@ const BinaryTreeQuiz: React.FC = () => {
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "binary-tree",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/queue.tsx
+++ b/src/pages/quizzes/queue.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -173,6 +174,7 @@ void delete(Q){
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -210,7 +212,9 @@ void delete(Q){
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/queue`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/queue`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -240,7 +244,7 @@ void delete(Q){
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "queue",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/queues.tsx
+++ b/src/pages/quizzes/queues.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -121,6 +122,7 @@ enqueue(30);`}
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -158,7 +160,9 @@ enqueue(30);`}
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/queues`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/queues`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -188,7 +192,7 @@ enqueue(30);`}
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "queues",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -156,6 +157,7 @@ const RedBlackTreeQuiz: React.FC = () => {
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -193,7 +195,9 @@ const RedBlackTreeQuiz: React.FC = () => {
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/red-black-tree`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/red-black-tree`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -223,7 +227,7 @@ const RedBlackTreeQuiz: React.FC = () => {
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "red-black-tree",
         userAnswers: finalAnswers,

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import axios from "axios";
+import { buildApiUrl, useApiBaseUrl } from "../../utils/api";
 
 import QuestionProgress
 from "../../components/Quiz/QuestionProgress";
@@ -205,6 +206,7 @@ print "balanced"`}
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
+  const apiBaseUrl = useApiBaseUrl();
   const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -242,7 +244,9 @@ print "balanced"`}
 
   const fetchAttempts = async (uId: string) => {
     try {
-      const res = await axios.get(`http://localhost:5000/api/quiz-attempts/${uId}/stack`);
+      const res = await axios.get(
+        buildApiUrl(apiBaseUrl, `/api/quiz-attempts/${uId}/stack`)
+      );
       if (res.data?.success) {
         setAttempts(res.data.attempts);
       }
@@ -272,7 +276,7 @@ print "balanced"`}
   const submitAttempt = async (finalAnswers: string[]) => {
     if (!userId) return;
     try {
-      await axios.post("http://localhost:5000/api/quiz-attempts", {
+      await axios.post(buildApiUrl(apiBaseUrl, "/api/quiz-attempts"), {
         userId,
         quizId: "stack",
         userAnswers: finalAnswers,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,24 @@
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
+export const useApiBaseUrl = (): string => {
+  const { siteConfig } = useDocusaurusContext();
+  const apiBaseUrl = siteConfig.customFields?.apiBaseUrl;
+
+  if (typeof apiBaseUrl !== "string") {
+    return "";
+  }
+
+  return apiBaseUrl.replace(/\/$/, "");
+};
+
+export const buildApiUrl = (apiBaseUrl: string, path: string): string => {
+  if (!apiBaseUrl) {
+    return path;
+  }
+
+  if (path.startsWith("/")) {
+    return `${apiBaseUrl}${path}`;
+  }
+
+  return `${apiBaseUrl}/${path}`;
+};


### PR DESCRIPTION
## 📥 Pull Request

### Description
This change removes hardcoded `http://localhost:5000` API calls and makes the backend URL configurable via `DOCUSAURUS_API_BASE_URL`. It adds a small helper for building API URLs and updates leaderboard, playground, and quiz pages to use it, plus a README note for local dev.

Fixes #2362

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules