### PR TITLE
fix: align @docusaurus/* dependencies to ^3.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@docusaurus/plugin-content-docs": "^3.5.2",
     "@docusaurus/plugin-debug": "^3.5.2",
     "@docusaurus/preset-classic": "^3.5.2",
-    "@docusaurus/theme-live-codeblock": "^3.10.1",
-    "@docusaurus/theme-mermaid": "^3.10.1",
+    "@docusaurus/theme-live-codeblock": "^3.5.2",
+    "@docusaurus/theme-mermaid": "^3.5.2",
     "@docusaurus/theme-search-algolia": "^3.5.2",
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
@@ -43,6 +43,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-icons": "^5.3.0",
+    "react-katex": "^3.1.0",
     "react-lite-youtube-embed": "^2.4.0",
     "react-simple-chatbot": "^0.5.3",
     "react-toastify": "^10.0.5",
@@ -58,7 +59,9 @@
     "autoprefixer": "^10.4.20",
     "concurrently": "^8.2.2",
     "gh-pages": "^6.1.0",
+    "pa11y-ci": "^4.1.1",
     "postcss": "^8.4.47",
+    "start-server-and-test": "^3.0.11",
     "tailwindcss": "^3.4.13"
   },
   "overrides": {


### PR DESCRIPTION
## 📥 Pull Request

### Description
Aligned `@docusaurus/theme-mermaid` and `@docusaurus/theme-live-codeblock` from `^3.10.1` to `^3.5.2` to match the rest of the Docusaurus core packages. This prevents potential compatibility issues from the version gap between 3.5.2 and 3.10.1.

Fixes #2846

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules