### PR TITLE
docs: integrate external learning resources into CONTRIBUTING (#2414)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,23 @@
 
 Thank you for your interest in contributing to **Algo**! We welcome contributions from everyone, whether you're a beginner or an experienced developer. Contributions can include adding new algorithms, improving documentation, fixing bugs, or enhancing the user experience. This guide will help you get started.
 
-## Resources for Guidance
-Here are some resources that may be helpful as you contribute to Algo:
-- [Docusaurus Documentation](https://docusaurus.io/docs/docs-introduction)
-- [React.js Documentation](https://react.dev/learn)
-- [Markdown Guide](https://www.markdownguide.org/)
-- [MDX Documentation](https://mdxjs.com/docs/)
-- [Mermaid Documentation](https://mermaid.js.org/)
-- [KaTeX Math Rendering Documentation](https://katex.org/docs/supported.html)
-- [Math Equations](https://docusaurus.io/docs/markdown-features/math-equations)
+## Recommended reading
+
+Algo’s docs site is built with **Docusaurus** (React + MDX). You do not need to master every tool before your first contribution—use this list when you hit a specific task. The same links appear in the README under [Resources for Guidance](./README.md#resources-for-guidance).
+
+| Resource | When it is useful |
+| -------- | ----------------- |
+| [Docusaurus docs](https://docusaurus.io/docs/docs-introduction) | Site structure, docs folders, sidebars, front-matter, and local preview (`npm start`). Start here if you are new to this repo. |
+| [Markdown Guide](https://www.markdownguide.org/) | Writing `.md` pages: headings, lists, links, and fenced code blocks for algorithm implementations. |
+| [MDX documentation](https://mdxjs.com/docs/) | Pages that use `.mdx` and embed React components (imports/JSX inside a doc file). |
+| [React docs](https://react.dev/learn) | Custom components under `src/components/` or interactive examples referenced from MDX. |
+| [Mermaid](https://mermaid.js.org/) | Flowcharts and diagrams inside docs (see also [Writing Documentation](#4-writing-documentation-for-algo) below). |
+| [KaTeX supported functions](https://katex.org/docs/supported.html) | Math notation in docs (`$...$` / `$$...$$`). |
+| [Docusaurus math equations](https://docusaurus.io/docs/markdown-features/math-equations) | Enabling and troubleshooting math rendering in this project. |
+
+**Contributing to the site?** Read [How to Contribute](#how-to-contribute) and [Writing Documentation for Algo](#4-writing-documentation-for-algo).
+
+**Following the DSA roadmap?** See [learn.md](./learn.md) and [Roadmap to Learning DSA](docs/data-structures/roadmap-to-dsa.md) for study paths; use the table above when you want to read or improve doc pages alongside your practice.
 
 ## How to Contribute
 

--- a/README.md
+++ b/README.md
@@ -184,12 +184,14 @@ To manually invoke Gemini Code Assist, you can use the following commands in the
 [![Forkers repo roster for @ajay-dhangar/algo](https://reporoster.com/forks/dark/ajay-dhangar/algo)](https://github.com/ajay-dhangar/algo/network/members)
 
 ## Resources for Guidance
-Here are some resources that may be helpful as you contribute to Algo:
-- [Docusaurus Documentation](https://docusaurus.io/docs/docs-introduction)
-- [React.js Documentation](https://legacy.reactjs.org/docs/getting-started.html)
-- [Markdown Guide](https://www.markdownguide.org/)
-- [MDX Documentation](https://mdxjs.com/docs/)
-- [Mermaid Documentation](https://mermaid.js.org/)
+
+These links are summarized in [CONTRIBUTING.md — Recommended reading](./CONTRIBUTING.md#recommended-reading) with a one-line note on when to use each tool while contributing or editing docs.
+
+- [Docusaurus Documentation](https://docusaurus.io/docs/docs-introduction) — site layout, sidebars, and local preview
+- [Markdown Guide](https://www.markdownguide.org/) — writing `.md` algorithm and tutorial pages
+- [MDX Documentation](https://mdxjs.com/docs/) — pages that embed React components
+- [React.js Documentation](https://react.dev/learn) — custom components and interactive docs
+- [Mermaid Documentation](https://mermaid.js.org/) — flowcharts and diagrams in documentation
 
 <div align="center">
     <a href="#top">

--- a/docs/data-structures/roadmap-to-dsa.md
+++ b/docs/data-structures/roadmap-to-dsa.md
@@ -11,7 +11,7 @@ tags: [dsa, learning roadmap, algorithms, data-structures]
 Understanding Data Structures and Algorithms (DSA) is crucial for solving complex problems efficiently. DSA forms the foundation of computer science, providing the necessary tools to manage and manipulate data effectively. This roadmap outlines a structured approach to mastering DSA, designed for both beginners and experienced programmers.
 
 :::tip External references for reading or writing docs
-If you are also browsing or contributing to Algo’s documentation, see [Recommended reading in CONTRIBUTING.md](https://github.com/ajay-dhangar/algo/blob/main/CONTRIBUTING.md#recommended-reading) for links to Docusaurus, Markdown, MDX, Mermaid, and React—with a short note on when each applies. Learners following this roadmap can use [learn.md](https://github.com/ajay-dhangar/algo/blob/main/learn.md#documentation--tooling-for-contributors-and-doc-readers) for the same pointers.
+If you are also browsing or contributing to Algo’s documentation, see [Recommended reading in CONTRIBUTING.md](https://github.com/ajay-dhangar/algo/blob/main/CONTRIBUTING.md#recommended-reading) for links to Docusaurus, Markdown, MDX, Mermaid, and React—with a short note on when each applies. Learners following this roadmap can use [learn.md](https://github.com/ajay-dhangar/algo/blob/main/learn.md#documentation-and-tooling) for the same pointers.
 :::
 
 <AdsComponent />

--- a/docs/data-structures/roadmap-to-dsa.md
+++ b/docs/data-structures/roadmap-to-dsa.md
@@ -10,6 +10,10 @@ tags: [dsa, learning roadmap, algorithms, data-structures]
 
 Understanding Data Structures and Algorithms (DSA) is crucial for solving complex problems efficiently. DSA forms the foundation of computer science, providing the necessary tools to manage and manipulate data effectively. This roadmap outlines a structured approach to mastering DSA, designed for both beginners and experienced programmers.
 
+:::tip External references for reading or writing docs
+If you are also browsing or contributing to Algo’s documentation, see [Recommended reading in CONTRIBUTING.md](https://github.com/ajay-dhangar/algo/blob/main/CONTRIBUTING.md#recommended-reading) for links to Docusaurus, Markdown, MDX, Mermaid, and React—with a short note on when each applies. Learners following this roadmap can use [learn.md](https://github.com/ajay-dhangar/algo/blob/main/learn.md#documentation--tooling-for-contributors-and-doc-readers) for the same pointers.
+:::
+
 <AdsComponent />
 
 ## Your Learning Journey

--- a/learn.md
+++ b/learn.md
@@ -47,6 +47,10 @@ Learn the design patterns used to solve complex computing problems:
 * **Multi-Language Support:** Code snippets are available in popular languages like **JavaScript, TypeScript, Python, Java, and C++**.
 * **Open Source Community:** Built by developers, for developers. You can contribute, suggest improvements, or add your own solutions!
 
+## Documentation & tooling (for contributors and doc readers)
+
+While you follow this roadmap, you may want to read or improve pages on the Algo site. Official references for **Markdown**, **MDX**, **Docusaurus**, **Mermaid**, and **React** are listed in [CONTRIBUTING.md — Recommended reading](./CONTRIBUTING.md#recommended-reading) (same list as the README’s Resources for Guidance). Use them when you need help formatting a page, adding a diagram, or understanding how the site is built—not before you start learning DSA basics.
+
 ## How to Get Started
 
 1. **Pick a Topic:** Choose a module from the sidebar based on your current skill level.

--- a/learn.md
+++ b/learn.md
@@ -47,7 +47,7 @@ Learn the design patterns used to solve complex computing problems:
 * **Multi-Language Support:** Code snippets are available in popular languages like **JavaScript, TypeScript, Python, Java, and C++**.
 * **Open Source Community:** Built by developers, for developers. You can contribute, suggest improvements, or add your own solutions!
 
-## Documentation & tooling (for contributors and doc readers)
+## Documentation and tooling
 
 While you follow this roadmap, you may want to read or improve pages on the Algo site. Official references for **Markdown**, **MDX**, **Docusaurus**, **Mermaid**, and **React** are listed in [CONTRIBUTING.md — Recommended reading](./CONTRIBUTING.md#recommended-reading) (same list as the README’s Resources for Guidance). Use them when you need help formatting a page, adding a diagram, or understanding how the site is built—not before you start learning DSA basics.
 


### PR DESCRIPTION
## 📥 Pull Request

### Description

Adds a **Recommended reading** section to `CONTRIBUTING.md` and cross-links it across `README.md`, `learn.md`, and the DSA roadmap doc, resolving the gap in #2414 where the repo lacked curated, context-aware resource references for contributors and learners.

Changes include:
- **`CONTRIBUTING.md`** — Replaced the bare "Resources for Guidance" list with a **Recommended reading** table covering Docusaurus, Markdown, MDX, React, Mermaid, KaTeX, and Docusaurus math — each with a one-line "when it's useful" note. Includes pointers distinguishing contributor vs roadmap-learner use cases, and cross-links to `README.md`, `learn.md`, and the DSA roadmap doc.
- **`README.md`** — Resources section updated with short descriptions per link and a reference to CONTRIBUTING's Recommended reading. React link aligned to `react.dev`.
- **`learn.md`** — New **Documentation & tooling** section for roadmap learners and contributors.
- **`docs/data-structures/roadmap-to-dsa.md`** — Tip box added linking readers to `CONTRIBUTING.md` and `learn.md` for tooling references.


Closes #2414

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules