### PR TITLE
feat: connect challenge completion to Profile page with persistent progress tracking

### DIFF
--- a/src/components/DPChallengeLayout.tsx
+++ b/src/components/DPChallengeLayout.tsx
@@ -53,7 +53,20 @@ export default function DPChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <span className={`ml-auto px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
+          <button
+            onClick={() => {
+              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
+              progress[challenge.id] = true;
+              progress[`${challenge.id}_title`] = challenge.title;
+              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+              localStorage.setItem("algo_progress", JSON.stringify(progress));
+              alert("Marked as solved!");
+            }}
+            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+          >
+            <FaCheck /> Mark as Solved ✅
+          </button>
+          <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>
           <span className="flex items-center gap-1.5 text-xs font-mono text-slate-400">

--- a/src/components/DPChallengeLayout.tsx
+++ b/src/components/DPChallengeLayout.tsx
@@ -53,19 +53,19 @@ export default function DPChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <button
-            onClick={() => {
-              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
-              progress[challenge.id] = true;
-              progress[`${challenge.id}_title`] = challenge.title;
-              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
-              localStorage.setItem("algo_progress", JSON.stringify(progress));
-              alert("Marked as solved!");
-            }}
-            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
-          >
-            <FaCheck /> Mark as Solved ✅
-          </button>
+<button
+  onClick={() => {
+    const progress = readAlgoProgress();
+    progress[challenge.id] = true;
+    progress[`${challenge.id}_title`] = challenge.title;
+    progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+    writeAlgoProgress(progress);
+    alert("Marked as solved!");
+  }}
+  className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+>
+  <FaCheck /> Mark as Solved ✅
+</button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -441,19 +441,19 @@ export default function GraphChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <button
-            onClick={() => {
-              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
-              progress[challenge.id] = true;
-              progress[`${challenge.id}_title`] = challenge.title;
-              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
-              localStorage.setItem("algo_progress", JSON.stringify(progress));
-              alert("Marked as solved!");
-            }}
-            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
-          >
-            <FaCheck /> Mark as Solved ✅
-          </button>
+<button
+  onClick={() => {
+    const progress = readAlgoProgress();
+    progress[challenge.id] = true;
+    progress[`${challenge.id}_title`] = challenge.title;
+    progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+    writeAlgoProgress(progress);
+    alert("Marked as solved!");
+  }}
+  className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+>
+  <FaCheck /> Mark as Solved ✅
+</button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -6,7 +6,7 @@ import Layout from "@theme/Layout";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
 import {
-  FaArrowLeft, FaLightbulb, FaPlay,
+  FaArrowLeft, FaLightbulb, FaPlay, FaCheck,
   FaEye, FaEyeSlash, FaClock, FaChevronRight,
   FaProjectDiagram,
 } from "react-icons/fa";
@@ -441,7 +441,20 @@ export default function GraphChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <span className={`ml-auto px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
+          <button
+            onClick={() => {
+              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
+              progress[challenge.id] = true;
+              progress[`${challenge.id}_title`] = challenge.title;
+              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+              localStorage.setItem("algo_progress", JSON.stringify(progress));
+              alert("Marked as solved!");
+            }}
+            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+          >
+            <FaCheck /> Mark as Solved ✅
+          </button>
+          <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>
           <span className="flex items-center gap-1.5 text-xs font-mono text-slate-400">

--- a/src/components/GreedyChallengeLayout.tsx
+++ b/src/components/GreedyChallengeLayout.tsx
@@ -53,7 +53,20 @@ export default function GreedyChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <span className={`ml-auto px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
+          <button
+            onClick={() => {
+              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
+              progress[challenge.id] = true;
+              progress[`${challenge.id}_title`] = challenge.title;
+              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+              localStorage.setItem("algo_progress", JSON.stringify(progress));
+              alert("Marked as solved!");
+            }}
+            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+          >
+            <FaCheck /> Mark as Solved ✅
+          </button>
+          <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>
           <span className="flex items-center gap-1.5 text-xs font-mono text-slate-400">

--- a/src/components/GreedyChallengeLayout.tsx
+++ b/src/components/GreedyChallengeLayout.tsx
@@ -53,19 +53,19 @@ export default function GreedyChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <button
-            onClick={() => {
-              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
-              progress[challenge.id] = true;
-              progress[`${challenge.id}_title`] = challenge.title;
-              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
-              localStorage.setItem("algo_progress", JSON.stringify(progress));
-              alert("Marked as solved!");
-            }}
-            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
-          >
-            <FaCheck /> Mark as Solved ✅
-          </button>
+<button
+  onClick={() => {
+    const progress = readAlgoProgress();
+    progress[challenge.id] = true;
+    progress[`${challenge.id}_title`] = challenge.title;
+    progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+    writeAlgoProgress(progress);
+    alert("Marked as solved!");
+  }}
+  className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+>
+  <FaCheck /> Mark as Solved ✅
+</button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>

--- a/src/components/SortingChallengeLayout.tsx
+++ b/src/components/SortingChallengeLayout.tsx
@@ -53,7 +53,20 @@ export default function SortingChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <span className={`ml-auto px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
+          <button
+            onClick={() => {
+              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
+              progress[challenge.id] = true;
+              progress[`${challenge.id}_title`] = challenge.title;
+              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+              localStorage.setItem("algo_progress", JSON.stringify(progress));
+              alert("Marked as solved!");
+            }}
+            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+          >
+            <FaCheck /> Mark as Solved ✅
+          </button>
+          <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>
           <span className="flex items-center gap-1.5 text-xs font-mono text-slate-400">

--- a/src/components/SortingChallengeLayout.tsx
+++ b/src/components/SortingChallengeLayout.tsx
@@ -53,19 +53,19 @@ export default function SortingChallengeLayout({ challenge }: Props) {
           <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
             {challenge.title}
           </span>
-          <button
-            onClick={() => {
-              const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
-              progress[challenge.id] = true;
-              progress[`${challenge.id}_title`] = challenge.title;
-              progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
-              localStorage.setItem("algo_progress", JSON.stringify(progress));
-              alert("Marked as solved!");
-            }}
-            className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
-          >
-            <FaCheck /> Mark as Solved ✅
-          </button>
+<button
+  onClick={() => {
+    const progress = readAlgoProgress();
+    progress[challenge.id] = true;
+    progress[`${challenge.id}_title`] = challenge.title;
+    progress[`${challenge.id}_updatedAt`] = new Date().toISOString();
+    writeAlgoProgress(progress);
+    alert("Marked as solved!");
+  }}
+  className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+>
+  <FaCheck /> Mark as Solved ✅
+</button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}
           </span>

--- a/src/components/TreeChallenge/ChallengeHeader.tsx
+++ b/src/components/TreeChallenge/ChallengeHeader.tsx
@@ -29,19 +29,19 @@ export default function ChallengeHeader({ id, title, difficulty, timeLimit }: Ch
       <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
         {title}
       </span>
-      <button
-        onClick={() => {
-          const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
-          progress[id] = true;
-          progress[`${id}_title`] = title;
-          progress[`${id}_updatedAt`] = new Date().toISOString();
-          localStorage.setItem("algo_progress", JSON.stringify(progress));
-          alert("Marked as solved!");
-        }}
-        className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
-      >
-        <FaCheck /> Mark as Solved ✅
-      </button>
+<button
+  onClick={() => {
+    const progress = readAlgoProgress();
+    progress[id] = true;
+    progress[`${id}_title`] = title;
+    progress[`${id}_updatedAt`] = new Date().toISOString();
+    writeAlgoProgress(progress);
+    alert("Marked as solved!");
+  }}
+  className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+>
+  <FaCheck /> Mark as Solved ✅
+</button>
       <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[difficulty]}`}>
         {difficulty}
       </span>

--- a/src/components/TreeChallenge/ChallengeHeader.tsx
+++ b/src/components/TreeChallenge/ChallengeHeader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "@docusaurus/Link";
-import { FaArrowLeft, FaChevronRight, FaClock } from "react-icons/fa";
+import { FaArrowLeft, FaChevronRight, FaClock, FaCheck } from "react-icons/fa";
 import type { TreeChallenge } from "../../data/treeChallengesData";
 
 const DIFF_COLORS = {
@@ -10,12 +10,13 @@ const DIFF_COLORS = {
 };
 
 interface ChallengeHeaderProps {
+  id: string;
   title: string;
   difficulty: TreeChallenge["difficulty"];
   timeLimit: string;
 }
 
-export default function ChallengeHeader({ title, difficulty, timeLimit }: ChallengeHeaderProps) {
+export default function ChallengeHeader({ id, title, difficulty, timeLimit }: ChallengeHeaderProps) {
   return (
     <div className="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800 px-6 py-3 flex items-center gap-4">
       <Link
@@ -28,7 +29,20 @@ export default function ChallengeHeader({ title, difficulty, timeLimit }: Challe
       <span className="text-slate-700 dark:text-slate-300 text-sm font-mono font-bold truncate">
         {title}
       </span>
-      <span className={`ml-auto px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[difficulty]}`}>
+      <button
+        onClick={() => {
+          const progress = JSON.parse(localStorage.getItem("algo_progress") || "{}");
+          progress[id] = true;
+          progress[`${id}_title`] = title;
+          progress[`${id}_updatedAt`] = new Date().toISOString();
+          localStorage.setItem("algo_progress", JSON.stringify(progress));
+          alert("Marked as solved!");
+        }}
+        className="ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors cursor-pointer"
+      >
+        <FaCheck /> Mark as Solved ✅
+      </button>
+      <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[difficulty]}`}>
         {difficulty}
       </span>
       <span className="flex items-center gap-1.5 text-xs font-mono text-slate-400">

--- a/src/components/TreeChallenge/index.tsx
+++ b/src/components/TreeChallenge/index.tsx
@@ -36,6 +36,7 @@ export default function TreeChallengeLayout({ challenge }: Props) {
       <div className="min-h-screen bg-slate-50 dark:bg-[#0b0f19] flex flex-col">
         {/* Navigation Info Bar */}
         <ChallengeHeader 
+          id={challenge.id}
           title={challenge.title} 
           difficulty={challenge.difficulty} 
           timeLimit={challenge.timeLimit} 


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR connects the challenge pages with the existing Profile progress system by introducing a "Mark as Solved ✅" action across all reusable challenge layouts.

Previously, src/pages/profile.tsx read challenge completion data from algo_progress in localStorage, but no challenge page ever wrote to this storage. As a result, the Profile page always displayed 0 Challenges Solved, regardless of the user's activity.

This update bridges that gap by recording completed challenges using the exact schema already expected by the Profile page.

Fixes #3053 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
