### PR TITLE
Fix issue #2701: Integrate RedBlackTreeVisualizer component in Red-Black Trees documentation

### DIFF
--- a/docs/extra/binary-search-tree/red-black-trees.mdx
+++ b/docs/extra/binary-search-tree/red-black-trees.mdx
@@ -7,9 +7,17 @@ description: "In this blog post, we'll explore Red-Black trees, a type of self-b
 tags: [dsa, data structures, rbt]
 ---
 
+import { RedBlackTreeVisualizer } from '@site/src/components/Visualizing/RedBlackTreeVisualizer';
+
 A **Red-Black Tree (RBT)** is a self-balancing binary search tree (BST) that ensures the tree remains approximately balanced after insertions and deletions. The primary goal of a Red-Black Tree is to keep the height of the tree O(log n), ensuring efficient operations.
 
 Each node in a Red-Black Tree has an additional property: a color, which is either **red** or **black**. The tree follows specific rules regarding the colors, which ensures that it remains balanced.
+
+## Red-Black Tree Visualizer
+
+Below is an interactive Red-Black Tree visualizer. You can insert integer values to see how the tree automatically rebalances itself using left/right rotations and recoloring to satisfy the RBT properties.
+
+<RedBlackTreeVisualizer />
 
 ## Properties of Red-Black Trees
 
@@ -153,5 +161,3 @@ Node* deleteNode(Node* root, int key) {
 - **Linux Kernel:** Red-Black Trees are used in process scheduling and other kernel operations.
 - **Database Indexing:** Red-Black Trees are used in databases to maintain balance for indexing.
 - **Computational Geometry:** Used for dynamic sets of intervals and points in geometric algorithms.
-
----


### PR DESCRIPTION
This PR resolves #2701 by converting the Red-Black Trees documentation to MDX and embedding the interactive RedBlackTreeVisualizer component. Closes #2701.