### PR TITLE
fix: GitHub repository metrics fetch failing due to CORS policy

### DIFF
--- a/src/components/Homepage/HeroSection.tsx
+++ b/src/components/Homepage/HeroSection.tsx
@@ -8,7 +8,7 @@ const HeroSection = () => {
 
   useEffect(() => {
     // Corrected target path pointing directly to the official GitHub Developer REST API endpoint
-    fetch("https://github.com/ajay-dhangar/algo")
+    fetch("https://api.github.com/repos/ajay-dhangar/algo")
       .then((res) => {
         if (!res.ok) throw new Error("Network response was not OK");
         return res.json();


### PR DESCRIPTION
### Summary of Changes
Fixes the CORS policy failure when trying to fetch live GitHub repository metrics (stars and forks count) on the homepage.

### Root Cause
The homepage was attempting to make a `fetch()` request directly to the HTML page of the repository (`https://github.com/ajay-dhangar/algo`). Because GitHub repository web pages do not permit cross-origin requests, the browser blocked the request under the CORS policy, resulting in a `TypeError: Failed to fetch` console error and preventing live metrics from loading.

### Solution
Updated the fetch request in `src/components/Homepage/HeroSection.tsx` to use the official GitHub REST API endpoint:
`https://api.github.com/repos/ajay-dhangar/algo`

This endpoint allows cross-origin requests (supports CORS) and returns the repository details in JSON format containing `stargazers_count` and `forks_count`.

---

### Files Changed
* **[HeroSection.tsx](file:///d:/Projects/github/Gssoc/algo-Trushi/src/components/Homepage/HeroSection.tsx)**: Changed the URL requested in the `fetch` statement to the GitHub API endpoint.

### Verification Done
* Ran `npm install` to update local workspace packages.
* Ran `npm run build` to compile the website, ensuring that there are no syntax, typescript, or build errors.
