### PR TITLE
fix: unify quiz username under a single localStorage key (#2928)

### DIFF
--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -131,7 +131,7 @@ const ArrayQuiz: React.FC = () => {
 
   useEffect(() => {
     setIsMounted(true);
-    const storedUser = localStorage.getItem("algo_quiz_username");
+    const storedUser = localStorage.getItem("quiz_username");
     if (storedUser) {
       setUsername(storedUser);
       const historyKey = `algo_array_history_${storedUser.toLowerCase()}`;
@@ -166,7 +166,7 @@ const ArrayQuiz: React.FC = () => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
     const cleanName = usernameInput.trim();
-    localStorage.setItem("algo_quiz_username", cleanName);
+    localStorage.setItem("quiz_username", cleanName);
     setUsername(cleanName);
 
     const historyKey = `algo_array_history_${cleanName.toLowerCase()}`;
@@ -174,7 +174,7 @@ const ArrayQuiz: React.FC = () => {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("algo_quiz_username");
+    localStorage.removeItem("quiz_username");
     setUsername(null);
     setUsernameInput("");
     setLocalHistory([]);

--- a/src/pages/quizzes/avl-tree.tsx
+++ b/src/pages/quizzes/avl-tree.tsx
@@ -150,7 +150,7 @@ const AVLTreeQuiz: React.FC = () => {
 
   useEffect(() => {
     setIsMounted(true);
-    const storedUser = localStorage.getItem("algo_quiz_username");
+    const storedUser = localStorage.getItem("quiz_username");
     if (storedUser) {
       setUsername(storedUser);
       const historyKey = `algo_avl_history_${storedUser.toLowerCase()}`;
@@ -185,7 +185,7 @@ const AVLTreeQuiz: React.FC = () => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
     const cleanName = usernameInput.trim();
-    localStorage.setItem("algo_quiz_username", cleanName);
+    localStorage.setItem("quiz_username", cleanName);
     setUsername(cleanName);
 
     const historyKey = `algo_avl_history_${cleanName.toLowerCase()}`;
@@ -193,7 +193,7 @@ const AVLTreeQuiz: React.FC = () => {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("algo_quiz_username");
+    localStorage.removeItem("quiz_username");
     setUsername(null);
     setUsernameInput("");
     setLocalHistory([]);

--- a/src/pages/quizzes/queue.tsx
+++ b/src/pages/quizzes/queue.tsx
@@ -243,13 +243,16 @@ const QueueQuiz: React.FC = () => {
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
-    localStorage.setItem("quiz_username", usernameInput.trim());
-    setUsername(usernameInput.trim());
+    const cleanName = usernameInput.trim();
+    localStorage.setItem("quiz_username", cleanName);
+    setUsername(cleanName);
+    setHistory(safeJsonParse<AttemptHistory[]>(`quiz_history_${cleanName}_queue`, []));
   };
-
   const handleLogout = () => {
     localStorage.removeItem("quiz_username");
     setUsername(null);
+    setUsernameInput("");
+    setHistory([]);
     handleRetry();
   };
 

--- a/src/pages/quizzes/queue.tsx
+++ b/src/pages/quizzes/queue.tsx
@@ -216,7 +216,7 @@ const QueueQuiz: React.FC = () => {
 
   useEffect(() => {
     setIsMounted(true);
-    const savedUser = localStorage.getItem("quiz_user_queue");
+    const savedUser = localStorage.getItem("quiz_username");
     if (savedUser) {
       setUsername(savedUser);
       setHistory(safeJsonParse<AttemptHistory[]>(`quiz_history_${savedUser}_queue`, []));
@@ -243,12 +243,12 @@ const QueueQuiz: React.FC = () => {
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
-    localStorage.setItem("quiz_user_queue", usernameInput.trim());
+    localStorage.setItem("quiz_username", usernameInput.trim());
     setUsername(usernameInput.trim());
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("quiz_user_queue");
+    localStorage.removeItem("quiz_username");
     setUsername(null);
     handleRetry();
   };

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -186,13 +186,16 @@ const RedBlackTreeQuiz: React.FC = () => {
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
-    localStorage.setItem("quiz_username", usernameInput.trim());
-    setUsername(usernameInput.trim());
+    const cleanName = usernameInput.trim();
+    localStorage.setItem("quiz_username", cleanName);
+    setUsername(cleanName);
+    setHistory(safeJsonParse<AttemptRecord[]>(`rbt_history_${cleanName}`, []));
   };
-
   const handleLogout = () => {
     localStorage.removeItem("quiz_username");
     setUsername(null);
+    setUsernameInput("");
+    setHistory([]);
     handleRetry();
   };
 

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -158,7 +158,7 @@ const RedBlackTreeQuiz: React.FC = () => {
   // Initialize from LocalStorage
   useEffect(() => {
     setIsMounted(true);
-    const savedUser = localStorage.getItem("rbt_quiz_user");
+    const savedUser = localStorage.getItem("quiz_username");
     if (savedUser) {
       setUsername(savedUser);
       setHistory(safeJsonParse<AttemptRecord[]>(`rbt_history_${savedUser}`, []));
@@ -186,12 +186,12 @@ const RedBlackTreeQuiz: React.FC = () => {
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
-    localStorage.setItem("rbt_quiz_user", usernameInput.trim());
+    localStorage.setItem("quiz_username", usernameInput.trim());
     setUsername(usernameInput.trim());
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("rbt_quiz_user");
+    localStorage.removeItem("quiz_username");
     setUsername(null);
     handleRetry();
   };

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -158,7 +158,7 @@ const StackQuiz: React.FC = () => {
 
   useEffect(() => {
     setIsMounted(true);
-    const storedUser = localStorage.getItem("algo_quiz_username");
+    const storedUser = localStorage.getItem("quiz_username");
     if (storedUser) {
       setUsername(storedUser);
       const historyKey = `algo_quiz_history_${storedUser.toLowerCase()}`;
@@ -195,7 +195,7 @@ const StackQuiz: React.FC = () => {
     e.preventDefault();
     if (!usernameInput.trim()) return;
     const cleanName = usernameInput.trim();
-    localStorage.setItem("algo_quiz_username", cleanName);
+    localStorage.setItem("quiz_username", cleanName);
     setUsername(cleanName);
 
     const historyKey = `algo_quiz_history_${cleanName.toLowerCase()}`;
@@ -203,7 +203,7 @@ const StackQuiz: React.FC = () => {
   };
 
   const handleLogout = () => {
-    localStorage.removeItem("algo_quiz_username");
+    localStorage.removeItem("quiz_username");
     setUsername(null);
     setUsernameInput("");
     setLocalHistory([]);


### PR DESCRIPTION
## 📥 Pull Request

### Description

The quiz username was stored under four different `localStorage` keys across the quiz pages, so a name entered on one quiz wasn't recognized on others and users had to re-enter it. Logging out on one page also didn't clear the identity stored under the other keys, so a user could be logged out on some quizzes but still logged in on others.

The 13 pages using the shared `useQuizData` hook already store the username under `quiz_username`. Five pages were never migrated and each hand-rolled its own key:

- `arrays.tsx`, `avl-tree.tsx`, `stack.tsx` → `algo_quiz_username`
- `queue.tsx` → `quiz_user_queue`
- `red-black-tree.tsx` → `rbt_quiz_user`

This standardizes all five outlier pages on `quiz_username`, so the username is a single shared identity across the whole quiz suite: entering it once carries across every quiz, and logging out clears it everywhere.

Only the username key is changed (the `getItem` / `setItem` / `removeItem` calls). The per-quiz history keys (`quiz_history_..._queue`, `rbt_history_...`, etc.) are untouched, since they key off the username *value*, not the username storage key, so existing history is unaffected.

Note: this is the plain key-swap fix. Users who had already entered a name on one of the five outlier pages under the old key will be asked to re-enter it once (their name was stored under the old key). Since this is a quiz display name in `localStorage`, that one-time re-entry seemed acceptable versus adding fallback-migration logic to five files, but happy to add a migration read if you'd prefer to preserve existing names.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Related Issue

Closes #2928

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

### Notes

Verified locally with `docusaurus start`: entering a username on `/quizzes/graph` (which uses `quiz_username`) is now recognized on `/quizzes/arrays` (previously `algo_quiz_username`), instead of showing the username-entry screen again.

A natural follow-up would be migrating the five outlier pages fully onto the shared `useQuizData` hook that the other 13 use, but this PR keeps the scope to the user-facing username-key fix.