### PR TITLE
feat(ui): Add bouncing scroll-down indicator to Hero Section

### DIFF
--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { FaGithub, FaArrowRight } from "react-icons/fa";
+import { FaGithub, FaArrowRight, FaChevronDown } from "react-icons/fa";
 import { FiCode } from "react-icons/fi";
 import { default as Link } from "@docusaurus/Link"; // Fixed import statement for Link
 
 const HeroSection = () => {
   return (
     <section className="relative min-h-screen flex items-center justify-center py-16 px-8 noise-bg">
-      <div className="max-w-4xl text-center">
+      <div className="max-w-4xl text-center z-10">
         <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-slate-900/5 dark:bg-white/5 border border-slate-900/10 dark:border-white/10 text-slate-600 dark:text-gray-400 text-xs font-bold uppercase tracking-wider mb-6 backdrop-blur-sm">
           <FiCode className="w-3.5 h-3.5 text-blue-500 dark:text-blue-400" />
           <span>v2.0 Architecture</span>
@@ -52,6 +52,14 @@ const HeroSection = () => {
       <div className="absolute inset-0 pointer-events-none overflow-hidden">
         <div className="absolute -top-20 -left-10 w-72 h-72 bg-blue-500 opacity-30 rounded-full blur-3xl animate-pulse"></div>
         <div className="absolute -bottom-20 -right-10 w-72 h-72 bg-pink-500 opacity-30 rounded-full blur-3xl animate-pulse"></div>
+      </div>
+
+      <div 
+        className="absolute bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce cursor-pointer text-slate-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400 transition-colors duration-300 z-20"
+        onClick={() => window.scrollTo({ top: window.innerHeight, behavior: 'smooth' })}
+        title="Scroll down"
+      >
+        <FaChevronDown size={32} />
       </div>
     </section>
   );

--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -54,13 +54,14 @@ const HeroSection = () => {
         <div className="absolute -bottom-20 -right-10 w-72 h-72 bg-pink-500 opacity-30 rounded-full blur-3xl animate-pulse"></div>
       </div>
 
-      <div 
-        className="absolute bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce cursor-pointer text-slate-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400 transition-colors duration-300 z-20"
+      <button 
+        className="absolute bottom-10 left-1/2 transform -translate-x-1/2 animate-bounce cursor-pointer text-slate-400 hover:text-blue-500 dark:text-gray-500 dark:hover:text-blue-400 transition-colors duration-300 z-20 bg-transparent border-0 p-0 focus:outline-none"
         onClick={() => window.scrollTo({ top: window.innerHeight, behavior: 'smooth' })}
+        aria-label="Scroll down"
         title="Scroll down"
       >
         <FaChevronDown size={32} />
-      </div>
+      </button>
     </section>
   );
 };


### PR DESCRIPTION
## Description
This PR introduces a small but impactful UI polish to the homepage. Because the Hero Section occupies the full viewport height, users might not immediately realize there is more content below. This adds a visual cue to encourage exploring the rest of the homepage.

## Changes Made
- Imported `FaChevronDown` from `react-icons/fa` into `HeroSection.tsx`.
- Added an absolute-positioned bouncing chevron at the bottom-center of the Hero Section.
- Implemented a smooth scroll `onClick` handler that scrolls the window down exactly `window.innerHeight` pixels, seamlessly transitioning the user to the next section.
- Added appropriate `z-index` layering to ensure the content and the new arrow sit above the decorative background orbs.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] UI / UX Polish

Resolves #2490 