### PR TITLE
feat: Add Complexity Cheat Sheet Quick-Reference Cards for Each Data Structure (#3024)

### DIFF
--- a/docs/extra/Queue/circular-queue.md
+++ b/docs/extra/Queue/circular-queue.md
@@ -370,18 +370,16 @@ int main() {
 }
 
 ```
-### Complexity
+### Complexity Cheat Sheet
 
-- **Time Complexity**:
-
-  - Enqueue: $O(1)$
-  - Dequeue: $O(1)$
-  - Peek: $O(1)$
-  - isEmpty: $O(1)$
-  - isFull: $O(1)$
-  - Size: $O(1)$
-
-- **Space Complexity**: $O(n)$, where $n$ is the number of elements that can be stored in the circular queue.
+| Operation | Best Case | Average Case | Worst Case | Space Complexity |
+| :--- | :--- | :--- | :--- | :--- |
+| **Enqueue** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Dequeue** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Peek** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **isEmpty / isFull** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Size** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Overall Queue Storage** | - | - | - | $O(n)$ |
 
 ### Example
 

--- a/docs/extra/Queue/priority-queue.md
+++ b/docs/extra/Queue/priority-queue.md
@@ -317,17 +317,15 @@ public class PriorityQueue {
 }
 ```
 
-### Complexity
+### Complexity Cheat Sheet
 
-- **Time Complexity**:
-
-  - Insert: $O(n \log n)$ (due to sorting)
-  - Remove: $O(n)$ (removing the first element)
-  - Peek: $O(1)$
-  - isEmpty: $O(1)$
-  - Size: $O(1)$
-
-- **Space Complexity**: $O(n)$, where $n$ is the number of elements in the priority queue.
+| Operation | Binary Heap | Unsorted Array | Sorted Array | Space Complexity |
+| :--- | :--- | :--- | :--- | :--- |
+| **Insert / Enqueue** | $O(\log n)$ | $O(1)$ | $O(n)$ | $O(1)$ |
+| **Delete Min/Max (Extract)** | $O(\log n)$ | $O(n)$ | $O(1)$ | $O(1)$ |
+| **Peek (Get Min/Max)** | $O(1)$ | $O(n)$ | $O(1)$ | $O(1)$ |
+| **isEmpty / Size** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Overall Queue Storage** | - | - | - | $O(n)$ |
 
 ### Example
 

--- a/docs/extra/Stack/introduction-to-stack.md
+++ b/docs/extra/Stack/introduction-to-stack.md
@@ -286,18 +286,16 @@ public class Stack {
 }
 ```
 
-### Complexity
+### Complexity Cheat Sheet
 
-- **Time Complexity**:
-
-  - Push: $O(1)$
-  - Pop: $O(1)$
-  - Peek: $O(1)$
-  - isEmpty: $O(1)$
-  - isFull: $O(1)$
-  - Size: $O(1)$
-
-- **Space Complexity**: $O(n)$, where $n$ is the number of elements that can be stored in the stack.
+| Operation | Best Case | Average Case | Worst Case | Space Complexity |
+| :--- | :--- | :--- | :--- | :--- |
+| **Push** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Pop** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Peek / Top** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **isEmpty / isFull** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Size** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Overall Storage** | - | - | - | $O(n)$ |
 
 ### Example
 

--- a/docs/extra/basic-dsa/array/arrays-dsa.md
+++ b/docs/extra/basic-dsa/array/arrays-dsa.md
@@ -552,6 +552,18 @@ The maximum and minimum elements in an array can be found by iterating through t
 :::
 
 
+## Complexity Cheat Sheet
+
+| Operation | Best Case | Average Case | Worst Case | Space Complexity |
+| :--- | :--- | :--- | :--- | :--- |
+| **Access (by index)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Search (Unsorted)** | $O(1)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Search (Sorted)** | $O(1)$ | $O(\log n)$ | $O(\log n)$ | $O(1)$ |
+| **Insertion (End)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Insertion (Start/Middle)** | $O(n)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Deletion (End)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Deletion (Start/Middle)** | $O(n)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+
 ## Conclusion
 
 In this tutorial, we learned about arrays in data structures and algorithms. We learned how to declare an array, access an array, update an array, find the length of an array, iterate through an array, and find the maximum and minimum elements in an array. Arrays are an important data structure that is used in many algorithms and data structures.

--- a/docs/extra/basic-dsa/array/arrays-dsa.md
+++ b/docs/extra/basic-dsa/array/arrays-dsa.md
@@ -559,7 +559,7 @@ The maximum and minimum elements in an array can be found by iterating through t
 | **Access (by index)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
 | **Search (Unsorted)** | $O(1)$ | $O(n)$ | $O(n)$ | $O(1)$ |
 | **Search (Sorted)** | $O(1)$ | $O(\log n)$ | $O(\log n)$ | $O(1)$ |
-| **Insertion (End)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Insertion (End)** | $O(1)$ | $O(1)$ | $O(n)$ | $O(1)$ |
 | **Insertion (Start/Middle)** | $O(n)$ | $O(n)$ | $O(n)$ | $O(1)$ |
 | **Deletion (End)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
 | **Deletion (Start/Middle)** | $O(n)$ | $O(n)$ | $O(n)$ | $O(1)$ |

--- a/docs/extra/linked-list/doubly-linked-list.md
+++ b/docs/extra/linked-list/doubly-linked-list.md
@@ -403,16 +403,17 @@ public class Main {
 
 ```
 
-### Complexity
+### Complexity Cheat Sheet
 
-- **Time Complexity**:
-
-  - Insertion : $O(1)$
-  - Deletion: $O(1)$
-  - Search: $O(n)$	
-  - Traversal: $O(n)$
-
-- **Space Complexity**: $O(1)$
+| Operation | Best Case | Average Case | Worst Case | Space Complexity |
+| :--- | :--- | :--- | :--- | :--- |
+| **Insertion (Head / Tail with pointer)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Insertion (Given Node)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Deletion (Head / Tail with pointer)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Deletion (Given Node Pointer)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Search (By Value)** | $O(1)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Traversal (Forward / Backward)** | $O(n)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Overall Storage** | - | - | - | $O(n)$ |
 
 
 ### Conclusion

--- a/docs/extra/linked-list/introduction-to-linked-list.md
+++ b/docs/extra/linked-list/introduction-to-linked-list.md
@@ -430,17 +430,17 @@ class LinkedList {
 }
 ```
 
-### Complexity
+### Complexity Cheat Sheet
 
-- **Time Complexity**:
-
-  - Insertion at the Beginning: $O(1)$
-  - Insertion at the End: $O(n)$
-  - Deletion by Value: $O(n)$
-  - Search for a Node by Value: $O(n)$
-  - Traversal (Print the List): $O(n)$
-
-- **Space Complexity**: $O(n)$, where $n$ is the number of nodes.
+| Operation | Best Case | Average Case | Worst Case | Space Complexity |
+| :--- | :--- | :--- | :--- | :--- |
+| **Insertion (Beginning)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Insertion (End)** | $O(1)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Deletion (Beginning)** | $O(1)$ | $O(1)$ | $O(1)$ | $O(1)$ |
+| **Deletion (By Value / End)** | $O(1)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Search (By Value)** | $O(1)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Traversal** | $O(n)$ | $O(n)$ | $O(n)$ | $O(1)$ |
+| **Overall Storage** | - | - | - | $O(n)$ |
 
 ### Example
 


### PR DESCRIPTION
## Pull Request

### Description
Adds standardized Complexity Cheat Sheet quick-reference tables to Data Structure documentation pages (e.g. Array and Circular Queue). The tables summarize Best Case, Average Case, Worst Case time complexities along with Space Complexity using KaTeX notation.

Fixes #3024

### Type of change

- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas