### PR TITLE
fix: resolve duplicate Detailed Breakdown entries in TOC

### DIFF
--- a/docs/content.mdx
+++ b/docs/content.mdx
@@ -31,7 +31,7 @@ Welcome to the master blueprint of your DSA journey. To help you navigate effici
 
     <br />
 
-    ### Detailed Breakdown
+    ### Detailed Breakdown - Data Structures
 
     * **Foundations:** Memory allocation, Time & Space Complexity ($O(n)$ basics).
     * **Linear Structures:** Sequential arrangements, insertions, and fast deletions.
@@ -56,7 +56,7 @@ Welcome to the master blueprint of your DSA journey. To help you navigate effici
 
     <br />
 
-    ### Detailed Breakdown
+    ### Detailed Breakdown - Algorithms
 
     * **Search & Sort:** From basic linear lookups to advanced Divide & Conquer structures (Quick/Merge Sort).
     * **Algorithmic Patterns:** Recognizing sub-problems using Memoization, Tabulation, and Greedy strategies.
@@ -80,7 +80,7 @@ Welcome to the master blueprint of your DSA journey. To help you navigate effici
 
     <br />
 
-    ### Detailed Breakdown
+    ### Detailed Breakdown - Practice
 
     * **Curated Problem Sets:** Handpicked patterns matching high-frequency questions on LeetCode and HackerRank.
     * **Pattern Matching:** Master Sliding Window, Two Pointers, and Fast/Slow Pointers.


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR fixes the duplicate "Detailed Breakdown" entries in the Curriculum Roadmap page's Table of Contents and improves navigation behavior.

Changes made:
- Updated the structure of the "Detailed Breakdown" sections.
- Ensured the TOC entries are properly differentiated and navigable.
- Improved the overall user experience of the Curriculum Roadmap page.

Fixes #2942 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

###Screenshot:
<img width="462" height="342" alt="db fix" src="https://github.com/user-attachments/assets/dba202e8-f2b8-4dd4-b934-455a7bd4f308" />
