### PR TITLE
fix: remove incompatible amp-auto-ads script from homepage and books page

### DIFF
--- a/src/pages/books/index.tsx
+++ b/src/pages/books/index.tsx
@@ -407,11 +407,6 @@ export default function Book(): JSX.Element {
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5832817025080991"
           crossOrigin="anonymous"
          />
-        <script
-          async
-          custom-element="amp-auto-ads"
-          src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"
-         />
         <meta name="google-adsense-account" content="ca-pub-5832817025080991" />
       </Head>
       <main className="margin-vert--lg">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -22,11 +22,6 @@ export default function Home() {
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5832817025080991"
           crossorigin="anonymous"
         />
-        <script
-          async
-          custom-element="amp-auto-ads"
-          src="https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js"
-        />
         <meta name='impact-site-verification' value='1e9bf198-a4f7-4132-b77d-46b34e45f6ad' />
       </Head>
       <main>


### PR DESCRIPTION
## Description

This PR resolves #2840 by removing the `amp-auto-ads` script from the homepage and the books page.

Since this website is a standard React/Docusaurus site and not an AMP (Accelerated Mobile Pages) site, loading this script is redundant and incompatible. Removing it improves network performance by preventing unnecessary CDN requests and prevents potential browser console warnings/errors.

AdSense ads are already properly loaded using the standard Google AdSense scripts on these pages.

## Related Issues
Closes #2840

## Affected Files
- `src/pages/index.js`
- `src/pages/books/index.tsx`

## Checklist
- [x] AMP Auto-Ads script removed
- [x] Tested and verified that no other components depend on the script
