### PR TITLE
chore: clean up dead Chatrace CSS classes (closes #2845)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -247,22 +247,6 @@ html[data-theme='dark'] header.doc-header-banner {
   background-color: #000;
 }
 
-.ktt10-btn {
-  position: absolute;
-  bottom: 0;
-  left: 0.5rem;
-  background-color: #3b82f6;
-  color: #fff;
-  cursor: pointer;
-  transition: background-color 0.3s ease;
-}
-
-.ktt10-flt {
-  position: fixed;
-  bottom: 1rem;
-  left: 1rem;
-  z-index: 1000;
-}
 
 button {
   cursor: pointer;


### PR DESCRIPTION
### Summary
The commented-out `useEffect` block for the Chatrace chatbot integration in `src/pages/index.js` was previously removed in commit 027fbfdb98e47a07905a0ec26a1ce2e7b32216e2. 

However, the styling rules for the defunct Chatrace classes (`.ktt10-btn` and `.ktt10-flt`) were left behind in `src/css/custom.css`. This PR cleans up those remaining dead CSS rules.

### Changes
- **Modified** [src/css/custom.css](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/css/custom.css): Removed unused `.ktt10-btn` and `.ktt10-flt` style definitions.

Closes #2845
