### PR TITLE
fix: redirect 'Explore Algorithms' button to root docs (#2348)

### DIFF
--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -25,7 +25,7 @@ const HeroSection = () => {
         <div className="flex flex-col md:flex-row items-center justify-center space-y-4 md:space-y-0 md:space-x-6">
           
           <Link
-            to="/docs/category/algorithms"
+            to="/docs/"
             className="group relative overflow-hidden flex items-center px-6 py-3 text-lg font-medium text-white rounded-lg shadow-lg transition-all duration-300 ease-in-out hover:scale-110 hover:shadow-blue-500/50 hover:shadow-2xl hover:text-gray-100 active:scale-95">
             <span className="absolute inset-0 bg-gradient-to-r from-blue-700 via-blue-600 to-cyan-500 transition duration-300 group-hover:from-blue-800 group-hover:via-blue-700 group-hover:to-cyan-600"></span>
             <span className="relative z-10 flex items-center">


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR fixes the routing on the landing page where the "Explore Algorithms" button was redirecting users to the obscure `/docs/category/algorithms` category. The link has been updated to point to the main `Welcome to Algo` introduction page (`/docs/`), ensuring that new visitors are properly onboarded to the platform instead of being deep-linked.

Fixes #2348

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
