### PR TITLE
[Docs]: Replace SECURITY.md placeholder template with real vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,6 +24,7 @@ Vulnerabilities in the following are considered in-scope:
 
 Out-of-scope:
 - Third-party dependencies (report to their respective maintainers)
+- Client-side mock authentication limitations (not representative of production security)
 
 ## Disclosure Policy
 
@@ -32,3 +33,4 @@ We follow a coordinated disclosure process:
 2. Maintainer acknowledges receipt within 48 hours
 3. Fix is developed and tested in private
 4. Fix is released, and the advisory is published publicly
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,33 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| Version | Supported |
+| ------- | --------- |
+| latest  | ✅        |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you discover a security vulnerability, please report it responsibly:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+1. **GitHub Security Advisories**: Use the "Report a vulnerability" button on the [Security tab](https://github.com/ajay-dhangar/algo/security/advisories)
+2. **Do NOT** open public issues for security vulnerabilities
+
+We aim to acknowledge reports within 48 hours and provide a fix timeline within 7 days.
+
+## Scope
+
+Vulnerabilities in the following are considered in-scope:
+- The Docusaurus website configuration and deployment
+- Documentation content and build scripts
+- Any authentication or authorization mechanisms
+
+Out-of-scope:
+- Third-party dependencies (report to their respective maintainers)
+
+## Disclosure Policy
+
+We follow a coordinated disclosure process:
+1. Reporter submits vulnerability via Security Advisory
+2. Maintainer acknowledges receipt within 48 hours
+3. Fix is developed and tested in private
+4. Fix is released, and the advisory is published publicly

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,11 @@
 
 | Version | Supported |
 | ------- | --------- |
-| latest  | ✅        |
+| latest  | :white_check_mark: |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -20,11 +24,11 @@ We aim to acknowledge reports within 48 hours and provide a fix timeline within 
 Vulnerabilities in the following are considered in-scope:
 - The Docusaurus website configuration and deployment
 - Documentation content and build scripts
-- Any authentication or authorization mechanisms
+- Any authentication or authorization mechanisms (excluding client-side sandbox/mock limitations)
 
 Out-of-scope:
 - Third-party dependencies (report to their respective maintainers)
-- Client-side mock authentication limitations (not representative of production security)
+- Client-side mock authentication limitations (e.g., local storage, client-side hashing)
 
 ## Disclosure Policy
 
@@ -33,4 +37,3 @@ We follow a coordinated disclosure process:
 2. Maintainer acknowledges receipt within 48 hours
 3. Fix is developed and tested in private
 4. Fix is released, and the advisory is published publicly
-


### PR DESCRIPTION
## 📥 Pull Request

### Description
Replaced the default GitHub SECURITY.md template (with fictional version numbers 5.1.x, 5.0.x, 4.0.x and placeholder text) with a real project-specific security policy. This gives security researchers and GSSoC contributors a clear vulnerability disclosure pathway.

Fixes #2816

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
