### PR TITLE
fix: persist DSA Roadmap expanded state using localStorage (#2452)

### DIFF
--- a/src/pages/dsa-roadmap/index.tsx
+++ b/src/pages/dsa-roadmap/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import Translate from "@docusaurus/Translate";
 import Link from "@docusaurus/Link";
@@ -106,10 +106,43 @@ const DSARoadmap: React.FC = () => {
     return `${categoryBase}/programming-fundamentals`;
   };
 
-  // State for major topics (Top level nodes) - open the first one by default
-  const [expandedTopics, setExpandedTopics] = useState<{ [key: number]: boolean }>({ 0: true });
-  // State for specific folders (Second level nodes)
-  const [expandedFolders, setExpandedFolders] = useState<{ [key: string]: boolean }>({});
+  // State for major topics (Top level nodes) - restore from localStorage or open the first one by default
+  const [expandedTopics, setExpandedTopics] = useState<{ [key: number]: boolean }>(() => {
+    try {
+      const saved = localStorage.getItem("dsa_roadmap_topics");
+      return saved ? JSON.parse(saved) : { 0: true };
+    } catch {
+      return { 0: true };
+    }
+  });
+
+  // State for specific folders (Second level nodes) - restore from localStorage
+  const [expandedFolders, setExpandedFolders] = useState<{ [key: string]: boolean }>(() => {
+    try {
+      const saved = localStorage.getItem("dsa_roadmap_folders");
+      return saved ? JSON.parse(saved) : {};
+    } catch {
+      return {};
+    }
+  });
+
+  // Persist expandedTopics to localStorage whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem("dsa_roadmap_topics", JSON.stringify(expandedTopics));
+    } catch {
+      // localStorage not available (e.g. private browsing with storage blocked)
+    }
+  }, [expandedTopics]);
+
+  // Persist expandedFolders to localStorage whenever it changes
+  useEffect(() => {
+    try {
+      localStorage.setItem("dsa_roadmap_folders", JSON.stringify(expandedFolders));
+    } catch {
+      // localStorage not available
+    }
+  }, [expandedFolders]);
 
   const toggleTopic = (idx: number) => {
     setExpandedTopics((prev) => ({ ...prev, [idx]: !prev[idx] }));

--- a/src/pages/dsa-roadmap/index.tsx
+++ b/src/pages/dsa-roadmap/index.tsx
@@ -17,8 +17,6 @@ import { topics } from "../../data/topics";
 const DSARoadmap: React.FC = () => {
   const categoryBase = useBaseUrl("/docs/category");
 
-  // Explicit mapping from topic folder names to actual generated category URLs
-  // Built by matching topics.ts folder names to actual categories in /docs/category/
   const topicCategoryMap: Record<string, Record<string, string>> = {
     "Pick a Language": {
       "JavaScript": "javascript",
@@ -26,8 +24,8 @@ const DSARoadmap: React.FC = () => {
       "Java": "java",
       "C++": "c-1",
       "C#": "c",
-      "Ruby": "python",  // Ruby docs don't exist; fallback to Python
-      "GO": "java",  // GO docs don't exist; fallback to Java
+      "Ruby": "python",
+      "GO": "java",
       "Rust": "rust",
     },
     "Programming Fundamentals": {
@@ -91,58 +89,61 @@ const DSARoadmap: React.FC = () => {
   };
 
   const getDocLink = (topicTitle: string, folderName: string, fileName: string) => {
-    // Use explicit mapping to avoid guessing category URLs
     const topicMap = topicCategoryMap[topicTitle];
     if (topicMap && topicMap[folderName]) {
       return `${categoryBase}/${topicMap[folderName]}`;
     }
-
-    // Fallback: link to languages category for unmapped topics
     if (topicTitle === "Pick a Language") {
       return `${categoryBase}/languages`;
     }
-
-    // For any other unmapped topic, link to programming-fundamentals as safe default
     return `${categoryBase}/programming-fundamentals`;
   };
 
-  // State for major topics (Top level nodes) - restore from localStorage or open the first one by default
-  const [expandedTopics, setExpandedTopics] = useState<{ [key: number]: boolean }>(() => {
-    try {
-      const saved = localStorage.getItem("dsa_roadmap_topics");
-      return saved ? JSON.parse(saved) : { 0: true };
-    } catch {
-      return { 0: true };
-    }
-  });
+  // Initialize with default values (SSR-safe — no localStorage access here)
+  const [expandedTopics, setExpandedTopics] = useState<{ [key: number]: boolean }>({ 0: true });
+  const [expandedFolders, setExpandedFolders] = useState<{ [key: string]: boolean }>({});
 
-  // State for specific folders (Second level nodes) - restore from localStorage
-  const [expandedFolders, setExpandedFolders] = useState<{ [key: string]: boolean }>(() => {
-    try {
-      const saved = localStorage.getItem("dsa_roadmap_folders");
-      return saved ? JSON.parse(saved) : {};
-    } catch {
-      return {};
-    }
-  });
+  // isLoaded flag prevents save useEffects from overwriting localStorage
+  // with default values before the load useEffect has run
+  const [isLoaded, setIsLoaded] = useState(false);
 
-  // Persist expandedTopics to localStorage whenever it changes
+  // Load persisted state from localStorage on mount (client-side only)
+  // This runs after hydration, avoiding SSR mismatch
   useEffect(() => {
+    try {
+      const savedTopics = localStorage.getItem("dsa_roadmap_topics");
+      if (savedTopics) {
+        setExpandedTopics(JSON.parse(savedTopics));
+      }
+      const savedFolders = localStorage.getItem("dsa_roadmap_folders");
+      if (savedFolders) {
+        setExpandedFolders(JSON.parse(savedFolders));
+      }
+    } catch (e) {
+      // Handle private browsing or storage restriction errors
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Persist expandedTopics to localStorage whenever it changes (after initial load)
+  useEffect(() => {
+    if (!isLoaded) return;
     try {
       localStorage.setItem("dsa_roadmap_topics", JSON.stringify(expandedTopics));
     } catch {
-      // localStorage not available (e.g. private browsing with storage blocked)
+      // localStorage not available
     }
-  }, [expandedTopics]);
+  }, [expandedTopics, isLoaded]);
 
-  // Persist expandedFolders to localStorage whenever it changes
+  // Persist expandedFolders to localStorage whenever it changes (after initial load)
   useEffect(() => {
+    if (!isLoaded) return;
     try {
       localStorage.setItem("dsa_roadmap_folders", JSON.stringify(expandedFolders));
     } catch {
       // localStorage not available
     }
-  }, [expandedFolders]);
+  }, [expandedFolders, isLoaded]);
 
   const toggleTopic = (idx: number) => {
     setExpandedTopics((prev) => ({ ...prev, [idx]: !prev[idx] }));
@@ -156,14 +157,12 @@ const DSARoadmap: React.FC = () => {
   const expandAll = () => {
     const allTopics: { [key: number]: boolean } = {};
     const allFolders: { [key: string]: boolean } = {};
-    
     topics.forEach((topic, tIdx) => {
       allTopics[tIdx] = true;
       topic.folders.forEach((_, fIdx) => {
         allFolders[`${tIdx}-${fIdx}`] = true;
       });
     });
-    
     setExpandedTopics(allTopics);
     setExpandedFolders(allFolders);
   };
@@ -180,7 +179,7 @@ const DSARoadmap: React.FC = () => {
     >
       <div className="min-h-screen bg-gray-50 dark:bg-[#1b1b1d] py-12">
         <div className="container mx-auto px-4 md:px-8 max-w-5xl">
-          
+
           {/* header */}
           <div className="text-center mb-12">
             <h1 className="text-4xl md:text-5xl font-extrabold mb-4 flex items-center justify-center gap-4 text-gray-900 dark:text-white">
@@ -190,7 +189,7 @@ const DSARoadmap: React.FC = () => {
             <p className="text-lg text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
               <Translate>A comprehensive, step-by-step interactive learning path to master Data Structures, Algorithms, and Problem Solving.</Translate>
             </p>
-         
+
             <div className="flex justify-center gap-4 mt-6">
               <button
                 type="button"
@@ -214,12 +213,12 @@ const DSARoadmap: React.FC = () => {
             {topics.map((topic, tIdx) => (
               <div key={tIdx} className="mb-10 ml-8 relative">
 
-                <div 
+                <div
                   className={`absolute -left-[2.65rem] top-[21px] h-8 w-8 rounded-full border-4 border-gray-50 dark:border-[#1b1b1d] shadow-sm flex items-center justify-center z-10 transition-colors duration-300 ${
                     expandedTopics[tIdx] ? "bg-[var(--ifm-color-primary)]" : "bg-gray-300 dark:bg-gray-600"
                   }`}
                 ></div>
-      
+
                 <h2 className="m-0">
                   <button
                     type="button"
@@ -242,7 +241,7 @@ const DSARoadmap: React.FC = () => {
                   </button>
                 </h2>
 
-                <div 
+                <div
                   id={`roadmap-topic-${tIdx}`}
                   className={`grid transition-[grid-template-rows,opacity] duration-300 ease-in-out ${
                     expandedTopics[tIdx] ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
@@ -254,8 +253,8 @@ const DSARoadmap: React.FC = () => {
                         const isFolderExpanded = expandedFolders[`${tIdx}-${fIdx}`];
 
                         return (
-                          <div 
-                            key={fIdx} 
+                          <div
+                            key={fIdx}
                             className="bg-white dark:bg-gray-800/80 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm overflow-hidden h-fit"
                           >
                             <h3 className="m-0">
@@ -280,7 +279,7 @@ const DSARoadmap: React.FC = () => {
                               </button>
                             </h3>
 
-                            <div 
+                            <div
                               id={`roadmap-folder-${tIdx}-${fIdx}`}
                               className={`grid transition-[grid-template-rows,opacity] duration-300 ease-in-out ${
                                 isFolderExpanded ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
@@ -291,7 +290,6 @@ const DSARoadmap: React.FC = () => {
                                   <ul className="ml-2 border-l-2 border-gray-200 dark:border-gray-600 pl-4 space-y-3 mt-3">
                                     {folder.files.map((file, fileIdx) => {
                                       const fileLink = getDocLink(topic.title, folder.name, file);
-
                                       return (
                                         <li key={fileIdx}>
                                           <Link


### PR DESCRIPTION
##  Bug Fix: Persist DSA Roadmap expanded state using localStorage

### Description
The DSA Roadmap step indicator circles correctly turned blue on expand, but this state was never saved. On every page refresh, all progress reset to gray , making the roadmap non-functional as a learning tracker.
This PR fixes the issue by persisting expanded state to localStorage.


### **Proof of Fix (Screen Recording)**
A screen recording has been attached demonstrating the fix:

1. DSA Roadmap page opened — Step 01 and Step 02 are expanded (blue)
2. Page is refreshed (F5)
3. After refresh — both steps remain blue ✅
4. Previously, all steps would reset to gray on refresh ❌

The localStorage persistence is working correctly as shown in the recording.

https://github.com/user-attachments/assets/7d643d97-5b5d-44c5-9963-c6392a1abbf4



Fixes #2452

### Changes Made
- Added `useEffect` import alongside existing `useState`
- Changed `expandedTopics` initial state to lazy initializer — reads from `localStorage` on mount
- Changed `expandedFolders` initial state to lazy initializer — reads from `localStorage` on mount
- Added `useEffect` to save `expandedTopics` to `localStorage` on every change
- Added `useEffect` to save `expandedFolders` to `localStorage` on every change
- Wrapped all localStorage calls in `try/catch` for private browsing compatibility

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes