### PR TITLE
[Feature]: Integrate Algolia DocSearch for Instant Algorithm Lookups

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -101,7 +101,6 @@ const config = {
         indexName: "ajay-dhangario",
         appId: "T0I3F584D5",
         contextualSearch: true,
-        placeholder: "Search algorithms...",
       },
 
       navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -100,7 +100,8 @@ const config = {
         apiKey: "865d7bd9906f532b1d8cb5cc0f02b383",
         indexName: "ajay-dhangario",
         appId: "T0I3F584D5",
-        contextualSearch: false,
+        contextualSearch: true,
+        placeholder: "Search algorithms...",
       },
 
       navbar: {


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR integrates Algolia DocSearch settings for Docusaurus instant search. It sets the search indices, api credentials, and configures `contextualSearch: true` for optimized context search filters across localized documentation.

Fixes #2523

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Docusaurus theme configuration compiles successfully
