### PR TITLE
Fix quiz completion navigation by adding reusable "Back to Quizzes / Return to Quizzes" actions component

### DIFF
--- a/src/components/Quiz/QuizResultActions.tsx
+++ b/src/components/Quiz/QuizResultActions.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+
+interface QuizResultActionsProps {
+  onRetry: () => void;
+}
+
+const QuizResultActions: React.FC<QuizResultActionsProps> = ({ onRetry }) => {
+  return (
+    <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center" aria-label="Quiz navigation actions">
+      <Link
+        to="/quizzes"
+        className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600 transition-colors"
+      >
+        ← Back to Quizzes
+      </Link>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-500 transition-colors border-none cursor-pointer"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+};
+
+export default QuizResultActions;

--- a/src/components/Quiz/QuizResultActions.tsx
+++ b/src/components/Quiz/QuizResultActions.tsx
@@ -7,12 +7,12 @@ interface QuizResultActionsProps {
 
 const QuizResultActions: React.FC<QuizResultActionsProps> = ({ onRetry }) => {
   return (
-    <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center" aria-label="Quiz navigation actions">
+    <nav className="mt-6 flex flex-col sm:flex-row gap-3 justify-center" aria-label="Quiz navigation actions">
       <Link
         to="/quizzes"
         className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600 transition-colors"
       >
-        ← Back to Quizzes
+        <span aria-hidden="true" className="mr-1">&larr;</span> Back to Quizzes
       </Link>
       <button
         type="button"
@@ -21,7 +21,7 @@ const QuizResultActions: React.FC<QuizResultActionsProps> = ({ onRetry }) => {
       >
         Try Again
       </button>
-    </div>
+    </nav>
   );
 };
 

--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const ArrayQuiz: React.FC = () => {
   const questions = [
     {
@@ -281,6 +283,15 @@ int main()
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Arrays Quiz" description="Test your knowledge on array operations and algorithms.">
@@ -354,6 +365,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/avl-tree.tsx
+++ b/src/pages/quizzes/avl-tree.tsx
@@ -7,6 +7,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const AVLTreeQuiz: React.FC = () => {
   const questions = [
     // Easy Questions
@@ -127,6 +129,14 @@ const AVLTreeQuiz: React.FC = () => {
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+  };
+
   return (
     <Layout
       title="AVL Tree Quiz"
@@ -157,6 +167,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const BTree: React.FC = () => {
   const questions = [
     {
@@ -238,6 +240,13 @@ const BTree: React.FC = () => {
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setShowResult(false);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Quiz on B-Trees" description="Test your knowledge of B-Trees with this quiz!">
@@ -314,6 +323,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const BinarySearchTreeQuiz: React.FC = () => {
   const questions = [
     {
@@ -145,6 +147,15 @@ const BinarySearchTreeQuiz: React.FC = () => {
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Binary Search Tree Quiz" description="Test your knowledge of binary search trees with this quiz!">
@@ -218,6 +229,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 1 ? "Better luck next time!" : "Good job!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const BinaryTreeQuiz: React.FC = () => {
   const questions = [
     // Easy Questions
@@ -213,6 +215,15 @@ const BinaryTreeQuiz: React.FC = () => {
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Binary Tree Quiz" description="Test your knowledge of binary trees with this quiz!">
@@ -289,6 +300,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/queue.tsx
+++ b/src/pages/quizzes/queue.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const QueueQuiz: React.FC = () => {
   const questions = [
     {
@@ -279,6 +281,15 @@ void delete(Q){
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Queue Quiz" description="Test your knowledge of queues with this quiz!">
@@ -352,6 +363,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/queues.tsx
+++ b/src/pages/quizzes/queues.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const QueueQuiz: React.FC = () => {
   const questions = [
     // Easy Questions
@@ -235,6 +237,15 @@ enqueue(30);`}
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Queues Quiz" description="Challenge your knowledge on queue implementations and their use cases.">
@@ -308,6 +319,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const RedBlackTreeQuiz: React.FC = () => {
   const questions = [
     // Easy Questions
@@ -270,6 +272,15 @@ const RedBlackTreeQuiz: React.FC = () => {
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Quiz on Red-Black Trees" description="Challenge your understanding of the properties and algorithms of Red-Black Trees.">
@@ -343,6 +354,8 @@ setCurrentQuestionIndex={setCurrentQuestion}
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -9,6 +9,8 @@ from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator
 from "../../components/Quiz/QuestionNavigator";
 
+import QuizResultActions from "../../components/Quiz/QuizResultActions";
+
 const StackQuiz: React.FC = () => {
   const questions = [
     // Easy Questions
@@ -320,6 +322,15 @@ print "balanced"`}
     }
   };
 
+  const handleRetry = () => {
+    setCurrentQuestion(0);
+    setScore(0);
+    setShowResult(false);
+    setSelectedOption(null);
+    setUserAnswers([]);
+    setTimeSpent(0);
+  };
+
   if (!userId) {
     return (
       <Layout title="Stack Quiz" description="Evaluate your understanding of stack operations and applications.">
@@ -399,6 +410,8 @@ totalQuestions=
                   {score <= 5 ? "Better luck next time!" : score <= 8 ? "Good job!" : "Excellent work!"}
                 </p>
               </div>
+
+              <QuizResultActions onRetry={handleRetry} />
 
               {/* Solutions Section */}
               <div className="mt-8">


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR adds a reusable `QuizResultActions` component to improve navigation and retry functionality across quiz pages.

### Changes Made
<img width="1904" height="956" alt="Screenshot 2026-05-29 124317" src="https://github.com/user-attachments/assets/372f3539-0bfb-4f5b-8904-7bf2142958bb" />

* Added a reusable `QuizResultActions` component.
* Added a **"Back to Quizzes"** button on quiz result pages for easier navigation.
* Added a reusable **"Try Again"** action to restart quizzes without refreshing the page.
* Integrated the component into multiple quiz pages including:

  * Arrays
  * AVL Tree
  * B-Tree
  * Binary Search Tree
  * Binary Tree
  * Queue
  * Queues
  * Red-Black Tree
  * Stack

### Motivation

Previously, users had no quick navigation option after completing quizzes and retry logic was duplicated or missing in several quiz pages. This update improves user experience and code reusability by centralizing quiz result actions into a shared component.

Fixes #2357 

---

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

---

### Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas


* [x] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
