### PR TITLE
fix: cookie banner overlap and dark mode styling (#2620)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -360,3 +360,24 @@ button {
   padding-right: 2rem !important;
 }
 
+/* =============================================
+   Fix #2620: Cookie banner overlap + dark mode
+   ============================================= */
+
+body {
+  padding-bottom: 80px;
+}
+
+[data-theme='dark'] .cookieConsent,
+[data-theme='dark'] [class*='cookieConsent'],
+[data-theme='dark'] [class*='cookie'] {
+  background-color: var(--ifm-background-surface-color) !important;
+  color: var(--ifm-font-color-base) !important;
+  border-top: 1px solid var(--ifm-color-emphasis-300) !important;
+}
+
+[data-theme='dark'] .cookieConsent button,
+[data-theme='dark'] [class*='cookie'] button {
+  background-color: var(--ifm-color-primary) !important;
+  color: #ffffff !important;
+}


### PR DESCRIPTION
## Summary
Fixes two UI bugs with the cookie consent banner on the homepage.

## Changes Made
- Added `padding-bottom: 80px` to body so page content 
  is not hidden behind the fixed cookie banner
- Added dark mode CSS targeting Docusaurus `data-theme='dark'` 
  attribute using CSS variables for proper theme support
- Used `--ifm-background-surface-color` and `--ifm-font-color-base` 
  instead of hardcoded colors

## Files Changed
- `src/css/custom.css` — new lines added at the bottom only, 
  zero existing code modified

## Related Issue
Fixes #2620

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules