### PR TITLE
fix: throw instead of storing plaintext password when crypto.subtle is unavailable (#2880)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -75,9 +75,10 @@ function randomSalt() {
 async function hashPassword(password: string, salt: string) {
   const scope = safeWindow();
   if (!scope?.crypto?.subtle) {
-    return `${salt}:${password}`;
+    throw new Error(
+      "Secure crypto is unavailable. Please use the site over HTTPS (or localhost) to create an account."
+    );
   }
-
   const encoded = new TextEncoder().encode(`${salt}:${password}`);
   const digest = await scope.crypto.subtle.digest("SHA-256", encoded);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -76,7 +76,7 @@ async function hashPassword(password: string, salt: string) {
   const scope = safeWindow();
   if (!scope?.crypto?.subtle) {
     throw new Error(
-      "Secure crypto is unavailable. Please use the site over HTTPS (or localhost) to create an account."
+      "Secure crypto is unavailable. Please use the site over HTTPS (or localhost) to authenticate."
     );
   }
   const encoded = new TextEncoder().encode(`${salt}:${password}`);


### PR DESCRIPTION
## 📥 Pull Request

### Description

`hashPassword()` in `src/contexts/AuthContext.tsx` had a fallback branch that returned the plaintext password (`` `${salt}:${password}` ``) whenever `crypto.subtle` was unavailable. `crypto.subtle` (Web Crypto) is only exposed in secure contexts (HTTPS, plus `localhost`/`127.0.0.1`), so on any plain-HTTP non-localhost origin (a LAN dev server like `http://192.168.1.x:3000`, or an HTTP preview) registration wrote `salt:plaintextPassword` straight into `localStorage`.

Two problems came from that: passwords were stored in plaintext on those origins, and because `login()` recomputes the hash with the same function and compares, a user who registered in one context (plaintext fallback) and logged in from another (real SHA-256) got a hash mismatch and was locked out of their own account with "Incorrect password" despite entering the correct one.

This drops the plaintext fallback and throws instead, giving a single consistent hashing path and never storing plaintext:

```ts
if (!scope?.crypto?.subtle) {
  throw new Error(
    "Secure crypto is unavailable. Please use the site over HTTPS (or localhost) to create an account."
  );
}
```

The auth here is intentionally client-side/demo, so the threat model is limited, but the fallback defeated the one security control the code was applying and caused the lockout. Both `register` and `login` call `hashPassword` inside the `AuthPanel` try/catch that renders `error`, so on a non-secure origin the user now sees the clear message instead of silently storing a plaintext password.

Fixes #2880

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules