### PR TITLE
fix: fix broken triple-slash URL in manifest.json related_applications

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -10,7 +10,7 @@
   "related_applications": [
     {
       "platform": "webapp",
-      "url": "https://ajay-dhangar.github.io/algo///manifest.json"
+      "url": "https://ajay-dhangar.github.io/algo/manifest.json"
     }
   ],
   "icons": [


### PR DESCRIPTION
Fixes #2839

Fixed triple-slash URL (`///`) in `static/manifest.json` `related_applications` entry.

Changed `https://ajay-dhangar.github.io/algo///manifest.json` to `https://ajay-dhangar.github.io/algo/manifest.json`.