### PR TITLE
fix: resolve TypeScript type mismatch and remove dead code in quizzes

### DIFF
--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -155,13 +155,6 @@ const ArrayQuiz: React.FC = () => {
 
   const selectedOption = userAnswers[currentQuestion] || null;
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/avl-tree.tsx
+++ b/src/pages/quizzes/avl-tree.tsx
@@ -174,13 +174,6 @@ const AVLTreeQuiz: React.FC = () => {
 
   const selectedOption = userAnswers[currentQuestion] || null;
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -216,13 +216,6 @@ const BTreeQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -186,13 +186,6 @@ const BinarySearchTreeQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -178,13 +178,6 @@ const BinaryTreeQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/bplus-tree.tsx
+++ b/src/pages/quizzes/bplus-tree.tsx
@@ -241,13 +241,6 @@ const BPlusTreeQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/deque.tsx
+++ b/src/pages/quizzes/deque.tsx
@@ -241,13 +241,6 @@ const DequeQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/external-hashing.tsx
+++ b/src/pages/quizzes/external-hashing.tsx
@@ -241,13 +241,6 @@ const ExternalHashingQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/hash-indexing.tsx
+++ b/src/pages/quizzes/hash-indexing.tsx
@@ -241,13 +241,6 @@ const HashIndexingQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/isam.tsx
+++ b/src/pages/quizzes/isam.tsx
@@ -241,13 +241,6 @@ const IsamQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/linked-list.tsx
+++ b/src/pages/quizzes/linked-list.tsx
@@ -238,13 +238,6 @@ const LinkedListQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/priority-queue.tsx
+++ b/src/pages/quizzes/priority-queue.tsx
@@ -241,13 +241,6 @@ const PriorityQueueQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/queue.tsx
+++ b/src/pages/quizzes/queue.tsx
@@ -233,13 +233,6 @@ const QueueQuiz: React.FC = () => {
     return userAnswers.reduce((acc, ans, idx) => (ans === QUESTIONS[idx]?.answer ? acc + 1 : acc), 0);
   }, [userAnswers]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/recursion.tsx
+++ b/src/pages/quizzes/recursion.tsx
@@ -238,13 +238,6 @@ const RecursionQuiz: React.FC = () => {
     }
   }, [userId, fetchAttempts]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/red-black-tree.tsx
+++ b/src/pages/quizzes/red-black-tree.tsx
@@ -176,13 +176,6 @@ const RedBlackTreeQuiz: React.FC = () => {
     return userAnswers.reduce((acc, ans, idx) => (ans === QUESTIONS[idx]?.answer ? acc + 1 : acc), 0);
   }, [userAnswers]);
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;

--- a/src/pages/quizzes/stack.tsx
+++ b/src/pages/quizzes/stack.tsx
@@ -184,13 +184,6 @@ const StackQuiz: React.FC = () => {
 
   const selectedOption = userAnswers[currentQuestion] || null;
 
-  const handleKeyDown = (e: React.KeyboardEvent, option: string) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      handleRegister(option);
-    }
-  };
-
   const handleRegister = (e: React.FormEvent) => {
     e.preventDefault();
     if (!usernameInput.trim()) return;


### PR DESCRIPTION
# Description

This PR resolves the remaining TypeScript compilation and type-checking failures in the quiz components under `src/pages/quizzes/` by removing unused dead code.

Fixes #2782

## Root Cause & Changes

- A previous refactoring standardized quiz data structures (renaming `questionText` to `question`) and cleaned up unused component imports.
- However, an unused `handleKeyDown` helper function was left behind in 16 quiz files. 
- This function called `handleRegister(option)`, passing a `string` (the quiz option value) to a function that expects a `React.FormEvent`. This resulted in a type mismatch error when compiling/checking the project via `tsc --noEmit`.
- Since the `handleKeyDown` function was not referenced anywhere in the JSX template (no `onKeyDown` handlers on the option buttons), it was dead code and has been removed.

## Affected Files
The `handleKeyDown` function has been removed from the following quiz pages:
- `src/pages/quizzes/arrays.tsx`
- `src/pages/quizzes/avl-tree.tsx`
- `src/pages/quizzes/b-tree.tsx`
- `src/pages/quizzes/binary-search-tree.tsx`
- `src/pages/quizzes/binary-tree.tsx`
- `src/pages/quizzes/bplus-tree.tsx`
- `src/pages/quizzes/deque.tsx`
- `src/pages/quizzes/external-hashing.tsx`
- `src/pages/quizzes/hash-indexing.tsx`
- `src/pages/quizzes/isam.tsx`
- `src/pages/quizzes/linked-list.tsx`
- `src/pages/quizzes/priority-queue.tsx`
- `src/pages/quizzes/queue.tsx`
- `src/pages/quizzes/recursion.tsx`
- `src/pages/quizzes/red-black-tree.tsx`
- `src/pages/quizzes/stack.tsx`

## Verification
- Ran strict TypeScript compilation checks (`tsc --noEmit`) locally.
- Confirmed that the `src/pages/quizzes/` directory now compiles successfully with zero type mismatch errors.
