### PR TITLE
uiux: enhance language cards with custom descriptions and CTA

### DIFF
--- a/docs/languages/C/_category_.json
+++ b/docs/languages/C/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "C",
+  "position": 9,
+  "customProps": {
+    "description": "The language that started it all! It is super fast, incredibly powerful, and helps you learn exactly how computers work under the hood."
+  },
+  "link": {
+    "type": "generated-index",
+    "description": "Explore the C programming language, a foundational and highly efficient procedural language."
+  }
+}

--- a/docs/languages/Rust/_category_.json
+++ b/docs/languages/Rust/_category_.json
@@ -1,7 +1,11 @@
 {
-    "label": "Rust",
-    "position": 6,
-    "link": {
-      "type": "generated-index",
-      "description": "Welcome to the world of Rust! In this guide, we'll explore the fundamentals of Rust, a modern systems programming language focused on speed, memory safety, and concurrency. Let's get started!"}
+  "label": "Rust",
+  "position": 6,
+  "customProps": {
+    "description": "The modern superhero of safety and speed! Loved by developers for building insanely fast system software without the frustrating bugs."
+  },
+  "link": {
+    "type": "generated-index",
+    "description": "Welcome to the world of Rust! a systems programming language focused on speed, memory safety, and parallelism."
   }
+}  

--- a/docs/languages/SQL/_category_.json
+++ b/docs/languages/SQL/_category_.json
@@ -1,0 +1,11 @@
+{
+  "label": "SQL",
+  "position": 10,
+  "customProps": {
+    "description": "The master of data! The absolute best tool to communicate with, organize, and analyze massive databases that power modern applications."
+  },
+  "link": {
+    "type": "generated-index",
+    "description": "Structured Query Language, the standard language for managing and manipulating relational databases."
+  }
+}

--- a/docs/languages/TypeScript/_category_.json
+++ b/docs/languages/TypeScript/_category_.json
@@ -1,11 +1,21 @@
 {
   "label": "TypeScript",
-  "position": 12,
+  "position": 8,
+  "customProps": {
+    "description": "JavaScript with superpowers! It adds a powerful layer of safety to your web code, catching errors before you even run your application."
+  },
   "link": {
     "type": "generated-index",
     "title": "TypeScript Programming Language",
     "slug": "/category/typescript",
     "description": "Explore the TypeScript programming language, a strongly typed superset of JavaScript. Master its modern syntax, static type checking, compilation configurations, interfaces, advanced type mechanics, and object-oriented design patterns.",
-    "keywords": ["TypeScript", "Static Typing", "TS Config", "Interfaces", "Generics", "Object-Oriented JavaScript"]
+    "keywords": [
+      "TypeScript", 
+      "Static Typing", 
+      "TS Config", 
+      "Interfaces", 
+      "Generics", 
+      "Object-Oriented JavaScript"
+    ]
   }
 }

--- a/docs/languages/cpp/_category_.json
+++ b/docs/languages/cpp/_category_.json
@@ -1,11 +1,24 @@
-{    
-    "label": "C++",
-    "position": 3,
-    "link": {
-      "type": "generated-index",
-      "title": "C++ Programming Language",
-      "slug": "/category/cpp",
-      "description": "Explore the C++ programming language, including its syntax, features, and best practices for writing efficient and maintainable code. Learn about C++'s support for object-oriented programming, templates, and the Standard Template Library (STL). Whether you're a beginner or an experienced programmer, this section will help you master C++ and leverage its powerful capabilities for your projects.",
-      "keywords": ["C++ programming", "C++ syntax", "C++ features", "C++ best practices", "object-oriented programming in C++", "C++ templates", "C++ STL", "Standard Template Library", "C++ programming language"]
-    }
+{
+  "label": "C++",
+  "position": 2,
+  "customProps": {
+    "description": "The heavy lifter of the software world! Used to build massive 3D games, operating systems, and lightning-fast applications where performance is everything."
+  },
+  "link": {
+    "type": "generated-index",
+    "title": "C++ Programming Language",
+    "slug": "/category/cpp",
+    "description": "Explore the C++ programming language, including its syntax, features, and best practices for writing efficient and maintainable code. Learn about C++'s support for object-oriented programming, templates, and the Standard Template Library (STL). Whether you're a beginner or an experienced programmer, this section will help you master C++ and leverage its powerful capabilities for your projects.",
+    "keywords": [
+      "C++ programming", 
+      "C++ syntax", 
+      "C++ features", 
+      "C++ best practices", 
+      "object-oriented programming in C++", 
+      "C++ templates", 
+      "C++ STL", 
+      "Standard Template Library", 
+      "C++ programming language"
+    ]
   }
+}

--- a/docs/languages/csharp/_category_.json
+++ b/docs/languages/csharp/_category_.json
@@ -1,8 +1,10 @@
 {
   "label": "C#",
   "position": 4,
+  "customProps": {
+    "description": "The engine behind modern game development! Backed by Microsoft, it is the primary language used to build incredible games in the Unity engine."
+  },
   "link": {
-      "type": "generated-index",
-      "description": "C# is a modern, high-level programming language developed by Microsoft as part of the .NET framework. First released in 2002, C# is known for its strong typing, garbage collection, and support for object-oriented programming, making it popular for a variety of applications including web, desktop, and mobile development. With cross-platform support through .NET Core, C# allows developers to create versatile and performant software solutions across different environments."
-  }
+    "type": "generated-index",
+    "description": "Learn C#, a versatile language developed by Microsoft for building web, mobile, and desktop applications."}
 }

--- a/docs/languages/go/_category_.json
+++ b/docs/languages/go/_category_.json
@@ -1,8 +1,11 @@
 {
   "label": "Go",
   "position": 6,
+  "customProps": {
+    "description": "An open-source programming language supported by Google, known for simplicity, concurrency, and performance."
+  },
   "link": {
     "type": "generated-index",
-    "description": "Go (or Golang) is an open-source, compiled, statically typed programming language designed by Google. It is known for its simplicity, concurrency support, and performance, making it excellent for cloud-native development and scalable backend systems."
+    "description": "Built by Google for the modern cloud! It is simple, incredibly fast, and perfect for building scalable servers and backend networks."
   }
 }

--- a/docs/languages/java/_category_.json
+++ b/docs/languages/java/_category_.json
@@ -1,8 +1,11 @@
 {
-    "label": "Java",
-    "position": 5,
-    "link": {
-      "type": "generated-index",
-      "description": "Java is a high-level, class-based, object-oriented programming language that is designed to have as few implementation dependencies as possible."
-    }
+  "label": "Java",
+  "position": 5,
+  "customProps": {
+    "description": "Write once, run anywhere! A rock-solid, enterprise-level language used to power huge corporate systems, web servers, and native Android mobile apps."
+  },
+  "link": {
+    "type": "generated-index",
+    "description": "Discover Java, a robust, object-oriented language widely used for enterprise, web, and mobile development."
   }
+} 

--- a/docs/languages/javascript/_category_.json
+++ b/docs/languages/javascript/_category_.json
@@ -1,8 +1,11 @@
 {
-    "label": "JavaScript",
-    "position": 1,
-    "link": {
-      "type": "generated-index",
-      "description": "JavaScript is a programming language that conforms to the ECMAScript specification. JavaScript is high-level, often just-in-time compiled, and multi-paradigm."
-    }
+  "label": "JavaScript",
+  "position": 1,
+  "customProps": {
+    "description": "The magic behind the modern web! JavaScript turns boring, static pages into interactive experiences you can click, swipe, and play with."
+  },
+  "link": {
+    "type": "generated-index",
+    "description": "JavaScript is a programming language that conforms to the ECMAScript specification. JavaScript is high-level, often just-in-time compiled, and multi-paradigm."
   }
+}

--- a/docs/languages/python/_category_.json
+++ b/docs/languages/python/_category_.json
@@ -1,8 +1,11 @@
 {
-    "label": "Python",
-    "position": 3,
-    "link": {
-      "type": "generated-index",
-      "description": "Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace."
-    }
+  "label": "Python",
+  "position": 3,
+  "customProps": {
+    "description": "The ultimate beginner-friendly language! Used by data scientists, AI engineers, and web developers for its clean, readable, and powerful syntax."
+  },
+  "link": {
+    "type": "generated-index",
+    "description": "Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace. Explore the Python programming language, including its syntax, features, and libraries."
   }
+}

--- a/src/theme/DocCard/Description/index.tsx
+++ b/src/theme/DocCard/Description/index.tsx
@@ -1,0 +1,20 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import type {Props} from '@theme/DocCard/Description';
+
+import styles from './styles.module.css';
+
+export default function DocCardDescription({description}: Props): ReactNode {
+  return (
+    <p
+      className={clsx(
+        'text--truncate',
+        ThemeClassNames.docs.docCard.description,
+        styles.cardDescription,
+      )}
+      title={description}>
+      {description}
+    </p>
+  );
+}

--- a/src/theme/DocCard/Description/index.tsx
+++ b/src/theme/DocCard/Description/index.tsx
@@ -9,7 +9,6 @@ export default function DocCardDescription({description}: Props): ReactNode {
   return (
     <p
       className={clsx(
-        'text--truncate',
         ThemeClassNames.docs.docCard.description,
         styles.cardDescription,
       )}

--- a/src/theme/DocCard/Description/index.tsx
+++ b/src/theme/DocCard/Description/index.tsx
@@ -1,18 +1,20 @@
-import React, {type ReactNode} from 'react';
+import React, { type ReactNode } from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import type {Props} from '@theme/DocCard/Description';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import type { Props } from '@theme/DocCard/Description';
 
 import styles from './styles.module.css';
 
-export default function DocCardDescription({description}: Props): ReactNode {
+export default function DocCardDescription({ description }: Props): ReactNode {
+  if (!description) return null; // Defensive check to avoid empty rendering overhead
+
   return (
     <p
       className={clsx(
         ThemeClassNames.docs.docCard.description,
-        styles.cardDescription,
+        styles.cardDescription
       )}
-      title={description}>
+    >
       {description}
     </p>
   );

--- a/src/theme/DocCard/Description/styles.module.css
+++ b/src/theme/DocCard/Description/styles.module.css
@@ -1,0 +1,3 @@
+.cardDescription {
+  font-size: 0.8rem;
+}

--- a/src/theme/DocCard/Description/styles.module.css
+++ b/src/theme/DocCard/Description/styles.module.css
@@ -1,7 +1,16 @@
 .cardDescription {
-  font-size: 0.8rem;
+  margin: 0;
+  padding-top: 4px;
+  font-size: 0.875rem; 
+  line-height: 1.5;
+  letter-spacing: 0.01em;
+  color: var(--ifm-color-emphasis-600);
+
   display: -webkit-box;
-  -webkit-line-clamp: 3;
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
+  text-overflow: ellipsis;
+
+  transition: color 0.2s ease;
 }

--- a/src/theme/DocCard/Description/styles.module.css
+++ b/src/theme/DocCard/Description/styles.module.css
@@ -1,3 +1,7 @@
 .cardDescription {
   font-size: 0.8rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/src/theme/DocCard/Heading/Icon/index.tsx
+++ b/src/theme/DocCard/Heading/Icon/index.tsx
@@ -1,0 +1,15 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import type {Props} from '@theme/DocCard/Heading/Icon';
+
+import styles from './styles.module.css';
+
+export default function DocCardHeadingIcon({icon}: Props): ReactNode {
+  return (
+    <span
+      className={clsx(ThemeClassNames.docs.docCard.icon, styles.cardTitleIcon)}>
+      {icon}
+    </span>
+  );
+}

--- a/src/theme/DocCard/Heading/Icon/index.tsx
+++ b/src/theme/DocCard/Heading/Icon/index.tsx
@@ -1,15 +1,21 @@
-import React, {type ReactNode} from 'react';
+import React, { type ReactNode } from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import type {Props} from '@theme/DocCard/Heading/Icon';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import type { Props } from '@theme/DocCard/Heading/Icon';
 
 import styles from './styles.module.css';
 
-export default function DocCardHeadingIcon({icon}: Props): ReactNode {
+export default function DocCardHeadingIcon({ icon }: Props): ReactNode {
   return (
     <span
-      className={clsx(ThemeClassNames.docs.docCard.icon, styles.cardTitleIcon)}>
-      {icon}
+      className={clsx(
+        ThemeClassNames.docs.docCard.icon, 
+        styles.cardTitleIconWrapper
+      )}
+    >
+      <span className={styles.cardTitleIconInner}>
+        {icon}
+      </span>
     </span>
   );
 }

--- a/src/theme/DocCard/Heading/Icon/styles.module.css
+++ b/src/theme/DocCard/Heading/Icon/styles.module.css
@@ -1,0 +1,4 @@
+.cardTitleIcon {
+  font-size: 1.6rem;
+  margin-right: 0.6rem;
+}

--- a/src/theme/DocCard/Heading/Icon/styles.module.css
+++ b/src/theme/DocCard/Heading/Icon/styles.module.css
@@ -1,4 +1,45 @@
-.cardTitleIcon {
-  font-size: 1.6rem;
-  margin-right: 0.6rem;
+.cardTitleIconWrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px; /* Smooth squircle corners */
+  margin-right: 12px; /* Clean spacing before the text */
+  flex-shrink: 0;
+  /* background-color: rgba(0, 0, 0, 0.05); */
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), 
+              background-color 0.2s ease, 
+              border-color 0.2s ease;
+}
+
+:global([data-theme='dark']) .cardTitleIconWrapper {
+  /* background-color: rgba(255, 255, 255, 0.06); */
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.cardTitleIconInner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.cardTitleIconInner svg {
+  width: 18px;
+  height: 18px;
+  color: var(--ifm-color-primary);
+}
+
+:global(.card):hover .cardTitleIconWrapper {
+  transform: translateY(-2px) scale(1.05);
+  /* background-color: var(--ifm-color-primary-lightest); */
+  border-color: var(--ifm-color-primary);
+}
+
+:global([data-theme='dark']) :global(.card):hover .cardTitleIconWrapper {
+  /* background-color: rgba(var(--ifm-color-primary-rgb), 0.15); */
+  border-color: var(--ifm-color-primary);
 }

--- a/src/theme/DocCard/Heading/Text/index.tsx
+++ b/src/theme/DocCard/Heading/Text/index.tsx
@@ -1,0 +1,20 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import type {Props} from '@theme/DocCard/Heading/Text';
+
+import styles from './styles.module.css';
+
+export default function DocCardHeadingText({title}: Props): ReactNode {
+  return (
+    <span
+      className={clsx(
+        'text--truncate',
+
+        ThemeClassNames.docs.docCard.title,
+        styles.cardTitleText,
+      )}>
+      {title}
+    </span>
+  );
+}

--- a/src/theme/DocCard/Heading/Text/index.tsx
+++ b/src/theme/DocCard/Heading/Text/index.tsx
@@ -1,20 +1,21 @@
-import React, {type ReactNode} from 'react';
+import React, { type ReactNode } from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import type {Props} from '@theme/DocCard/Heading/Text';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import type { Props } from '@theme/DocCard/Heading/Text';
 
 import styles from './styles.module.css';
 
-export default function DocCardHeadingText({title}: Props): ReactNode {
+export default function DocCardHeadingText({ title }: Props): ReactNode {
   return (
-    <span
+    <h3
       className={clsx(
-        'text--truncate',
-
+        'text--truncate', // Kept for safety, but optimized in CSS
         ThemeClassNames.docs.docCard.title,
-        styles.cardTitleText,
-      )}>
+        styles.cardTitleText
+      )}
+      title={title} /* Native tooltip UX if text ever accidentally overflows */
+    >
       {title}
-    </span>
+    </h3>
   );
 }

--- a/src/theme/DocCard/Heading/Text/styles.module.css
+++ b/src/theme/DocCard/Heading/Text/styles.module.css
@@ -1,0 +1,3 @@
+.cardTitleText {
+  font-size: 1.2rem;
+}

--- a/src/theme/DocCard/Heading/Text/styles.module.css
+++ b/src/theme/DocCard/Heading/Text/styles.module.css
@@ -1,3 +1,9 @@
 .cardTitleText {
-  font-size: 1.2rem;
+  margin: 0;
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: -0.01em;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }

--- a/src/theme/DocCard/Heading/index.tsx
+++ b/src/theme/DocCard/Heading/index.tsx
@@ -1,0 +1,21 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import Heading from '@theme/Heading';
+import Icon from '@theme/DocCard/Heading/Icon';
+import Text from '@theme/DocCard/Heading/Text';
+import type {Props} from '@theme/DocCard/Heading';
+
+import styles from './styles.module.css';
+
+export default function DocCardHeading({item, title, icon}: Props): ReactNode {
+  return (
+    <Heading
+      as="h2"
+      className={clsx(ThemeClassNames.docs.docCard.heading, styles.cardTitle)}
+      title={title}>
+      {icon && <Icon item={item} icon={icon} />}
+      <Text item={item} title={title} />
+    </Heading>
+  );
+}

--- a/src/theme/DocCard/Heading/index.tsx
+++ b/src/theme/DocCard/Heading/index.tsx
@@ -1,21 +1,28 @@
-import React, {type ReactNode} from 'react';
+import React, { type ReactNode } from 'react';
 import clsx from 'clsx';
-import {ThemeClassNames} from '@docusaurus/theme-common';
-import Heading from '@theme/Heading';
+import { ThemeClassNames } from '@docusaurus/theme-common';
 import Icon from '@theme/DocCard/Heading/Icon';
 import Text from '@theme/DocCard/Heading/Text';
-import type {Props} from '@theme/DocCard/Heading';
+import type { Props } from '@theme/DocCard/Heading';
 
 import styles from './styles.module.css';
 
-export default function DocCardHeading({item, title, icon}: Props): ReactNode {
+export default function DocCardHeading({ item, title, icon }: Props): ReactNode {
   return (
-    <Heading
-      as="h2"
-      className={clsx(ThemeClassNames.docs.docCard.heading, styles.cardTitle)}
-      title={title}>
-      {icon && <Icon item={item} icon={icon} />}
-      <Text item={item} title={title} />
-    </Heading>
+    <div
+      className={clsx(
+        ThemeClassNames.docs.docCard.heading, 
+        styles.cardHeaderContainer
+      )}
+    >
+      {icon && (
+        <div className={styles.iconWrapper}>
+          <Icon item={item} icon={icon} />
+        </div>
+      )}
+      <div className={styles.textWrapper}>
+        <Text item={item} title={title} />
+      </div>
+    </div>
   );
 }

--- a/src/theme/DocCard/Heading/styles.module.css
+++ b/src/theme/DocCard/Heading/styles.module.css
@@ -1,0 +1,4 @@
+.cardTitle {
+  display: inline-flex;
+  align-items: center;
+}

--- a/src/theme/DocCard/Heading/styles.module.css
+++ b/src/theme/DocCard/Heading/styles.module.css
@@ -1,4 +1,22 @@
-.cardTitle {
-  display: inline-flex;
+.cardHeaderContainer {
+  display: flex;
+  align-items: center; /* Ensures icon and text are perfectly centered vertically */
+  gap: 4px; /* Tiny buffer space between containers */
+  width: 100%;
+  margin-bottom: 12px; /* Smooth spacing before card description/body */
+}
+
+/* Isolators to prevent layout shifting or accidental squishing */
+.iconWrapper {
+  display: flex;
   align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.textWrapper {
+  display: flex;
+  align-items: center;
+  min-width: 0; /* Critical for CSS text-truncation safety inside flexbox layouts */
+  flex-grow: 1;
 }

--- a/src/theme/DocCard/Layout/index.tsx
+++ b/src/theme/DocCard/Layout/index.tsx
@@ -1,0 +1,48 @@
+import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import {ThemeClassNames} from '@docusaurus/theme-common';
+import Heading from '@theme/DocCard/Heading';
+import Description from '@theme/DocCard/Description';
+import type {Props} from '@theme/DocCard/Layout';
+
+import styles from './styles.module.css';
+
+function Container({
+  className,
+  href,
+  children,
+}: {
+  className?: string;
+  href: string;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <Link
+      href={href}
+      className={clsx(
+        'card padding--lg',
+        ThemeClassNames.docs.docCard.container,
+        styles.cardContainer,
+        className,
+      )}>
+      {children}
+    </Link>
+  );
+}
+
+export default function DocCardLayout({
+  item,
+  className,
+  href,
+  icon,
+  title,
+  description,
+}: Props): ReactNode {
+  return (
+    <Container href={href} className={className}>
+      <Heading item={item} icon={icon} title={title} />
+      {description && <Description item={item} description={description} />}
+    </Container>
+  );
+}

--- a/src/theme/DocCard/Layout/styles.module.css
+++ b/src/theme/DocCard/Layout/styles.module.css
@@ -1,0 +1,19 @@
+.cardContainer {
+  --ifm-link-color: var(--ifm-color-emphasis-800);
+  --ifm-link-hover-color: var(--ifm-color-emphasis-700);
+  --ifm-link-hover-decoration: none;
+
+  box-shadow: 0 1.5px 3px 0 rgb(0 0 0 / 15%);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  transition: all var(--ifm-transition-fast) ease;
+  transition-property: border, box-shadow;
+}
+
+.cardContainer:hover {
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 3px 6px 0 rgb(0 0 0 / 20%);
+}
+
+.cardContainer *:last-child {
+  margin-bottom: 0;
+}

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -1,4 +1,7 @@
 import React, {type ReactNode} from 'react';
+import clsx from 'clsx';
+import Translate from '@docusaurus/Translate';
+import {ThemeClassNames} from '@docusaurus/theme-common';
 import {
   useDocById,
   findFirstSidebarItemLink,
@@ -9,7 +12,8 @@ import {
 } from '@docusaurus/theme-common/internal';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import Layout from '@theme/DocCard/Layout';
-import Link from '@docusaurus/Link'; // Added for smooth SPA routing
+import Link from '@docusaurus/Link';
+import cardStyles from './Layout/styles.module.css';
 
 import type {Props} from '@theme/DocCard';
 import type {
@@ -47,14 +51,18 @@ function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
   }
 
   const { icon, title } = getIconTitleProps(item);
-  const itemCountText = categoryItemsPlural(item.items.length);
-  // Pulls your custom description from the _category_.json file
-  const customDescription = item.customProps?.description || item.description;
+  const itemCountText = categoryItemsPlural(item.items?.length ?? 0);
+  const customDescription = item.customProps?.description;
 
   return (
     <Link
       href={href}
-      className={`card padding--lg ${item.className || ''}`}
+      className={clsx(
+        'card padding--lg',
+        ThemeClassNames.docs.docCard.container,
+        cardStyles.cardContainer,
+        item.className,
+      )}
       style={{ display: 'flex', flexDirection: 'column', height: '100%', textDecoration: 'none' }}
     >
       {/* Header: Icon & Title */}
@@ -77,7 +85,11 @@ function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
 
       {/* Persistent CTA Button */}
       <div style={{ marginTop: 'auto', fontSize: '0.9rem', fontWeight: 'bold', color: 'var(--ifm-color-primary)' }}>
-        Learn More &rarr;
+        <Translate
+          id="theme.DocCard.categoryDescription.learnMore"
+          description="The label for the link to a category page from a card">
+          Learn More →
+        </Translate>
       </div>
     </Link>
   );

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -1,0 +1,108 @@
+import React, {type ReactNode} from 'react';
+import {
+  useDocById,
+  findFirstSidebarItemLink,
+} from '@docusaurus/plugin-content-docs/client';
+import {
+  extractLeadingEmoji,
+  useDocCardDescriptionCategoryItemsPlural,
+} from '@docusaurus/theme-common/internal';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import Layout from '@theme/DocCard/Layout';
+import Link from '@docusaurus/Link'; // Added for smooth SPA routing
+
+import type {Props} from '@theme/DocCard';
+import type {
+  PropSidebarItemCategory,
+  PropSidebarItemLink,
+} from '@docusaurus/plugin-content-docs';
+
+function getFallbackEmojiIcon(
+  item: PropSidebarItemLink | PropSidebarItemCategory,
+): string {
+  if (item.type === 'category') {
+    return '🗃';
+  }
+  return isInternalUrl(item.href) ? '📄️' : '🔗';
+}
+
+function getIconTitleProps(
+  item: PropSidebarItemLink | PropSidebarItemCategory,
+): {icon: ReactNode; title: string} {
+  const extracted = extractLeadingEmoji(item.label);
+  const emoji = extracted.emoji ?? getFallbackEmojiIcon(item);
+  return {
+    icon: emoji,
+    title: extracted.rest.trim(),
+  };
+}
+
+// ✨ OUR CUSTOM ENHANCED CATEGORY CARD ✨
+function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
+  const href = findFirstSidebarItemLink(item);
+  const categoryItemsPlural = useDocCardDescriptionCategoryItemsPlural();
+
+  if (!href) {
+    return null;
+  }
+
+  const { icon, title } = getIconTitleProps(item);
+  const itemCountText = categoryItemsPlural(item.items.length);
+  // Pulls your custom description from the _category_.json file
+  const customDescription = item.customProps?.description || item.description;
+
+  return (
+    <Link
+      href={href}
+      className={`card padding--lg ${item.className || ''}`}
+      style={{ display: 'flex', flexDirection: 'column', height: '100%', textDecoration: 'none' }}
+    >
+      {/* Header: Icon & Title */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '8px' }}>
+        <span style={{ fontSize: '1.5rem' }}>{icon}</span>
+        <h3 style={{ margin: 0, fontSize: '1.2rem', color: 'var(--ifm-heading-color)' }}>{title}</h3>
+      </div>
+
+      {/* Subtitle: Item Count */}
+      <span style={{ fontSize: '0.85rem', color: 'var(--ifm-color-emphasis-600)', marginBottom: '12px', fontWeight: '500' }}>
+        {itemCountText}
+      </span>
+
+      {/* Dynamic Description */}
+      {customDescription && (
+         <p style={{ fontSize: '0.95rem', color: 'var(--ifm-color-emphasis-700)', flexGrow: 1, marginBottom: '20px', lineHeight: '1.5' }}>
+           {customDescription}
+         </p>
+      )}
+
+      {/* Persistent CTA Button */}
+      <div style={{ marginTop: 'auto', fontSize: '0.9rem', fontWeight: 'bold', color: 'var(--ifm-color-primary)' }}>
+        Learn More &rarr;
+      </div>
+    </Link>
+  );
+}
+
+function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
+  const doc = useDocById(item.docId ?? undefined);
+  return (
+    <Layout
+      item={item}
+      className={item.className}
+      href={item.href}
+      description={item.description ?? doc?.description}
+      {...getIconTitleProps(item)}
+    />
+  );
+}
+
+export default function DocCard({item}: Props): ReactNode {
+  switch (item.type) {
+    case 'link':
+      return <CardLink item={item} />;
+    case 'category':
+      return <CardCategory item={item} />;
+    default:
+      throw new Error(`unknown item type ${JSON.stringify(item)}`);
+  }
+}

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -1,7 +1,7 @@
-import React, {type ReactNode} from 'react';
+import React, { type ReactNode } from 'react';
 import clsx from 'clsx';
 import Translate from '@docusaurus/Translate';
-import {ThemeClassNames} from '@docusaurus/theme-common';
+import { ThemeClassNames } from '@docusaurus/theme-common';
 import {
   useDocById,
   findFirstSidebarItemLink,
@@ -12,10 +12,10 @@ import {
 } from '@docusaurus/theme-common/internal';
 import isInternalUrl from '@docusaurus/isInternalUrl';
 import Layout from '@theme/DocCard/Layout';
-import Link from '@docusaurus/Link';
-import cardStyles from './Layout/styles.module.css';
 
-import type {Props} from '@theme/DocCard';
+import styles from './styles.module.css';
+
+import type { Props } from '@theme/DocCard';
 import type {
   PropSidebarItemCategory,
   PropSidebarItemLink,
@@ -25,14 +25,14 @@ function getFallbackEmojiIcon(
   item: PropSidebarItemLink | PropSidebarItemCategory,
 ): string {
   if (item.type === 'category') {
-    return '🗃';
+    return '🗃️';
   }
   return isInternalUrl(item.href) ? '📄️' : '🔗';
 }
 
 function getIconTitleProps(
   item: PropSidebarItemLink | PropSidebarItemCategory,
-): {icon: ReactNode; title: string} {
+): { icon: ReactNode; title: string } {
   const extracted = extractLeadingEmoji(item.label);
   const emoji = extracted.emoji ?? getFallbackEmojiIcon(item);
   return {
@@ -41,8 +41,7 @@ function getIconTitleProps(
   };
 }
 
-// ✨ OUR CUSTOM ENHANCED CATEGORY CARD ✨
-function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
+function CardCategory({ item }: { item: PropSidebarItemCategory }): ReactNode {
   const href = findFirstSidebarItemLink(item);
   const categoryItemsPlural = useDocCardDescriptionCategoryItemsPlural();
 
@@ -52,63 +51,53 @@ function CardCategory({item}: {item: PropSidebarItemCategory}): ReactNode {
 
   const { icon, title } = getIconTitleProps(item);
   const itemCountText = categoryItemsPlural(item.items?.length ?? 0);
-  const customDescription = item.customProps?.description;
+  
+  // Clean fallback if no custom description is explicitly provided
+  const description = item.customProps?.description ?? `${itemCountText} available`;
 
   return (
-    <Link
-      href={href}
-      className={clsx(
-        'card padding--lg',
-        ThemeClassNames.docs.docCard.container,
-        cardStyles.cardContainer,
-        item.className,
-      )}
-      style={{ display: 'flex', flexDirection: 'column', height: '100%', textDecoration: 'none' }}
-    >
-      {/* Header: Icon & Title */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '8px' }}>
-        <span style={{ fontSize: '1.5rem' }}>{icon}</span>
-        <h3 style={{ margin: 0, fontSize: '1.2rem', color: 'var(--ifm-heading-color)' }}>{title}</h3>
-      </div>
-
-      {/* Subtitle: Item Count */}
-      <span style={{ fontSize: '0.85rem', color: 'var(--ifm-color-emphasis-600)', marginBottom: '12px', fontWeight: '500' }}>
-        {itemCountText}
-      </span>
-
-      {/* Dynamic Description */}
-      {customDescription && (
-         <p style={{ fontSize: '0.95rem', color: 'var(--ifm-color-emphasis-700)', flexGrow: 1, marginBottom: '20px', lineHeight: '1.5' }}>
-           {customDescription}
-         </p>
-      )}
-
-      {/* Persistent CTA Button */}
-      <div style={{ marginTop: 'auto', fontSize: '0.9rem', fontWeight: 'bold', color: 'var(--ifm-color-primary)' }}>
-        <Translate
-          id="theme.DocCard.categoryDescription.learnMore"
-          description="The label for the link to a category page from a card">
-          Learn More →
-        </Translate>
-      </div>
-    </Link>
+    <div className={clsx(styles.responsiveCardWrapper, item.className)}>
+      <Layout
+        item={item}
+        href={href}
+        icon={icon}
+        title={title}
+        description={description}
+      >
+        {/* Modern Interactive Footer Injection */}
+        <div className={styles.categoryFooter}>
+          <span className={styles.categoryBadge}>{itemCountText}</span>
+          <span className={styles.learnMoreAction}>
+            <Translate
+              id="theme.DocCard.categoryDescription.learnMore"
+              description="The label for the link to a category page from a card">
+              Explore
+            </Translate>
+            <svg className={styles.arrowIcon} viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M14 5l7 7m0 0l-7 7m7-7H3" />
+            </svg>
+          </span>
+        </div>
+      </Layout>
+    </div>
   );
 }
 
-function CardLink({item}: {item: PropSidebarItemLink}): ReactNode {
+function CardLink({ item }: { item: PropSidebarItemLink }): ReactNode {
   const doc = useDocById(item.docId ?? undefined);
   return (
-    <Layout
-      item={item}
-      className={item.className}
-      href={item.href}
-      description={item.description ?? doc?.description}
-      {...getIconTitleProps(item)}
-    />
+    <div className={styles.responsiveCardWrapper, item.className}>
+      <Layout
+        item={item}
+        href={item.href}
+        description={item.description ?? doc?.description}
+        {...getIconTitleProps(item)}
+      />
+    </div>
   );
 }
 
-export default function DocCard({item}: Props): ReactNode {
+export default function DocCard({ item }: Props): ReactNode {
   switch (item.type) {
     case 'link':
       return <CardLink item={item} />;

--- a/src/theme/DocCard/styles.module.css
+++ b/src/theme/DocCard/styles.module.css
@@ -1,0 +1,58 @@
+/* Responsive Grid Wrapper System */
+.responsiveCardWrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Category Extended Footer Layout Rules */
+.categoryFooter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: auto; /* Pushes footer neatly to bottom of card bounds */
+  padding-top: 16px;
+  border-top: 1px dashed rgba(0, 0, 0, 0.06);
+}
+
+:global([data-theme='dark']) .categoryFooter {
+  border-top: 1px dashed rgba(255, 255, 255, 0.06);
+}
+
+/* Modern Pill Badge for Document Item Counts */
+.categoryBadge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: 9999px; /* Absolute Capsule */
+  background-color: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-emphasis-700);
+  letter-spacing: 0.02em;
+}
+
+:global([data-theme='dark']) .categoryBadge {
+  background-color: rgba(255, 255, 255, 0.06);
+  color: var(--ifm-color-emphasis-400);
+}
+
+/* Call to Action Text Layout rules */
+.learnMoreAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--ifm-color-primary);
+}
+
+/* Vector Arrow Micro-Animation on hover */
+.arrowIcon {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* When the master card container is hovered anywhere, trigger the arrow animation */
+:global(.card):hover .arrowIcon {
+  transform: translateX(4px);
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description
Enhances the Docusaurus category cards to display both the item count and a custom description, along with a native "Know More →" call-to-action button. 

To achieve this, I swizzled the `@docusaurus/theme-classic DocCard` component to accept `customProps.description` and updated all language `_category_.json` files with beginner-friendly summaries. The UI seamlessly utilizes existing Docusaurus CSS variables to ensure perfect dark/light mode compatibility.

Fixes #2674 

### Type of Change
* **New feature:** Added custom UI functionality to the category cards.
* **Documentation update:** Added detailed descriptions to all language category JSON files.

### Completed Checklist
* Code follows the style guidelines of the project.
* Performed a self-review of the code.
* Added comments in the code to explain the custom DocCard logic.