### PR TITLE
chore: remove unused Chatrace script integration from homepage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -10,27 +10,6 @@ import TopToBottom from "../components/Scroller/TopToBottom/TopToBottom.tsx";
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
 
-  // useEffect(() => {
-  //   // Create and append the Chatrace script
-  //   const chatraceScript = document.createElement("script");
-  //   chatraceScript.src = "https://chatrace.com/webchat/plugin.js?v=5";
-  //   chatraceScript.async = true;
-  //   chatraceScript.onload = () => {
-  //     // Initialize the chat widget after the script loads
-  //     if (window.ktt10) {
-  //       window.ktt10.setup({
-  //         id: "2Xk6i0bywhd02D",
-  //         accountId: "1322274",
-  //         color: "#006dff",
-  //       });
-  //     }
-  //   };
-  //   document.body.appendChild(chatraceScript);
-
-  //   return () => {
-  //     document.body.removeChild(chatraceScript);
-  //   };
-  // }, []);
 
   return (
     <Layout


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR removes the dead, commented-out `useEffect` code for the Chatrace widget from `src/pages/index.js`.

### Changes made

* Removed the inactive `useEffect` block containing the Chatrace integration.
* Cleaned up `index.js` by eliminating unused, commented-out code.
* Improved code readability and maintainability by keeping the component focused on active functionality.

If the Chatrace widget needs to be reintroduced in the future, it should be integrated through Docusaurus configuration (`headTags` or the `scripts` array in `docusaurus.config.js`) instead of manipulating the DOM within the React component.

**Fixes #2851**

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

### Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
