### PR TITLE
fix(b-tree-quiz): prevent duplicate entries in userAnswers

### DIFF
--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -114,10 +114,15 @@ const BTree: React.FC = () => {
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -193,28 +198,17 @@ const BTree: React.FC = () => {
     }
   };
 
-  const handleAnswer=(selected:string)=>{
-
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
       submitAttempt(userAnswers);

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -208,8 +208,6 @@ const BTree: React.FC = () => {
   const nextQuestion = () => {
     if (selectedOption === null) return;
 
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
     if (selectedOption === questions[currentQuestion].answer) {
       setScore((prev) => prev + 1);
     }
@@ -219,8 +217,7 @@ const BTree: React.FC = () => {
       setSelectedOption(null);
     } else {
       setShowResult(true);
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 


### PR DESCRIPTION
## 📥 Pull Request

### Description

The B-Tree quiz was storing and submitting duplicate answer entries because `userAnswers` was being updated in two places for the same selected option.

In `src/pages/quizzes/b-tree.tsx`, `handleAnswer` already records the selected answer at the current question index:

```tsx
const updatedAnswers = [...userAnswers];
updatedAnswers[currentQuestion] = selected;
setUserAnswers(updatedAnswers);
```

However, `nextQuestion` was appending the same selected option again:

```tsx
setUserAnswers((prev) => [...prev, selectedOption]);
```

And on the final question, it built the submitted payload by appending `selectedOption` once more:

```tsx
const finalAnswers = [...userAnswers, selectedOption];
submitAttempt(finalAnswers);
```

This caused the saved/submitted `userAnswers` array to contain more entries than the number of quiz questions (e.g. 11 entries for a 10-question quiz).

**Fix:** Use a single source of truth. Since `handleAnswer` already records the answer at the correct index, the redundant append in `nextQuestion` was removed and `submitAttempt` is now called with `userAnswers` directly. The submitted payload now contains exactly one answer per question at the matching index.

Fixes #2373

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### How to verify

1. Open `/quizzes/b-tree`.
2. Answer all 10 questions and submit.
3. Inspect the network request payload to `POST /api/quiz-attempts`.
4. `userAnswers` now contains exactly 10 entries with no duplicates.
