### PR TITLE
[Bug]: Fix organizationName mismatch in docusaurus.config.js that breaks GitHub Pages deployment

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,7 +34,7 @@ const config = {
 
   url: "https://ajay-dhangar.github.io",
   baseUrl: "/algo/",
-  organizationName: "codeharborhub",
+  organizationName: "ajay-dhangar",
   projectName: "algo",
 
   onBrokenLinks: "throw",


### PR DESCRIPTION
## 📥 Pull Request

### Description
Changed `organizationName` from `"codeharborhub"` (incorrect) to `"ajay-dhangar"` (correct) in `docusaurus.config.js`. The repository is owned by `ajay-dhangar`, not `codeharborhub`. This mismatch causes:
1. gh-pages deployment targeting the wrong org
2. Misleading configuration for new contributors
3. Potential CI/CD failures reading the wrong org name

Fixes #2817

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
