### PR TITLE
fix: remove userAnswers double-append in 7 quiz files

### DIFF
--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -170,10 +170,15 @@ int main()
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const apiBaseUrl = useApiBaseUrl();
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -251,43 +256,26 @@ int main()
     }
   };
 
-  const handleAnswer=(selected:string)=>{
-
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
-
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
     setTimeSpent(0);
   };

--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -257,9 +257,11 @@ int main()
   };
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/avl-tree.tsx
+++ b/src/pages/quizzes/avl-tree.tsx
@@ -97,43 +97,35 @@ const AVLTreeQuiz: React.FC = () => {
   ];
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
 
- const handleAnswer=(selected:string)=>{
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption !== null) {
-      setUserAnswers((prevAnswers) => [...prevAnswers, selectedOption]);
-      if (selectedOption === questions[currentQuestion].answer) {
-        setScore(score + 1);
-      }
-      if (currentQuestion < questions.length - 1) {
-        setCurrentQuestion(currentQuestion + 1);
-        setSelectedOption(null);
-      } else {
-        setShowResult(true);
-      }
+    if (!selectedOption) return;
+
+    if (currentQuestion < questions.length - 1) {
+      setCurrentQuestion(currentQuestion + 1);
+    } else {
+      setShowResult(true);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
   };
 

--- a/src/pages/quizzes/avl-tree.tsx
+++ b/src/pages/quizzes/avl-tree.tsx
@@ -108,9 +108,11 @@ const AVLTreeQuiz: React.FC = () => {
   );
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -122,9 +122,11 @@ const BinarySearchTreeQuiz: React.FC = () => {
   };
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -35,10 +35,15 @@ const BinarySearchTreeQuiz: React.FC = () => {
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const apiBaseUrl = useApiBaseUrl();
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -116,42 +121,26 @@ const BinarySearchTreeQuiz: React.FC = () => {
     }
   };
 
-  const handleAnswer=(selected:string)=>{
-
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
     setTimeSpent(0);
   };

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -190,9 +190,11 @@ const BinaryTreeQuiz: React.FC = () => {
   };
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -103,10 +103,15 @@ const BinaryTreeQuiz: React.FC = () => {
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const apiBaseUrl = useApiBaseUrl();
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -184,42 +189,26 @@ const BinaryTreeQuiz: React.FC = () => {
     }
   };
 
-  const handleAnswer=(selected:string)=>{
-
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
     setTimeSpent(0);
   };

--- a/src/pages/quizzes/queues.tsx
+++ b/src/pages/quizzes/queues.tsx
@@ -125,10 +125,15 @@ enqueue(30);`}
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const apiBaseUrl = useApiBaseUrl();
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -206,42 +211,26 @@ enqueue(30);`}
     }
   };
 
-  const handleAnswer=(selected:string)=>{
-
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
     setTimeSpent(0);
   };

--- a/src/pages/quizzes/queues.tsx
+++ b/src/pages/quizzes/queues.tsx
@@ -212,9 +212,11 @@ enqueue(30);`}
   };
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -160,10 +160,15 @@ const RedBlackTreeQuiz: React.FC = () => {
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const apiBaseUrl = useApiBaseUrl();
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -241,42 +246,26 @@ const RedBlackTreeQuiz: React.FC = () => {
     }
   };
 
-  const handleAnswer=(selected:string)=>{
-
- setSelectedOption(selected);
-
- const updatedAnswers=[...userAnswers];
-
- updatedAnswers[currentQuestion]=selected;
-
- setUserAnswers(updatedAnswers);
-
-}
+  const handleAnswer = (selected: string) => {
+    const updatedAnswers = [...userAnswers];
+    updatedAnswers[currentQuestion] = selected;
+    setUserAnswers(updatedAnswers);
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
     setTimeSpent(0);
   };

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -247,9 +247,11 @@ const RedBlackTreeQuiz: React.FC = () => {
   };
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -296,9 +296,11 @@ print "balanced"`}
   };
 
   const handleAnswer = (selected: string) => {
-    const updatedAnswers = [...userAnswers];
-    updatedAnswers[currentQuestion] = selected;
-    setUserAnswers(updatedAnswers);
+    setUserAnswers((prev) => {
+      const updatedAnswers = [...prev];
+      updatedAnswers[currentQuestion] = selected;
+      return updatedAnswers;
+    });
   };
 
   const nextQuestion = () => {

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -209,10 +209,15 @@ print "balanced"`}
 
   const [currentQuestion, setCurrentQuestion] = useState(0);
   const apiBaseUrl = useApiBaseUrl();
-  const [score, setScore] = useState(0);
   const [showResult, setShowResult] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [userAnswers, setUserAnswers] = useState<string[]>([]);
+
+  // Derived state: eliminates score desync and selectedOption carry-over bugs
+  const selectedOption = userAnswers[currentQuestion] || null;
+  const score = userAnswers.reduce(
+    (acc, answer, index) => (answer === questions[index]?.answer ? acc + 1 : acc),
+    0
+  );
 
   // Custom states for persistence, timer, and history
   const [usernameInput, setUsernameInput] = useState("");
@@ -291,42 +296,25 @@ print "balanced"`}
   };
 
   const handleAnswer = (selected: string) => {
-
-    setSelectedOption(selected);
-
     const updatedAnswers = [...userAnswers];
-
-    updatedAnswers[currentQuestion] =
-    selected;
-
+    updatedAnswers[currentQuestion] = selected;
     setUserAnswers(updatedAnswers);
-
-};
+  };
 
   const nextQuestion = () => {
-    if (selectedOption === null) return;
-
-    setUserAnswers((prev) => [...prev, selectedOption]);
-
-    if (selectedOption === questions[currentQuestion].answer) {
-      setScore((prev) => prev + 1);
-    }
+    if (!selectedOption) return;
 
     if (currentQuestion < questions.length - 1) {
       setCurrentQuestion(currentQuestion + 1);
-      setSelectedOption(null);
     } else {
       setShowResult(true);
-      const finalAnswers = [...userAnswers, selectedOption];
-      submitAttempt(finalAnswers);
+      submitAttempt(userAnswers);
     }
   };
 
   const handleRetry = () => {
     setCurrentQuestion(0);
-    setScore(0);
     setShowResult(false);
-    setSelectedOption(null);
     setUserAnswers([]);
     setTimeSpent(0);
   };


### PR DESCRIPTION
## 📥 Pull Request

### Description
Removes the duplicate `setUserAnswers` append in `nextQuestion` across 7 quiz files that caused the `userAnswers` array to grow to double the question count, corrupting answer tracking, the Solutions review, and backend submissions.

The fix aligns all affected files with the correct pattern already established in `b-tree.tsx` (PR #2380):
- `handleAnswer` writes the answer by index (single source of truth)
- `nextQuestion` only handles navigation — no append
- `score` and `selectedOption` are derived from `userAnswers` to eliminate state desync

Fixes #2394

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules