### PR TITLE
Fix issue #2705: Fix duplicate React keys in ArrayVisualizations

### DIFF
--- a/src/components/DSA/arrays/ArrayVisualizations/index.tsx
+++ b/src/components/DSA/arrays/ArrayVisualizations/index.tsx
@@ -94,9 +94,7 @@ const ArrayVisualizations: React.FC = () => {
         {array.map((value, index) => (
           <div
             key={index}
-            className={`w-8 mx-1 bg-blue-500 transition-all duration-300
-              ${index === minIndex ? "bg-red-500" : ""}
-              ${index === currentIndex ? "bg-yellow-300" : ""}`}
+            className={"w-8 mx-1 transition-all duration-300 " + (index === minIndex ? "bg-red-500" : index === currentIndex ? "bg-yellow-300" : "bg-blue-500")}
             style={{ height: `${value * 3}px` }}
           />
         ))}

--- a/src/components/DSA/arrays/ArrayVisualizations/index.tsx
+++ b/src/components/DSA/arrays/ArrayVisualizations/index.tsx
@@ -93,7 +93,7 @@ const ArrayVisualizations: React.FC = () => {
       <div className="flex justify-center items-end h-72">
         {array.map((value, index) => (
           <div
-            key={value}
+            key={index}
             className={`w-8 mx-1 bg-blue-500 transition-all duration-300
               ${index === minIndex ? "bg-red-500" : ""}
               ${index === currentIndex ? "bg-yellow-300" : ""}`}


### PR DESCRIPTION
This PR resolves #2705 by using array indices instead of element values as the React keys for visualizer bars to avoid warnings. Closes #2705.