### PR TITLE
fix: configure playground backend api url

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,7 @@ const { execSync } = require("child_process");
 // Can be explicitly overridden with DOCUSAURUS_ENABLE_GIT_HISTORY=true|false.
 const gitHistoryOverride = process.env.DOCUSAURUS_ENABLE_GIT_HISTORY;
 const showGitHistory =
+
   gitHistoryOverride === "true"
     ? true
     : gitHistoryOverride === "false"
@@ -27,6 +28,11 @@ const showGitHistory =
           }
         })();
 
+        const isProductionBuild = process.env.NODE_ENV === "production";
+const playgroundApiBaseUrl =
+  process.env.PLAYGROUND_API_BASE_URL ||
+  (isProductionBuild ? "" : "http://localhost:5000");
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Algo",
@@ -37,6 +43,9 @@ const config = {
   baseUrl: "/algo/",
   organizationName: "codeharborhub",
   projectName: "algo",
+  customFields: {
+  playgroundApiBaseUrl,
+},
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -43,9 +43,17 @@ const config = {
   baseUrl: "/algo/",
   organizationName: "codeharborhub",
   projectName: "algo",
-  customFields: {
-  playgroundApiBaseUrl,
-},
+    customFields: {
+    apiBaseUrl:
+      process.env.ALGO_API_URL ||
+      process.env.DOCUSARUS_API_BASE_URL ||
+      (process.env.NODE_ENV === "development" ? "http://localhost:5000" : ""),
+    playgroundApiBaseUrl:
+      process.env.PLAYGROUND_API_BASE_URL ||
+      process.env.ALGO_API_URL ||
+      process.env.DOCUSARUS_API_BASE_URL ||
+      (process.env.NODE_ENV === "development" ? "http://localhost:5000" : ""),
+  },
 
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -756,7 +756,7 @@ const PlaygroundContent: React.FC = () => {
 
   const executeBackend = async (lang: LanguageType, sourceCode: string, startTime: number) => {
     try {
-     const response = await fetch(`${playgroundApiBaseUrl}/api/execute-code`,  {
+      const response = await fetch(`${playgroundApiBaseUrl}/api/execute-code`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -11,6 +11,8 @@ import {
   FaTerminal,
   FaLightbulb,
 } from "react-icons/fa";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+
 
 // Language configuration
 type LanguageType = "javascript" | "python" | "cpp" | "java";
@@ -581,6 +583,12 @@ const PlaygroundContent: React.FC = () => {
   const [logs, setLogs] = useState<string[]>([]);
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const [execTime, setExecTime] = useState<number | null>(null);
+  const { siteConfig } = useDocusaurusContext();
+  const rawPlaygroundApiBaseUrl = siteConfig.customFields?.playgroundApiBaseUrl;
+  const playgroundApiBaseUrl =
+  typeof rawPlaygroundApiBaseUrl === "string"
+    ? rawPlaygroundApiBaseUrl.replace(/\/$/, "")
+    : "";
 
   const workerRef = useRef<Worker | null>(null);
   const consolePanelRef = useRef<HTMLDivElement | null>(null);
@@ -633,7 +641,16 @@ const PlaygroundContent: React.FC = () => {
 
   const handleRun = async () => {
     if (isRunning) return;
-
+    if (language !== "javascript" && !playgroundApiBaseUrl) {
+  setLogs([
+    "❌ Multi-language execution is not configured for this deployment.",
+    "",
+    "// JavaScript runs in the browser.",
+    "// To run Python, C++, or Java locally, start the backend with: npm run server:dev",
+  ]);
+  setExecTime(null);
+  return;
+}
     setIsRunning(true);
     setLogs(["// Starting execution...", ""]);
     setExecTime(null);
@@ -739,7 +756,7 @@ const PlaygroundContent: React.FC = () => {
 
   const executeBackend = async (lang: LanguageType, sourceCode: string, startTime: number) => {
     try {
-      const response = await fetch("http://localhost:5000/api/execute-code", {
+     const response = await fetch(`${playgroundApiBaseUrl}/api/execute-code`,  {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes the Playground backend API URL issue where Python, C++, and Java execution used a hardcoded `http://localhost:5000/api/execute-code` endpoint.

On the deployed website, visitors do not have the Algo backend running on their local machine, so non-JavaScript code execution fails. This change makes the backend API URL configurable through Docusaurus custom fields, keeps localhost only as a local development fallback, and prevents production builds from calling the visitor's own localhost.

Fixes #2467

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules