### PR TITLE
fix: avoid state mutation in mergeSort visualizer

### DIFF
--- a/src/components/Visualizing/index.tsx
+++ b/src/components/Visualizing/index.tsx
@@ -161,13 +161,13 @@ const DSARoadmap: React.FC = () => {
 
     for (let i = 0; i < n1; i++) {
       await waitforme(delay, signal);
-      arr[left + i].color = "orange";
+      arr[left + i] = { ...arr[left + i], color: "orange" };
       leftArr[i] = arr[left + i].value;
       setBars([...arr]);
     }
     for (let j = 0; j < n2; j++) {
       await waitforme(delay, signal);
-      arr[mid + 1 + j].color = "yellow";
+      arr[mid + 1 + j] = { ...arr[mid + 1 + j], color: "yellow" };
       rightArr[j] = arr[mid + 1 + j].value;
       setBars([...arr]);
     }
@@ -177,12 +177,10 @@ const DSARoadmap: React.FC = () => {
     while (i < n1 && j < n2) {
       await waitforme(delay, signal);
       if (leftArr[i] <= rightArr[j]) {
-        arr[k].value = leftArr[i];
-        arr[k].color = "lightgreen";
+        arr[k] = { ...arr[k], value: leftArr[i], color: "lightgreen" };
         i++;
       } else {
-        arr[k].value = rightArr[j];
-        arr[k].color = "lightgreen";
+        arr[k] = { ...arr[k], value: rightArr[j], color: "lightgreen" };
         j++;
       }
       k++;
@@ -190,16 +188,14 @@ const DSARoadmap: React.FC = () => {
     }
     while (i < n1) {
       await waitforme(delay, signal);
-      arr[k].value = leftArr[i];
-      arr[k].color = "lightgreen";
+      arr[k] = { ...arr[k], value: leftArr[i], color: "lightgreen" };
       i++;
       k++;
       setBars([...arr]);
     }
     while (j < n2) {
       await waitforme(delay, signal);
-      arr[k].value = rightArr[j];
-      arr[k].color = "lightgreen";
+      arr[k] = { ...arr[k], value: rightArr[j], color: "lightgreen" };
       j++;
       k++;
       setBars([...arr]);
@@ -218,7 +214,7 @@ const DSARoadmap: React.FC = () => {
     await mergeSortHelper(arr, 0, arr.length - 1, signal);
     // Color them all green when done
     for (let i = 0; i < arr.length; i++) {
-      arr[i].color = SORTED_COLOR;
+      arr[i] = { ...arr[i], color: SORTED_COLOR };
     }
     setBars([...arr]);
   };


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes a state mutation issue in the Sorting Visualizer's `mergeSort` implementation located in `src/components/Visualizing/index.tsx`.

Previously, the sorting logic directly mutated properties of objects stored in the React state array (e.g., `arr[k].color = "lightgreen"`). Although `setBars([...arr])` was called afterward, the underlying objects were still being modified in place, which violates React's immutability principles and can lead to unreliable re-renders.

The fix updates both `mergeSort` and its helper `merge` function to create new object instances whenever an element is modified. Instead of mutating existing objects, updated elements are replaced using object spread syntax:

```ts
arr[k] = {
  ...arr[k],
  value: leftArr[i],
  color: "lightgreen",
};
```

This ensures that state updates remain immutable, allowing React to correctly detect changes and trigger consistent UI updates throughout the sorting visualization.

Fixes #2681 

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

### Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
