### PR TITLE
docs(java): rename ex4.md to ex3.md to fix numbering gap

### DIFF
--- a/docs/languages/java/ex3.md
+++ b/docs/languages/java/ex3.md
@@ -1,6 +1,6 @@
 ---
 id: multithreading-in-java
-sidebar_position: 4
+sidebar_position: 3
 title: Multithread in Java
 sidebar_label: Multithread in Java
 ---


### PR DESCRIPTION
## 📥 Pull Request

### Description

- Renamed docs/languages/java/ex4.md to ex3.md to close the gap in the series (ex1.md, ex2.md, ex3.md).
- Updated the frontmatter in the renamed file to change sidebar_position: 4 to sidebar_position: 3 so that the sidebar numbering aligns perfectly.

Fixes #2398 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
