### PR TITLE
Add active state styling to navigation links

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -116,6 +116,31 @@ div[class^="announcementBar_"] .clean-btn {
   /* Lighter blue hover color in dark mode */
 }
 
+/* Active navbar link styling - Light mode */
+.navbar__link--active {
+  background-color: #3b82f6 !important;
+  color: white !important;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  transition: background-color 0.3s ease;
+}
+
+.navbar__link--active:hover {
+  background-color: #2563eb !important;
+}
+
+/* Active navbar link styling - Dark mode */
+[data-theme="dark"] .navbar__link--active {
+  background-color: #eab308 !important;
+  color: #0d1117 !important;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+}
+
+[data-theme="dark"] .navbar__link--active:hover {
+  background-color: #ca8a04 !important;
+}
+
 [data-theme="dark"] #__docusaurus_skipToContent_fallback {
   /*   background: linear-gradient(rgba(15, 23, 42, 0.796), rgba(15, 23, 42, 0.23)); */
   background: #0d1117;


### PR DESCRIPTION
## 📥 Pull Request

### Description

Fixes #2479 
This PR resolves the navbar active state issue where users could not easily identify their current location on the website.

### Changes Made
- Updated `custom.css` to add styling for active navigation links.
- Added a distinct visual indicator for the currently active page.
- Improved navigation clarity and overall user experience.
- Ensured active state styling remains consistent across all navbar items.

## change in Dark Mode 
<img width="1914" height="941" alt="Screenshot 2026-06-02 003730" src="https://github.com/user-attachments/assets/148fbbbb-057b-40cc-9b29-393976f1b026" />

## Change in Light Mode
<img width="1910" height="955" alt="Screenshot 2026-06-02 003739" src="https://github.com/user-attachments/assets/425647e7-61ea-4dad-b25c-6041c3c5d82b" />

### Expected Result
When users navigate to pages such as Contributors, Blog, FAQ, or Tutorial, the corresponding navbar link is visually highlighted, making it clear which page is currently active.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code


- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules