### PR TITLE
Add Missing Visualizers to the Visualization Hub

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -194,6 +194,44 @@ const config = {
                 to: "quiz-solutions",
                 label: "Compiled Solutions",
               },
+              {
+                type: "html",
+                value:
+                  '<hr style="margin: 0.4rem 0; border: none; border-top: 1px solid var(--ifm-contents-border-color, #e2e8f0); opacity: 0.6;"/>',
+              },
+              {
+                type: "html",
+                value:
+                  '<div style="padding: 0.25rem 0.75rem; font-family: var(--ifm-font-family-monospace); font-size: 10px; font-weight: 800; tracking-spacing: 0.05em; text-transform: uppercase; color: var(--ifm-color-primary);">Visualizers</div>',
+              },
+              {
+                to: "visualization",
+                label: "Algorithm Visualizer",
+              },
+              {
+                to: "backtracking-visualizer",
+                label: "Backtracking & Grid Solver",
+              },
+              {
+                to: "bitwise-visualizer",
+                label: "Bitwise Operations",
+              },
+              {
+                to: "n-queens-visualizer",
+                label: "N-Queens Visualizer",
+              },
+              {
+                to: "largest-rectangle-visualizer",
+                label: "Largest Rectangle (Histogram)",
+              },
+              {
+                to: "maximal-rectangle-visualizer",
+                label: "Maximal Rectangle (Matrix)",
+              },
+              {
+                to: "maximum-building-height-visualizer",
+                label: "Max Building Height",
+              },
             ],
           },
           {
@@ -240,30 +278,6 @@ const config = {
               {
                 to: "visualization",
                 label: "Algorithm Visualizer",
-              },
-              {
-                to: "backtracking-visualizer",
-                label: "Backtracking & Grid Solver",
-              },
-              {
-                to: "bitwise-visualizer",
-                label: "Bitwise Operations",
-              },
-              {
-                to: "n-queens-visualizer",
-                label: "N-Queens Visualizer",
-              },
-              {
-                to: "largest-rectangle-visualizer",
-                label: "Largest Rectangle (Histogram)",
-              },
-              {
-                to: "maximal-rectangle-visualizer",
-                label: "Maximal Rectangle (Matrix)",
-              },
-              {
-                to: "maximum-building-height-visualizer",
-                label: "Max Building Height",
               },
               {
                 to: "stories",


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR adds six existing algorithm visualizers to the Visualization Hub, making them discoverable through the application's primary visualization catalog.

While the visualizer pages were already fully implemented and accessible via their routes, they were not included in the Visualization Hub. This made these educational tools difficult to discover unless users already knew their URLs.

This PR updates the Visualization Hub to include cards for all six visualizers in their appropriate categories.

Fixes #3146 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
