### PR TITLE
refactor: sync algo_progress with Supabase backend

### DIFF
--- a/src/components/ProgressTracker/SidebarUpdater.tsx
+++ b/src/components/ProgressTracker/SidebarUpdater.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { safeJsonParse } from '../../utils/safeStorage';
+import { safeJsonParse, syncAlgoProgress } from '../../utils/safeStorage';
 
 
 interface ProgressData {
@@ -17,7 +17,10 @@ const SidebarUpdater: React.FC = () => {
         console.error(e);
       }
     };
-    load();
+    
+    // Initial fetch from supabase if authenticated
+    syncAlgoProgress().then(load).catch(load);
+
     window.addEventListener('progressUpdated', load);
     return () => window.removeEventListener('progressUpdated', load);
   }, []);

--- a/src/components/ProgressTracker/index.tsx
+++ b/src/components/ProgressTracker/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import clsx from 'clsx';
 import { FiCheckCircle, FiCircle, FiTrendingUp, FiAward } from 'react-icons/fi';
-import { safeJsonParse } from '../../utils/safeStorage';
+import { safeJsonParse, writeAlgoProgress } from '../../utils/safeStorage';
 
 interface Props {
   topicId: string;
@@ -38,7 +38,7 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
       progress[`${topicId}_title`] = topicTitle;
       progress[`${topicId}_updatedAt`] = new Date().toISOString();
       
-      localStorage.setItem('algo_progress', JSON.stringify(progress));
+      writeAlgoProgress(progress);
 
       // Dispatch unified pipeline context updates across component domains
       window.dispatchEvent(

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -2,6 +2,49 @@ export interface AlgoProgressData {
   [key: string]: unknown;
 }
 
+import { supabase } from './supabaseClient';
+
+export function getUserId(): string | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  try {
+    const sessionRaw = window.localStorage.getItem("algo.auth.session.v1");
+    if (sessionRaw) {
+      const session = JSON.parse(sessionRaw);
+      if (session && session.accountId) return session.accountId;
+    }
+  } catch {}
+  return window.localStorage.getItem("quiz_userId") || null;
+}
+
+export async function syncAlgoProgress(): Promise<void> {
+  const userId = getUserId();
+  if (!userId) return;
+
+  try {
+    const { data, error } = await supabase
+      .from('user_progress')
+      .select('progress_data')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      if (error.code !== 'PGRST116') {
+        console.error("[Algo] Failed to sync progress from Supabase:", error);
+      }
+      return;
+    }
+
+    if (data && data.progress_data) {
+      const current = readAlgoProgress();
+      const merged = { ...current, ...data.progress_data };
+      window.localStorage.setItem('algo_progress', JSON.stringify(merged));
+      window.dispatchEvent(new Event('progressUpdated'));
+    }
+  } catch (err) {
+    console.error("[Algo] Error syncing progress from Supabase:", err);
+  }
+}
+
 export interface AchievementSnapshot {
   completedCount: number;
   completedTopics: string[];
@@ -37,6 +80,18 @@ export function writeAlgoProgress(progress: AlgoProgressData): void {
   }
 
   window.localStorage.setItem('algo_progress', JSON.stringify(progress));
+
+  const userId = getUserId();
+  if (userId) {
+    supabase.from('user_progress').upsert(
+      { user_id: userId, progress_data: progress, updated_at: new Date().toISOString() },
+      { onConflict: 'user_id' }
+    ).then(({ error }) => {
+      if (error) {
+        console.error("[Algo] Failed to save progress to Supabase:", error);
+      }
+    });
+  }
 }
 
 function computeStreak(progress: AlgoProgressData): number {


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR refactors `safeStorage.ts` to synchronize `algo_progress` with the Supabase backend instead of relying solely on `localStorage`.

Previously, progress data (completed topics, streaks, and related metadata) was stored only in the browser, causing users to lose their progress after clearing browser storage or when accessing the application from a different device. While quiz data had already been migrated to Supabase, progress persistence remained inconsistent.

### Changes Made

* Refactored `safeStorage.ts` to support Supabase synchronization.
* Added `syncAlgoProgress()` to:

  * Identify the authenticated user (or fall back to `quiz_userId`).
  * Fetch the user's `algo_progress` from the `user_progress` table during application initialization.
* Updated `writeAlgoProgress()` to:

  * Continue updating local storage for fast local access.
  * Perform a fire-and-forget `upsert` to the Supabase `user_progress` table, keeping remote data synchronized.
* Updated `ProgressTracker/index.tsx` to use `writeAlgoProgress()` instead of writing directly to `localStorage`.
* Updated `SidebarUpdater.tsx` to invoke `syncAlgoProgress()` during application startup so user progress is restored from Supabase on login, browser changes, or after clearing cache.

This provides consistent, cross-device persistence while preserving the existing local caching behavior.

**Fixes #3020**

---

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

---

### Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [ ] I have added tests that prove my fix is effective or that my feature works
* [x] New and existing unit tests pass locally with my changes (`npm run typecheck` and `npm run build`)
* [ ] Any dependent changes have been merged and published in downstream modules