### PR TITLE
fix(security): remove exposed algolia api key fallback in docusaurus config (#2787)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,7 +111,7 @@ const config = {
         textColor: "var(--announcement-text)",
         isCloseable: true,
       },
-      ...(process.env.ALGOLIA_API_KEY ? {
+      ...(process.env.ALGOLIA_API_KEY && process.env.ALGOLIA_APP_ID && process.env.ALGOLIA_INDEX_NAME ? {
         algolia: {
           appId: process.env.ALGOLIA_APP_ID,
           apiKey: process.env.ALGOLIA_API_KEY,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,13 +111,14 @@ const config = {
         textColor: "var(--announcement-text)",
         isCloseable: true,
       },
-      algolia: {
-        appId: process.env.ALGOLIA_APP_ID || "T0I3F584D5",
-        apiKey:
-          process.env.ALGOLIA_API_KEY || "865d7bd9906f532b1d8cb5cc0f02b383",
-        indexName: process.env.ALGOLIA_INDEX_NAME || "ajay-dhangario",
-        contextualSearch: true,
-      },
+      ...(process.env.ALGOLIA_API_KEY ? {
+        algolia: {
+          appId: process.env.ALGOLIA_APP_ID,
+          apiKey: process.env.ALGOLIA_API_KEY,
+          indexName: process.env.ALGOLIA_INDEX_NAME,
+          contextualSearch: true,
+        }
+      } : {}),
 
       navbar: {
         title: "Algo",


### PR DESCRIPTION

### Description
This PR addresses a security concern regarding the exposed Algolia API key hardcoded in `docusaurus.config.js`. 

Previously, the configuration would fall back to a hardcoded `apiKey` and `appId` string if the environment variables were missing. To adhere to strict zero-trust security practices, this PR completely removes these hardcoded strings. The `algolia` search configuration is now conditionally injected into `themeConfig` exclusively when `process.env.ALGOLIA_API_KEY` is present, ensuring no keys are accidentally leaked while maintaining full local development compatibility.

Fixes #2787

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
