### PR TITLE
fix: update PWA manifest.json to use size-specific icon filenames

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -15,32 +15,32 @@
   ],
   "icons": [
     {
-      "src": "logo/logo.png",
+      "src": "logo/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "logo/logo.png",
+      "src": "logo/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     },
     {
-      "src": "logo/logo.png",
+      "src": "logo/icon-180x180.png",
       "sizes": "180x180",
       "type": "image/png"
     },
     {
-      "src": "logo/logo.png",
+      "src": "logo/icon-16x16.png",
       "sizes": "16x16",
       "type": "image/png"
     },
     {
-      "src": "logo/logo.png",
+      "src": "logo/icon-32x32.png",
       "sizes": "32x32",
       "type": "image/png"
     },
     {
-      "src": "logo/logo.png",
+      "src": "logo/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     }


### PR DESCRIPTION
Fixes #2843

## Changes

Updated `static/manifest.json` to use distinct size-specific icon filenames instead of the same `logo/logo.png` for all sizes.

### Before
All icon entries referenced `logo/logo.png` regardless of size.

### After
Each icon entry now references a size-specific filename:
- `logo/icon-192x192.png` (192×192)
- `logo/icon-512x512.png` (512×512)
- `logo/icon-180x180.png` (180×180)
- `logo/icon-16x16.png` (16×16)
- `logo/icon-32x32.png` (32×32)

This enables proper PWA icon caching and ensures the correct icon is served for each resolution.