### PR TITLE
docs: replace SECURITY.md placeholder with actual vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,15 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
 | Version | Supported          |
 | ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+| latest  | :white_check_mark: |
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+If you discover a security vulnerability, please report it responsibly:
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+1. **GitHub Security Advisories**: Use the "Report a vulnerability" button on the Security tab
+2. **Expected Response**: We aim to acknowledge reports within 48 hours and provide a fix timeline within 7 days
+
+Please do NOT open public issues for security vulnerabilities.


### PR DESCRIPTION
Fixes #2816

Replaces the GitHub template placeholder in `SECURITY.md` with a proper vulnerability disclosure policy including supported versions (latest only) and reporting instructions via GitHub Security Advisories.