### PR TITLE
feat: enhance sorting visualizer with pause/resume and new algorithms

### DIFF
--- a/src/components/Visualizing/index.tsx
+++ b/src/components/Visualizing/index.tsx
@@ -12,18 +12,42 @@ const COMPARE_COLOR = "blue";
 const SWAP_COLOR = "red";
 const SORTED_COLOR = "green";
 
-const DSARoadmap: React.FC = () => {
+const SortingVisualizer: React.FC = () => {
   const [bars, setBars] = useState<BarData[]>([]);
   const [arraySize, setArraySize] = useState<number>(40);
   const [speed, setSpeed] = useState<number>(100);
   const [isSorting, setIsSorting] = useState<boolean>(false);
+  const [isPaused, setIsPaused] = useState<boolean>(false);
 
   const abortControllerRef = useRef<AbortController | null>(null);
+  const isPausedRef = useRef<boolean>(false);
+  const unpauseRef = useRef<(() => void) | null>(null);
+
+  const togglePause = () => {
+    if (isPausedRef.current) {
+      isPausedRef.current = false;
+      setIsPaused(false);
+      if (unpauseRef.current) {
+        unpauseRef.current();
+        unpauseRef.current = null;
+      }
+    } else {
+      isPausedRef.current = true;
+      setIsPaused(true);
+    }
+  };
 
   // Derive delay from speed: speed is 20-300. Max delay should be smaller for higher speed.
   const getDelay = () => 320 - speed;
 
-  const waitforme = (millis: number, signal: AbortSignal): Promise<void> => {
+  const waitforme = async (millis: number, signal: AbortSignal): Promise<void> => {
+    if (signal.aborted) throw new Error("aborted");
+    while (isPausedRef.current) {
+      await new Promise<void>((resolve) => {
+        unpauseRef.current = resolve;
+      });
+      if (signal.aborted) throw new Error("aborted");
+    }
     return new Promise((resolve, reject) => {
       if (signal.aborted) return reject(new Error("aborted"));
       const onAbort = () => {
@@ -42,6 +66,10 @@ const DSARoadmap: React.FC = () => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
+    if (unpauseRef.current) {
+      unpauseRef.current();
+      unpauseRef.current = null;
+    }
     const newBars: BarData[] = [];
     for (let i = 0; i < size; i++) {
       newBars.push({
@@ -51,6 +79,8 @@ const DSARoadmap: React.FC = () => {
     }
     setBars(newBars);
     setIsSorting(false);
+    setIsPaused(false);
+    isPausedRef.current = false;
   }, []);
 
   useEffect(() => {
@@ -76,20 +106,32 @@ const DSARoadmap: React.FC = () => {
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
     }
+    if (unpauseRef.current) {
+      unpauseRef.current();
+      unpauseRef.current = null;
+    }
     const newController = new AbortController();
     abortControllerRef.current = newController;
     setIsSorting(true);
+    setIsPaused(false);
+    isPausedRef.current = false;
 
     const barsCopy = bars.map(b => ({ ...b, color: DEFAULT_COLOR }));
     setBars(barsCopy);
 
     sortFn(barsCopy, newController.signal)
-      .then(() => setIsSorting(false))
+      .then(() => {
+        setIsSorting(false);
+        setIsPaused(false);
+        isPausedRef.current = false;
+      })
       .catch((err) => {
         if (err.message !== "aborted") {
           console.error(err);
         }
         setIsSorting(false);
+        setIsPaused(false);
+        isPausedRef.current = false;
       });
   };
 
@@ -289,7 +331,148 @@ const DSARoadmap: React.FC = () => {
     setBars([...arr]);
   };
 
-  // --- SELECTION SORT ---
+  // --- SHELL SORT ---
+  const shellSort = async (arr: BarData[], signal: AbortSignal) => {
+    const delay = getDelay();
+    let n = arr.length;
+    for (let gap = Math.floor(n / 2); gap > 0; gap = Math.floor(gap / 2)) {
+      for (let i = gap; i < n; i += 1) {
+        let temp = arr[i].value;
+        let j;
+        arr[i].color = COMPARE_COLOR;
+        setBars([...arr]);
+        await waitforme(delay, signal);
+
+        for (j = i; j >= gap && arr[j - gap].value > temp; j -= gap) {
+          arr[j].color = COMPARE_COLOR;
+          arr[j - gap].color = COMPARE_COLOR;
+          setBars([...arr]);
+          await waitforme(delay, signal);
+
+          arr[j].value = arr[j - gap].value;
+          arr[j].color = DEFAULT_COLOR;
+          arr[j - gap].color = DEFAULT_COLOR;
+        }
+        arr[j].value = temp;
+        arr[i].color = DEFAULT_COLOR;
+        setBars([...arr]);
+      }
+    }
+    for (let i = 0; i < arr.length; i++) {
+      arr[i].color = SORTED_COLOR;
+    }
+    setBars([...arr]);
+  };
+
+  // --- HEAP SORT ---
+  const heapify = async (arr: BarData[], n: number, i: number, signal: AbortSignal) => {
+    const delay = getDelay();
+    let largest = i;
+    const left = 2 * i + 1;
+    const right = 2 * i + 2;
+
+    if (left < n && arr[left].value > arr[largest].value) {
+      largest = left;
+    }
+    if (right < n && arr[right].value > arr[largest].value) {
+      largest = right;
+    }
+
+    if (largest !== i) {
+      arr[i].color = COMPARE_COLOR;
+      arr[largest].color = COMPARE_COLOR;
+      setBars([...arr]);
+      await waitforme(delay, signal);
+
+      const temp = arr[i].value;
+      arr[i].value = arr[largest].value;
+      arr[largest].value = temp;
+      setBars([...arr]);
+
+      arr[i].color = DEFAULT_COLOR;
+      arr[largest].color = DEFAULT_COLOR;
+
+      await heapify(arr, n, largest, signal);
+    }
+  };
+
+  const heapSort = async (arr: BarData[], signal: AbortSignal) => {
+    const delay = getDelay();
+    const n = arr.length;
+
+    for (let i = Math.floor(n / 2) - 1; i >= 0; i--) {
+      await heapify(arr, n, i, signal);
+    }
+
+    for (let i = n - 1; i > 0; i--) {
+      arr[0].color = COMPARE_COLOR;
+      arr[i].color = COMPARE_COLOR;
+      setBars([...arr]);
+      await waitforme(delay, signal);
+
+      const temp = arr[0].value;
+      arr[0].value = arr[i].value;
+      arr[i].value = temp;
+
+      arr[0].color = DEFAULT_COLOR;
+      arr[i].color = SORTED_COLOR;
+      setBars([...arr]);
+
+      await heapify(arr, i, 0, signal);
+    }
+    if (arr.length > 0) arr[0].color = SORTED_COLOR;
+    setBars([...arr]);
+  };
+
+  // --- RADIX SORT ---
+  const countSort = async (arr: BarData[], n: number, exp: number, signal: AbortSignal) => {
+    const delay = getDelay();
+    let output = new Array(n);
+    let count = new Array(10).fill(0);
+
+    for (let i = 0; i < n; i++) {
+      count[Math.floor(arr[i].value / exp) % 10]++;
+      arr[i].color = COMPARE_COLOR;
+      setBars([...arr]);
+      await waitforme(delay, signal);
+      arr[i].color = DEFAULT_COLOR;
+    }
+
+    for (let i = 1; i < 10; i++) {
+      count[i] += count[i - 1];
+    }
+
+    for (let i = n - 1; i >= 0; i--) {
+      output[count[Math.floor(arr[i].value / exp) % 10] - 1] = arr[i].value;
+      count[Math.floor(arr[i].value / exp) % 10]--;
+    }
+
+    for (let i = 0; i < n; i++) {
+      arr[i].value = output[i];
+      arr[i].color = SWAP_COLOR;
+      setBars([...arr]);
+      await waitforme(delay, signal);
+      arr[i].color = DEFAULT_COLOR;
+    }
+  };
+
+  const radixSort = async (arr: BarData[], signal: AbortSignal) => {
+    let max = arr[0].value;
+    for (let i = 1; i < arr.length; i++) {
+      if (arr[i].value > max) {
+        max = arr[i].value;
+      }
+    }
+
+    for (let exp = 1; Math.floor(max / exp) > 0; exp *= 10) {
+      await countSort(arr, arr.length, exp, signal);
+    }
+
+    for (let i = 0; i < arr.length; i++) {
+      arr[i].color = SORTED_COLOR;
+    }
+    setBars([...arr]);
+  };
   const selectionSort = async (arr: BarData[], signal: AbortSignal) => {
     const delay = getDelay();
     for (let i = 0; i < arr.length; i++) {
@@ -342,6 +525,16 @@ const DSARoadmap: React.FC = () => {
                 >
                   New Array
                 </button>
+                {isSorting && (
+                  <button
+                    type="button"
+                    className="btn btn-outline-warning btn-dark ml-2"
+                    onClick={togglePause}
+                    aria-label={isPaused ? "Resume Sorting" : "Pause Sorting"}
+                  >
+                    {isPaused ? "Resume" : "Pause"}
+                  </button>
+                )}
               </div>
               <div className="col">
                 <label htmlFor="arr_sz">
@@ -373,10 +566,10 @@ const DSARoadmap: React.FC = () => {
                   />
                 </label>
               </div>
-              <div className="col gap-2 d-sm-flex justify-content-end">
+              <div className="col gap-2 d-sm-flex justify-content-end flex-wrap">
                 <button 
                   type="button" 
-                  className="btn btn-outline-primary btn-dark"
+                  className="btn btn-outline-primary btn-dark m-1"
                   onClick={() => startSort(bubbleSort)}
                   disabled={isSorting}
                   aria-label="Start Bubble Sort"
@@ -385,7 +578,7 @@ const DSARoadmap: React.FC = () => {
                 </button>
                 <button 
                   type="button" 
-                  className="btn btn-outline-primary btn-dark"
+                  className="btn btn-outline-primary btn-dark m-1"
                   onClick={() => startSort(selectionSort)}
                   disabled={isSorting}
                   aria-label="Start Selection Sort"
@@ -394,7 +587,7 @@ const DSARoadmap: React.FC = () => {
                 </button>
                 <button 
                   type="button" 
-                  className="btn btn-outline-primary btn-dark"
+                  className="btn btn-outline-primary btn-dark m-1"
                   onClick={() => startSort(insertionSort)}
                   disabled={isSorting}
                   aria-label="Start Insertion Sort"
@@ -403,7 +596,7 @@ const DSARoadmap: React.FC = () => {
                 </button>
                 <button 
                   type="button" 
-                  className="btn btn-outline-primary btn-dark"
+                  className="btn btn-outline-primary btn-dark m-1"
                   onClick={() => startSort(quickSort)}
                   disabled={isSorting}
                   aria-label="Start Quick Sort"
@@ -412,12 +605,39 @@ const DSARoadmap: React.FC = () => {
                 </button>
                 <button 
                   type="button" 
-                  className="btn btn-outline-primary btn-dark"
+                  className="btn btn-outline-primary btn-dark m-1"
                   onClick={() => startSort(mergeSort)}
                   disabled={isSorting}
                   aria-label="Start Merge Sort"
                 >
                   Merge Sort
+                </button>
+                <button 
+                  type="button" 
+                  className="btn btn-outline-primary btn-dark m-1"
+                  onClick={() => startSort(heapSort)}
+                  disabled={isSorting}
+                  aria-label="Start Heap Sort"
+                >
+                  Heap Sort
+                </button>
+                <button 
+                  type="button" 
+                  className="btn btn-outline-primary btn-dark m-1"
+                  onClick={() => startSort(radixSort)}
+                  disabled={isSorting}
+                  aria-label="Start Radix Sort"
+                >
+                  Radix Sort
+                </button>
+                <button 
+                  type="button" 
+                  className="btn btn-outline-primary btn-dark m-1"
+                  onClick={() => startSort(shellSort)}
+                  disabled={isSorting}
+                  aria-label="Start Shell Sort"
+                >
+                  Shell Sort
                 </button>
               </div>
             </div>
@@ -437,4 +657,4 @@ const DSARoadmap: React.FC = () => {
   );
 };
 
-export default DSARoadmap;
+export default SortingVisualizer;


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR enhances the Sorting Visualizer with new functionality, improved usability, and better code clarity.

#### Changes Included

**Component Refactoring**

* Renamed the main component from `DSARoadmap` to `SortingVisualizer` to better reflect its purpose and improve maintainability.

**Pause & Resume Functionality**

* Added support for pausing and resuming active sorting visualizations.
* Introduced `isPaused`, `isPausedRef`, and `unpauseRef` to manage pause state without disrupting React's rendering cycle.
* Updated the visualization timing logic to suspend execution while paused and resume seamlessly from the same position.
* Added a dynamic Pause/Resume button that appears while a sorting algorithm is running.

**New Sorting Algorithms**

* Added visualizations for:

  * Heap Sort
  * Radix Sort
  * Shell Sort
* Integrated each algorithm with the existing animation system and color-coding scheme for consistency.

**UI Improvements**

* Added toolbar buttons for the newly supported algorithms.
* Updated the sorting controls layout using `flex-wrap` and spacing utilities to prevent overflow and improve responsiveness on smaller screens.

These changes provide users with greater control over sorting visualizations, expand algorithm coverage, and improve the overall user experience.

Fixes #2683 

### Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

### Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [x] Any dependent changes have been merged and published in downstream modules
