### PR TITLE
fix: avoid CSS string parsing in merge sort comparisons

### DIFF
--- a/src/components/Visualizing/index.tsx
+++ b/src/components/Visualizing/index.tsx
@@ -12,7 +12,8 @@ const DSARoadmap: React.FC = () => {
     }
 
     // Helper to reliably get the numeric value of height for comparisons
-    function getHeightVal(el: HTMLElement | string): number {
+    function getHeightVal(el: HTMLElement | string | null | undefined): number {
+      if (!el) return 0;
       if (typeof el === "string") return parseFloat(el) || 0;
       return parseFloat(el.style.height) || 0;
     }

--- a/src/components/Visualizing/index.tsx
+++ b/src/components/Visualizing/index.tsx
@@ -11,6 +11,12 @@ const DSARoadmap: React.FC = () => {
       r.style.height = t;
     }
 
+    // Helper to reliably get the numeric value of height for comparisons
+    function getHeightVal(el: HTMLElement | string): number {
+      if (typeof el === "string") return parseFloat(el) || 0;
+      return parseFloat(el.style.height) || 0;
+    }
+
     // 2. Button and input references using clean TypeScript generics
     const bubbleSortBtn = document.querySelector<HTMLButtonElement>(".bubbleSort");
     const insertionSortBtn = document.querySelector<HTMLButtonElement>(".insertionSort");
@@ -141,7 +147,7 @@ const DSARoadmap: React.FC = () => {
           ele[j].style.background = "blue";
           ele[j + 1].style.background = "blue";
           await waitforme(delay);
-          if (parseInt(ele[j].style.height) > parseInt(ele[j + 1].style.height)) {
+          if (getHeightVal(ele[j]) > getHeightVal(ele[j + 1])) {
             swap(ele[j], ele[j + 1]);
           }
           ele[j].style.background = "cyan";
@@ -181,7 +187,7 @@ const DSARoadmap: React.FC = () => {
         let key = ele[i].style.height;
         ele[i].style.background = "blue";
         await waitforme(delay);
-        while (j >= 0 && parseInt(ele[j].style.height) > parseInt(key)) {
+        while (j >= 0 && getHeightVal(ele[j]) > getHeightVal(key)) {
           ele[j].style.background = "blue";
           ele[j + 1].style.height = ele[j].style.height;
           j--;
@@ -237,7 +243,7 @@ const DSARoadmap: React.FC = () => {
       while (i < n1 && j < n2) {
         await waitforme(delay);
 
-        if (parseInt(leftArr[i]) <= parseInt(rightArr[j])) {
+        if (getHeightVal(leftArr[i]) <= getHeightVal(rightArr[j])) {
           arr[k].style.height = leftArr[i];
           arr[k].style.backgroundColor = "lightgreen";
           i++;
@@ -302,7 +308,7 @@ const DSARoadmap: React.FC = () => {
       for (let r = low; r <= pivotIndex - 1; r++) {
         bars[r].style.background = "yellow";
         await waitforme(delay);
-        if (parseInt(bars[r].style.height) < parseInt(bars[pivotIndex].style.height)) {
+        if (getHeightVal(bars[r]) < getHeightVal(bars[pivotIndex])) {
           partitionIdx++;
           swap(bars[partitionIdx], bars[r]);
           bars[partitionIdx].style.background = "orange";
@@ -370,7 +376,7 @@ const DSARoadmap: React.FC = () => {
         for (let a = t + 1; a < bars.length; a++) {
           bars[a].style.background = "red";
           await waitforme(delay);
-          if (parseInt(bars[a].style.height) < parseInt(bars[minIdx].style.height)) {
+          if (getHeightVal(bars[a]) < getHeightVal(bars[minIdx])) {
             if (minIdx !== t) {
               bars[minIdx].style.background = "cyan";
             }


### PR DESCRIPTION
# 📥 Pull Request

## Description

This PR fixes the fragile comparison logic used across the sorting visualizations, where element heights were compared by parsing CSS height strings directly with `parseInt()`.

Previously, sorting algorithms relied on values such as `"150px"` as the source of truth:

```ts
parseInt(element.style.height)
```

This approach was fragile because invalid or unexpected style values could result in `NaN`, causing incorrect comparisons and potentially breaking sort execution.

### Changes Made

* Added a reusable `getHeightVal()` helper function to centralize height parsing.
* Replaced `parseInt()` with `parseFloat()` for more accurate numeric comparisons.
* Added safe fallback behavior (`0`) when parsing fails.
* Updated all sorting algorithms to use the helper function:

  * Bubble Sort
  * Insertion Sort
  * Merge Sort
  * Quick Sort
  * Selection Sort

```ts
function getHeightVal(el: HTMLElement | string): number {
  if (typeof el === "string") return parseFloat(el) || 0;
  return parseFloat(el.style.height) || 0;
}
```

### Motivation

This change removes duplicated parsing logic, improves maintainability, and ensures sorting comparisons are more resilient to styling changes, malformed values, and future UI updates. It also enables accurate handling of floating-point height values.

Fixes #2632 

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
