### PR TITLE
feat: add skip-to-content link and focus trap for modals (a11y)

### DIFF
--- a/src/components/Homepage/LoginModal.tsx
+++ b/src/components/Homepage/LoginModal.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect } from "react";
 import { FiX, FiArrowRight, FiLogIn, FiUserPlus, FiCompass, FiTerminal } from "react-icons/fi";
 import { useHistory } from "@docusaurus/router";
 import { useAuth } from "../../contexts/AuthContext";
+import useFocusTrap from "../../hooks/useFocusTrap";
 
 interface CTAActionModalProps {
   isOpen: boolean;
@@ -11,7 +12,7 @@ interface CTAActionModalProps {
 const CTAActionModal: React.FC<CTAActionModalProps> = ({ isOpen, onClose }) => {
   const history = useHistory();
   const { user, isAuthenticated } = useAuth();
-  const modalRef = useRef<HTMLDivElement>(null);
+  const modalRef = useFocusTrap(isOpen);
 
   // Close modal safely on backdrop clicks
   useEffect(() => {
@@ -38,6 +39,9 @@ const CTAActionModal: React.FC<CTAActionModalProps> = ({ isOpen, onClose }) => {
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-slate-950/70 backdrop-blur-md px-4 transition-all duration-300">
       <div
         ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="login-modal-title"
         className="relative w-full max-w-lg overflow-hidden rounded-2xl bg-white dark:bg-gray-900 border border-slate-100 dark:border-slate-800/80 shadow-2xl transition-all duration-300"
       >
         {/* Tech-Layer Grid Styling Backgrounds */}
@@ -61,7 +65,7 @@ const CTAActionModal: React.FC<CTAActionModalProps> = ({ isOpen, onClose }) => {
             <span className="text-[10px] font-bold uppercase tracking-widest text-blue-600 dark:text-blue-400 bg-blue-500/10 px-2.5 py-1 rounded-md">
               Workspace Core Engine
             </span>
-            <h2 className="text-2xl font-black tracking-tight text-slate-900 dark:text-white mt-3 mb-1">
+            <h2 id="login-modal-title" className="text-2xl font-black tracking-tight text-slate-900 dark:text-white mt-3 mb-1">
               Initialize Your Training Lab
             </h2>
             <p className="text-sm text-slate-500 dark:text-gray-400 m-0">

--- a/src/components/KeyboardShortcutsModal.jsx
+++ b/src/components/KeyboardShortcutsModal.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import useFocusTrap from "../hooks/useFocusTrap";
 
 const ShortcutRow = ({ action, shortcut }) => (
   <div
@@ -38,6 +39,8 @@ export default function KeyboardShortcutsModal({
   isOpen,
   onClose,
 }) {
+  const modalRef = useFocusTrap(isOpen);
+
   if (!isOpen) return null;
 
   return (
@@ -55,9 +58,11 @@ export default function KeyboardShortcutsModal({
       }}
     >
       <div
+        ref={modalRef}
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
+        aria-labelledby="keyboard-shortcuts-title"
         style={{
           background: "#ffffff",
           color: "#111827",
@@ -78,6 +83,7 @@ export default function KeyboardShortcutsModal({
         >
           <div>
             <h2
+              id="keyboard-shortcuts-title"
               style={{
                 margin: 0,
                 fontSize: "1.5rem",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -199,6 +199,27 @@
   background: #0d1117;
 }
 
+.skip-to-content {
+  position: absolute;
+  left: -9999px;
+  z-index: 10000;
+  padding: 10px 15px;
+  background-color: var(--ifm-color-primary);
+  color: white !important;
+  font-weight: bold;
+  border-radius: 4px;
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+}
+
+.skip-to-content:focus {
+  left: 50%;
+  transform: translateX(-50%);
+  top: 8px;
+  opacity: 1;
+}
+
 a:hover {
   text-decoration: none;
 }

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+
+export default function useFocusTrap(isActive: boolean) {
+  const ref = useRef<any>(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const focusableElementsString =
+      'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]';
+
+    const element = ref.current;
+    if (!element) return;
+
+    const focusableElements = element.querySelectorAll(focusableElementsString);
+    if (focusableElements.length === 0) return;
+
+    const firstElement = focusableElements[0] as HTMLElement;
+    const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+    const handleTabKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          lastElement.focus();
+          e.preventDefault();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          firstElement.focus();
+          e.preventDefault();
+        }
+      }
+    };
+
+    const previousActiveElement = document.activeElement as HTMLElement | null;
+
+    setTimeout(() => {
+      if (firstElement) firstElement.focus();
+    }, 10);
+
+    element.addEventListener('keydown', handleTabKey);
+
+    return () => {
+      element.removeEventListener('keydown', handleTabKey);
+      if (previousActiveElement) {
+        previousActiveElement.focus();
+      }
+    };
+  }, [isActive]);
+
+  return ref;
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -27,6 +27,9 @@ export default function Root({ children }) {
   return (
     <>
       <AuthProvider>
+        <a href="#__docusaurus" className="skip-to-content">
+          Skip to main content
+        </a>
         <SidebarUpdater />
         {isDocsPage && <PageProgressIndicator />}
         {children}


### PR DESCRIPTION
Fixes #1 Accessibility: Adds a visually hidden skip-to-content link and a focus trap for LoginModal and KeyboardShortcutsModal to comply with WCAG standards.