### PR TITLE
Add scroll navigation buttons to quiz-solutions page

### DIFF
--- a/src/pages/quiz-solutions/index.tsx
+++ b/src/pages/quiz-solutions/index.tsx
@@ -3,6 +3,8 @@ import Layout from "@theme/Layout";
 import Header from "../../components/Header";
 import QuizCard from "../../components/QuizCard";
 import quizData from "../../data/quizData";
+import ScrollBottomToTop from "../../components/Scroller/BottomToTop/BottomToTop";
+import ScrollTopToBottom from "../../components/Scroller/TopToBottom/TopToBottom";
 
 const Quizes: React.FC = () => (
   <Layout
@@ -25,6 +27,8 @@ const Quizes: React.FC = () => (
         ))}
       </div>
     </section>
+    <ScrollBottomToTop />
+    <ScrollTopToBottom />
   </Layout>
 );
 


### PR DESCRIPTION
## Summary
Adds floating scroll navigation buttons to the quiz-solutions page to improve user experience when navigating through long-form content.

## Changes
- Added scroll-to-top button (↑) that appears when scrolled past 100px
- Added scroll-to-bottom button (↓) that appears when not at page bottom
- Both buttons provide smooth scrolling navigation
- Utilized existing reusable scroll components: `ScrollBottomToTop` and `ScrollTopToBottom`

## Implementation Details
- Integrated `ScrollBottomToTop` component from `src/components/Scroller/BottomToTop/BottomToTop.tsx`
- Integrated `ScrollTopToBottom` component from `src/components/Scroller/TopToBottom/TopToBottom.tsx`
- Components are rendered at the end of the Layout in `src/pages/quiz-solutions/index.tsx`

## Why This Change?
The quiz-solutions page is content-heavy with multiple quiz cards. Users need a quick way to navigate to the top or bottom without manually scrolling through all content. These floating buttons follow the platform's existing navigation patterns already used on other lengthy pages.

## Testing
- ✅ Scroll to Top button appears after scrolling down ~100px
- ✅ Scroll to Bottom button appears when not at page bottom
- ✅ Smooth scrolling works on all browsers
- ✅ Buttons are accessible with proper ARIA labels

Fixes #2358