### PR TITLE
Fix issue #2703: Expand navigation keyboard shortcuts

### DIFF
--- a/src/components/KeyboardShortcutsModal.jsx
+++ b/src/components/KeyboardShortcutsModal.jsx
@@ -141,6 +141,26 @@ export default function KeyboardShortcutsModal({
             action="Go to Docs"
             shortcut="g + d"
           />
+
+          <ShortcutRow
+            action="Go to Playground"
+            shortcut="g + p"
+          />
+
+          <ShortcutRow
+            action="Go to Leaderboard"
+            shortcut="g + l"
+          />
+
+          <ShortcutRow
+            action="Go to Blog"
+            shortcut="g + b"
+          />
+
+          <ShortcutRow
+            action="Go to Quizzes"
+            shortcut="g + q"
+          />
         </div>
       </div>
     </div>

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -5,6 +5,10 @@ import { useHistory } from "@docusaurus/router";
 const SEQUENTIAL_SHORTCUTS = {
   gh: "/",
   gd: "/docs",
+  gp: "/playground",
+  gl: "/leaderboard",
+  gb: "/blog",
+  gq: "/quizzes",
 };
 
 const SEARCH_SELECTORS = [


### PR DESCRIPTION
This PR resolves #2703 by adding new keyboard shortcuts for the Code Playground, Leaderboard, Blog, and Quizzes, and listing them in the Help modal. Closes #2703.