### PR TITLE
feat: add Rust and Go support to multi-language playground

### DIFF
--- a/MULTI_LANGUAGE_PLAYGROUND.md
+++ b/MULTI_LANGUAGE_PLAYGROUND.md
@@ -2,12 +2,12 @@
 
 ## Overview
 
-The Algo Playground has been enhanced to support multiple programming languages: **JavaScript**, **Python**, **C++**, and **Java**. Users can now select their preferred language from a dropdown menu and write/execute algorithms in their chosen language.
+The Algo Playground has been enhanced to support multiple programming languages: **JavaScript**, **Python**, **C++**, **Java**, **Rust**, and **Go**. Users can now select their preferred language from a dropdown menu and write/execute algorithms in their chosen language.
 
 ## Features
 
 ### 1. Language Selection Dropdown
-- Users can select from: JavaScript, Python, C++, or Java
+- Users can select from: JavaScript, Python, C++, Java, Rust, or Go
 - Located in the playground header for easy access
 - Changing the language automatically loads appropriate templates
 
@@ -22,11 +22,11 @@ Templates are pre-written with working implementations to help users understand 
 
 ### 3. Dynamic Syntax Highlighting
 - Monaco Editor automatically adjusts syntax highlighting based on selected language
-- File extension in the editor tab reflects the current language (e.g., `script.js`, `script.py`, `script.cpp`, `script.java`)
+- File extension in the editor tab reflects the current language (e.g., `script.js`, `script.py`, `script.cpp`, `script.java`, `script.rs`, `script.go`)
 
 ### 4. Multi-Language Code Execution
 - **JavaScript**: Runs in Web Workers (client-side) for security and performance
-- **Python**, **C++**, **Java**: Execute on the backend server with proper compilation/interpretation
+- **Python**, **C++**, **Java**, **Rust**, **Go**: Execute on the backend server with proper compilation/interpretation
 
 ## Setup Instructions
 
@@ -35,7 +35,7 @@ The frontend changes are automatically included in `src/pages/playground/index.t
 
 ### Backend Requirements
 
-To use Python, C++, and Java execution, ensure the following tools are installed on your server:
+To use Python, C++, Java, Rust, and Go execution, ensure the following tools are installed on your server:
 
 #### Linux/macOS
 ```bash
@@ -48,21 +48,30 @@ g++ --version
 # Java
 java -version
 javac -version
+
+# Rust
+rustc --version
+cargo --version
+
+# Go
+go version
 ```
 
 Install if missing:
 ```bash
 # Ubuntu/Debian
-sudo apt-get install python3 g++ openjdk-11-jdk
+sudo apt-get install python3 g++ openjdk-11-jdk rustc golang-go
 
 # macOS with Homebrew
-brew install python@3.11 gcc openjdk
+brew install python@3.11 gcc openjdk rust go
 ```
 
 #### Windows
 1. **Python**: Download from https://www.python.org/downloads/
 2. **C++ Compiler**: Install MinGW or use Visual C++ Build Tools
 3. **Java**: Download JDK from https://www.oracle.com/java/technologies/javase-jdk11-downloads.html
+4. **Rust**: Download from https://www.rust-lang.org/tools/install
+5. **Go**: Download from https://golang.org/dl/
 
 ### Running the Backend Server
 
@@ -88,7 +97,7 @@ The server will listen on `http://localhost:5000` by default.
 **Request Body:**
 ```json
 {
-  "language": "python|cpp|java",
+  "language": "python|cpp|java|rust|go",
   "code": "// Your source code here"
 }
 ```
@@ -237,16 +246,16 @@ The playground employs layered security techniques depending on the execution ru
 * **Global Scope Isolation**: Web Workers do not have access to the browser's main thread global scope, the **window** object, the **document** (DOM), or cookies.
 * **Timeout Protection**: A watchdog timer automatically terminates execution if a script exceeds the 10-second execution limit, preventing infinite loop tab freezes.
 
-### 2. Backend Execution (Python, C++, Java)
+### 2. Backend Execution (Python, C++, Java, Rust, Go)
 Non-JavaScript languages are executed on the backend server.
-* **Execution Environment**: Code is written to temporary files in the server's temporary directory and executed using system commands (python, g++, java).
+* **Execution Environment**: Code is written to temporary files in the server's temporary directory and executed using system commands (python, g++, java, rustc, go).
 * **Timeout Protection**: Backend execution is limited to 10 seconds via the exec timeout option to prevent resource exhaustion.
 * **Cleanup**: Temporary source files and compiled binaries are deleted immediately after execution.
 
 ## Future Enhancements
 
 Potential improvements:
-- Add more languages (Rust, Go, C#, etc.)
+- Add more languages (C#, Kotlin, etc.)
 - Support for multiple files/modules
 - Code sharing and snippets
 - Collaborative editing

--- a/server/server.js
+++ b/server/server.js
@@ -175,9 +175,9 @@ app.post("/api/execute-code", async (req, res) => {
     return res.status(400).json({ success: false, error: "Missing language or code parameter." });
   }
 
-  const validLanguages = ["python", "cpp", "java"];
+  const validLanguages = ["python", "cpp", "java", "rust", "go"];
   if (!validLanguages.includes(language)) {
-    return res.status(400).json({ success: false, error: "Unsupported language. Supported: python, cpp, java" });
+    return res.status(400).json({ success: false, error: "Unsupported language. Supported: python, cpp, java, rust, go" });
   }
 
   try {
@@ -212,6 +212,24 @@ app.post("/api/execute-code", async (req, res) => {
         command = `cd "${tempDir}" && javac "${filename}" && java "${className}"`;
         break;
 
+      case "rust":
+        fileExtension = ".rs";
+        const sourceFile2 = path.join(tempDir, `script_${uniqueId}${fileExtension}`);
+        const executableFile2 = path.join(tempDir, `script_${uniqueId}${process.platform === "win32" ? ".exe" : ""}`);
+        filename = sourceFile2;
+        // Compile and run
+        command = `rustc "${sourceFile2}" -o "${executableFile2}" && "${executableFile2}"`;
+        break;
+
+      case "go":
+        fileExtension = ".go";
+        const goSourceFile = path.join(tempDir, `script_${uniqueId}${fileExtension}`);
+        const goExecutableFile = path.join(tempDir, `script_${uniqueId}${process.platform === "win32" ? ".exe" : ""}`);
+        filename = goSourceFile;
+        // Compile and run
+        command = `go run "${goSourceFile}"`;
+        break;
+
       default:
         return res.status(400).json({ success: false, error: "Unsupported language" });
     }
@@ -225,6 +243,12 @@ app.post("/api/execute-code", async (req, res) => {
       try {
         fs.unlinkSync(filename);
         if (language === "cpp") {
+          const executableFile = filename.replace(fileExtension, process.platform === "win32" ? ".exe" : "");
+          if (fs.existsSync(executableFile)) {
+            fs.unlinkSync(executableFile);
+          }
+        }
+        if (language === "rust") {
           const executableFile = filename.replace(fileExtension, process.platform === "win32" ? ".exe" : "");
           if (fs.existsSync(executableFile)) {
             fs.unlinkSync(executableFile);

--- a/server/server.js
+++ b/server/server.js
@@ -224,7 +224,6 @@ app.post("/api/execute-code", async (req, res) => {
       case "go":
         fileExtension = ".go";
         const goSourceFile = path.join(tempDir, `script_${uniqueId}${fileExtension}`);
-        const goExecutableFile = path.join(tempDir, `script_${uniqueId}${process.platform === "win32" ? ".exe" : ""}`);
         filename = goSourceFile;
         // Compile and run
         command = `go run "${goSourceFile}"`;

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "react-icons/fa";
 
 // Language configuration
-type LanguageType = "javascript" | "python" | "cpp" | "java";
+type LanguageType = "javascript" | "python" | "cpp" | "java" | "rust" | "go";
 
 interface LanguageConfig {
   name: string;
@@ -42,6 +42,16 @@ const LANGUAGE_CONFIGS: Record<LanguageType, LanguageConfig> = {
     name: "Java",
     monacoLanguage: "java",
     fileExtension: ".java",
+  },
+  rust: {
+    name: "Rust",
+    monacoLanguage: "rust",
+    fileExtension: ".rs",
+  },
+  go: {
+    name: "Go",
+    monacoLanguage: "go",
+    fileExtension: ".go",
   },
 };
 
@@ -572,6 +582,295 @@ public class Fibonacci {
 }
 `,
   },
+  rust: {
+    binarySearch: `// Binary Search Algorithm
+// Finds the index of a target element in a sorted array.
+// Returns -1 if not found.
+
+fn binary_search(arr: &[i32], target: i32) -> i32 {
+    let mut left = 0;
+    let mut right = (arr.len() as i32) - 1;
+
+    while left <= right {
+        let mid = left + (right - left) / 2;
+        if arr[mid as usize] == target {
+            return mid;
+        } else if arr[mid as usize] < target {
+            left = mid + 1;
+        } else {
+            right = mid - 1;
+        }
+    }
+    -1
+}
+
+fn main() {
+    let arr = vec![1, 3, 5, 7, 9, 11, 13, 15];
+    println!("Input Array: {:?}", arr);
+    println!("Searching for 7: {}", binary_search(&arr, 7));  // Expected: 3
+    println!("Searching for 10: {}", binary_search(&arr, 10));  // Expected: -1
+}
+`,
+    bubbleSort: `// Bubble Sort Algorithm
+// Sorts an array of numbers in ascending order.
+
+fn bubble_sort(arr: &mut [i32]) {
+    let n = arr.len();
+    for i in 0..n - 1 {
+        let mut swapped = false;
+        for j in 0..n - i - 1 {
+            if arr[j] > arr[j + 1] {
+                arr.swap(j, j + 1);
+                swapped = true;
+            }
+        }
+        if !swapped {
+            break;
+        }
+    }
+}
+
+fn main() {
+    let mut unsorted = vec![64, 34, 25, 12, 22, 11, 90];
+    println!("Unsorted: {:?}", unsorted);
+
+    bubble_sort(&mut unsorted);
+
+    println!("Sorted: {:?}", unsorted);
+}
+`,
+    reverseList: `// Reverse a Singly Linked List
+// Returns the new head of the reversed list.
+
+#[derive(Clone)]
+struct ListNode {
+    val: i32,
+    next: Option<Box<ListNode>>,
+}
+
+impl ListNode {
+    fn new(val: i32) -> Self {
+        ListNode { val, next: None }
+    }
+}
+
+fn reverse_list(mut head: Option<Box<ListNode>>) -> Option<Box<ListNode>> {
+    let mut prev = None;
+    while let Some(mut current) = head {
+        head = current.next.take();
+        current.next = prev;
+        prev = Some(current);
+    }
+    prev
+}
+
+fn print_list(head: &Option<Box<ListNode>>) {
+    print!("List: ");
+    let mut current = head;
+    while let Some(node) = current {
+        print!("{}", node.val);
+        if node.next.is_some() {
+            print!(" -> ");
+        }
+        current = &node.next;
+    }
+    println!();
+}
+
+fn main() {
+    let mut list = Box::new(ListNode::new(1));
+    list.next = Some(Box::new(ListNode::new(2)));
+    list.next.as_mut().unwrap().next = Some(Box::new(ListNode::new(3)));
+    list.next.as_mut().unwrap().next.as_mut().unwrap().next = Some(Box::new(ListNode::new(4)));
+    list.next.as_mut().unwrap().next.as_mut().unwrap().next.as_mut().unwrap().next = Some(Box::new(ListNode::new(5)));
+
+    print!("Original: ");
+    print_list(&Some(list.clone()));
+
+    let reversed = reverse_list(Some(list));
+    print!("Reversed: ");
+    print_list(&reversed);
+}
+`,
+    fibonacci: `// Fibonacci Generator
+// Generates the first N fibonacci numbers.
+
+fn generate_fibonacci(n: usize) -> Vec<i32> {
+    if n == 0 {
+        return vec![];
+    }
+    let mut series = vec![0];
+    if n > 1 {
+        series.push(1);
+    }
+
+    for _ in 2..n {
+        let len = series.len();
+        series.push(series[len - 1] + series[len - 2]);
+    }
+    series
+}
+
+fn main() {
+    let fib = generate_fibonacci(10);
+    print!("First 10 Fibonacci numbers: ");
+    for (i, &num) in fib.iter().enumerate() {
+        print!("{}", num);
+        if i < fib.len() - 1 {
+            print!(", ");
+        }
+    }
+    println!();
+}
+`,
+  },
+  go: {
+    binarySearch: `package main
+
+import "fmt"
+
+// Binary Search Algorithm
+// Finds the index of a target element in a sorted array.
+// Returns -1 if not found.
+
+func binarySearch(arr []int, target int) int {
+    left := 0
+    right := len(arr) - 1
+
+    for left <= right {
+        mid := left + (right-left)/2
+        if arr[mid] == target {
+            return mid
+        } else if arr[mid] < target {
+            left = mid + 1
+        } else {
+            right = mid - 1
+        }
+    }
+    return -1
+}
+
+func main() {
+    arr := []int{1, 3, 5, 7, 9, 11, 13, 15}
+    fmt.Println("Input Array:", arr)
+    fmt.Println("Searching for 7:", binarySearch(arr, 7))   // Expected: 3
+    fmt.Println("Searching for 10:", binarySearch(arr, 10)) // Expected: -1
+}
+`,
+    bubbleSort: `package main
+
+import "fmt"
+
+// Bubble Sort Algorithm
+// Sorts an array of numbers in ascending order.
+
+func bubbleSort(arr []int) {
+    n := len(arr)
+    for i := 0; i < n-1; i++ {
+        swapped := false
+        for j := 0; j < n-i-1; j++ {
+            if arr[j] > arr[j+1] {
+                arr[j], arr[j+1] = arr[j+1], arr[j]
+                swapped = true
+            }
+        }
+        if !swapped {
+            break
+        }
+    }
+}
+
+func main() {
+    unsorted := []int{64, 34, 25, 12, 22, 11, 90}
+    fmt.Println("Unsorted:", unsorted)
+
+    bubbleSort(unsorted)
+
+    fmt.Println("Sorted:  ", unsorted)
+}
+`,
+    reverseList: `package main
+
+import "fmt"
+
+// Reverse a Singly Linked List
+// Returns the new head of the reversed list.
+
+type ListNode struct {
+    Val  int
+    Next *ListNode
+}
+
+func reverseList(head *ListNode) *ListNode {
+    var prev *ListNode
+    current := head
+    for current != nil {
+        nextNode := current.Next
+        current.Next = prev
+        prev = current
+        current = nextNode
+    }
+    return prev
+}
+
+func printList(head *ListNode) {
+    fmt.Print("List: ")
+    for head != nil {
+        fmt.Print(head.Val)
+        if head.Next != nil {
+            fmt.Print(" -> ")
+        }
+        head = head.Next
+    }
+    fmt.Println()
+}
+
+func main() {
+    list := &ListNode{Val: 1, Next: &ListNode{Val: 2, Next: &ListNode{Val: 3, Next: &ListNode{Val: 4, Next: &ListNode{Val: 5}}}}}
+
+    fmt.Print("Original: ")
+    printList(list)
+
+    reversed := reverseList(list)
+    fmt.Print("Reversed: ")
+    printList(reversed)
+}
+`,
+    fibonacci: `package main
+
+import "fmt"
+
+// Fibonacci Generator
+// Generates the first N fibonacci numbers.
+
+func generateFibonacci(n int) []int {
+    if n <= 0 {
+        return []int{}
+    }
+    if n == 1 {
+        return []int{0}
+    }
+
+    series := []int{0, 1}
+    for i := 2; i < n; i++ {
+        series = append(series, series[i-1]+series[i-2])
+    }
+    return series
+}
+
+func main() {
+    fib := generateFibonacci(10)
+    fmt.Print("First 10 Fibonacci numbers: ")
+    for i, num := range fib {
+        fmt.Print(num)
+        if i < len(fib)-1 {
+            fmt.Print(", ")
+        }
+    }
+    fmt.Println()
+}
+`,
+  },
 };
 
 type EditorTelemetry = {
@@ -940,6 +1239,8 @@ const PlaygroundContent: React.FC = () => {
                 <option value="python">Python</option>
                 <option value="cpp">C++</option>
                 <option value="java">Java</option>
+                <option value="rust">Rust</option>
+                <option value="go">Go</option>
               </select>
             </div>
 

--- a/src/pages/playground/index.tsx
+++ b/src/pages/playground/index.tsx
@@ -616,6 +616,9 @@ fn main() {
 
 fn bubble_sort(arr: &mut [i32]) {
     let n = arr.len();
+    if n <= 1 {
+        return;
+    }
     for i in 0..n - 1 {
         let mut swapped = false;
         for j in 0..n - i - 1 {


### PR DESCRIPTION
## Summary
- Added Rust and Go as new supported languages in the code playground
- Implemented syntax highlighting and code templates for both languages
- Extended backend to compile and execute Rust and Go code with proper cleanup
- Updated documentation with setup instructions and usage information

## What's included
- **Frontend**: Language selector, Monaco editor integration, templates for all algorithms
- **Backend**: rustc and go compiler support with 10-second timeout protection
- **Templates**: Binary search, bubble sort, reverse linked list, and fibonacci for both languages
- **Documentation**: Updated MULTI_LANGUAGE_PLAYGROUND.md with setup and usage instructions

## Fixes
Resolves #2425

## Testing
Please test:
1. Select Rust from language dropdown and run each template
2. Select Go from language dropdown and run each template
3. Verify compilation errors are properly reported
4. Ensure timeout protection works (if supported)