### PR TITLE
test: wrap user interactions in act for ProblemFilterGrid tests

### DIFF
--- a/src/__tests__/components/ProblemFilterGrid.test.tsx
+++ b/src/__tests__/components/ProblemFilterGrid.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '../testUtils';
+import { act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ProblemFilterGrid from '../../components/ProblemFilterGrid';
 import type { DsaProblemsIndex } from '../../data/dsaProblemsTypes';
@@ -59,7 +60,9 @@ describe('ProblemFilterGrid', () => {
     const user = userEvent.setup();
     render(<ProblemFilterGrid data={mockData} />);
 
-    await user.click(screen.getByRole('button', { name: 'Easy' }));
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Easy' }));
+    });
 
     expect(screen.getByText('Two Sum')).toBeInTheDocument();
     expect(screen.queryByText('Course Schedule')).not.toBeInTheDocument();
@@ -70,7 +73,9 @@ describe('ProblemFilterGrid', () => {
     const user = userEvent.setup();
     render(<ProblemFilterGrid data={mockData} />);
 
-    await user.click(screen.getByRole('button', { name: 'Graph' }));
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Graph' }));
+    });
 
     expect(screen.getByText('Course Schedule')).toBeInTheDocument();
     expect(screen.queryByText('Two Sum')).not.toBeInTheDocument();
@@ -81,9 +86,11 @@ describe('ProblemFilterGrid', () => {
     const user = userEvent.setup();
     render(<ProblemFilterGrid data={mockData} />);
 
-    await user.click(screen.getByRole('button', { name: 'Hard' }));
-    await user.click(screen.getByRole('button', { name: 'DP' }));
-    await user.type(screen.getByPlaceholderText(/search problems/i), 'Edit');
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: 'Hard' }));
+      await user.click(screen.getByRole('button', { name: 'DP' }));
+      await user.type(screen.getByPlaceholderText(/search problems/i), 'Edit');
+    });
 
     expect(screen.getByText('Edit Distance')).toBeInTheDocument();
     expect(screen.queryByText('Two Sum')).not.toBeInTheDocument();
@@ -94,11 +101,15 @@ describe('ProblemFilterGrid', () => {
     const user = userEvent.setup();
     render(<ProblemFilterGrid data={mockData} />);
 
-    await user.type(screen.getByPlaceholderText(/search problems/i), 'nonexistent problem');
+    await act(async () => {
+      await user.type(screen.getByPlaceholderText(/search problems/i), 'nonexistent problem');
+    });
 
     expect(screen.getByText(/no problems match these filters/i)).toBeInTheDocument();
 
-    await user.click(screen.getAllByRole('button', { name: /clear filters/i })[0]);
+    await act(async () => {
+      await user.click(screen.getAllByRole('button', { name: /clear filters/i })[0]);
+    });
 
     expect(screen.getByText('Two Sum')).toBeInTheDocument();
     expect(screen.getByText('Course Schedule')).toBeInTheDocument();


### PR DESCRIPTION
# 📥 Pull Request

## Description

This PR fixes the failing Jest test suite caused by React `act(...)` warnings in `ProblemFilterGrid.test.tsx`.

The issue occurred because `userEvent` interactions triggered React state updates that were not wrapped in `act(...)`, resulting in warnings and CI failures. This PR wraps the relevant `userEvent` interactions with `act(...)` from `@testing-library/react`, ensuring that state updates are flushed before assertions are executed.

### Changes Made

- Wrapped state-triggering `userEvent` interactions in `ProblemFilterGrid.test.tsx` with `act(...)`.
- Imported `act` from `@testing-library/react`.
- Verified that the test suite runs without `act(...)` warnings.

### Verification

```bash
npm test -- ProblemFilterGrid.test.tsx
```

- ✅ All 5 tests passed successfully.
- ✅ No React `act(...)` warnings were reported.

**Fixes #3306 **

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added/updated tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
