### PR TITLE
fix(storage): correctly parse quiz IDs for user IDs containing underscores

### DIFF
--- a/src/__tests__/utils/safeStorage.test.ts
+++ b/src/__tests__/utils/safeStorage.test.ts
@@ -7,6 +7,7 @@ import {
   markChallengeSolved,
   saveQuizAttemptLocal,
   getUserId,
+  extractQuizIdFromStorageKey,
   getAchievementSnapshot,
 } from '../../utils/safeStorage';
 
@@ -14,6 +15,40 @@ describe('safeStorage', () => {
   beforeEach(() => {
     localStorage.clear();
     jest.clearAllMocks();
+  });
+
+  describe('extractQuizIdFromStorageKey', () => {
+    test('extracts quiz ID for normal user ID without underscores', () => {
+      expect(extractQuizIdFromStorageKey('quiz_attempts_user1_arrays')).toBe('arrays');
+      expect(extractQuizIdFromStorageKey('quiz_attempts_john_graphs')).toBe('graphs');
+    });
+
+    test('extracts quiz ID for user ID with one underscore', () => {
+      expect(extractQuizIdFromStorageKey('quiz_attempts_john_doe_arrays')).toBe('arrays');
+      expect(extractQuizIdFromStorageKey('quiz_attempts_user_123_sorting')).toBe('sorting');
+    });
+
+    test('extracts quiz ID for user ID with multiple underscores', () => {
+      expect(extractQuizIdFromStorageKey('quiz_attempts_guest_user_1_arrays')).toBe('arrays');
+      expect(extractQuizIdFromStorageKey('quiz_attempts_usr_test_account_99_recursion')).toBe('recursion');
+    });
+
+    test('extracts hyphenated quiz IDs and normalizes aliases', () => {
+      expect(extractQuizIdFromStorageKey('quiz_attempts_user_123_binary-trees')).toBe('binary-trees');
+      expect(extractQuizIdFromStorageKey('quiz_attempts_guest_user_1_binary-tree')).toBe('binary-trees');
+      expect(extractQuizIdFromStorageKey('quiz_attempts_john_doe_priority-queues')).toBe('priority-queues');
+    });
+
+    test('handles unknown quiz IDs safely', () => {
+      expect(extractQuizIdFromStorageKey('quiz_attempts_user_123_custom-algo-quiz')).toBe('custom-algo-quiz');
+    });
+
+    test('handles malformed keys and empty inputs without throwing', () => {
+      expect(extractQuizIdFromStorageKey('')).toBeNull();
+      expect(extractQuizIdFromStorageKey('quiz_attempts_')).toBeNull();
+      expect(extractQuizIdFromStorageKey('quiz_attempts_user_')).toBe('user');
+      expect(extractQuizIdFromStorageKey('invalid_prefix_key')).toBeNull();
+    });
   });
 
   describe('safeJsonParse', () => {
@@ -134,6 +169,27 @@ describe('safeStorage', () => {
       expect(snapshot.completedTopics).toContain('topic-1');
       expect(snapshot.completedTopics).toContain('topic-2');
       expect(snapshot.totalQuizzesAttempted).toBeGreaterThanOrEqual(1);
+    });
+
+    test('correctly calculates quiz stats for user IDs containing underscores and hyphenated quiz IDs', () => {
+      saveQuizAttemptLocal('john_doe', 'arrays', { score: 10 });
+      saveQuizAttemptLocal('guest_user_1', 'binary-tree', { score: 12 }); // 12/12 = 100% (mastered)
+
+      const snapshot = getAchievementSnapshot();
+      expect(snapshot.totalQuizzesAttempted).toBe(2);
+      expect(snapshot.quizzesPassed).toBe(2);
+      expect(snapshot.quizzesMastered).toBe(2);
+    });
+
+    test('handles empty storage and malformed keys gracefully', () => {
+      localStorage.clear();
+      localStorage.setItem('quiz_attempts_', JSON.stringify([{ score: 10 }]));
+      localStorage.setItem('quiz_attempts_user_', JSON.stringify([{ score: 10 }]));
+      localStorage.setItem('corrupt_quiz_key', 'invalid json');
+
+      const snapshot = getAchievementSnapshot();
+      expect(snapshot.totalQuizzesAttempted).toBe(1); // 'user' fallback
+      expect(snapshot.quizzesPassed).toBe(1);
     });
   });
 });

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -228,6 +228,35 @@ export interface QuizAttemptRecord {
   completedAt?: string;
 }
 
+export function extractQuizIdFromStorageKey(key: string): string | null {
+  if (!key || !key.startsWith('quiz_attempts_')) return null;
+  const raw = key.slice('quiz_attempts_'.length).replace(/_+$/, '');
+  if (!raw) return null;
+
+  const knownCandidates = [
+    ...ALL_QUIZ_IDS,
+    ...Object.keys(QUIZ_ID_ALIASES),
+    ...Object.values(QUIZ_ID_ALIASES),
+  ];
+
+  let bestMatch: string | null = null;
+  for (const candidate of knownCandidates) {
+    if (raw === candidate || raw.endsWith('_' + candidate)) {
+      if (!bestMatch || candidate.length > bestMatch.length) {
+        bestMatch = candidate;
+      }
+    }
+  }
+
+  if (bestMatch) {
+    return normalizeQuizId(bestMatch);
+  }
+
+  const lastUnderscoreIndex = raw.lastIndexOf('_');
+  const trailing = lastUnderscoreIndex !== -1 ? raw.slice(lastUnderscoreIndex + 1) : raw;
+  return trailing ? normalizeQuizId(trailing) : null;
+}
+
 function computeQuizStats(): { passed: number; mastered: number; attempted: number } {
   if (typeof window === 'undefined' || !window.localStorage) {
     return { passed: 0, mastered: 0, attempted: 0 };
@@ -246,9 +275,9 @@ function computeQuizStats(): { passed: number; mastered: number; attempted: numb
     const attempts = safeJsonParse<QuizAttemptRecord[]>(key, []);
     if (!Array.isArray(attempts) || attempts.length === 0) continue;
 
-    // Extract quiz id from key: quiz_attempts_<uid>_<quizId>
-    const parts = key.replace('quiz_attempts_', '').split('_');
-    const quizId = normalizeQuizId(parts.slice(1).join('_') || parts[0]);
+    const quizId = extractQuizIdFromStorageKey(key);
+    if (!quizId) continue;
+
     const total = QUIZ_QUESTION_COUNTS[quizId] ?? 10;
 
     const bestScore = Math.max(...attempts.map((a) => (typeof a.score === 'number' ? a.score : 0)));


### PR DESCRIPTION



This PR fixes a data corruption bug in `computeQuizStats()` ([`src/utils/safeStorage.ts`](file:///Users/tanvitiwari/algo/src/utils/safeStorage.ts)) where user IDs containing underscores were incorrectly split during `localStorage` key parsing.

**Problem & Context:**  
Storage keys generated by `saveQuizAttemptLocal` follow the format `quiz_attempts_<userId>_<quizId>`. Previously, `computeQuizStats()` used `key.replace('quiz_attempts_', '').split('_')`, assuming `userId` contained no underscores. When a user ID contained an underscore (such as `john_doe`, `guest_user_1`, or Supabase account handles), `.split('_')` extracted corrupted quiz IDs (e.g. `"doe_arrays"` instead of `"arrays"`). This caused lookup failures in `QUIZ_QUESTION_COUNTS`, miscalculating achievement snapshots (`quizzesPassed`, `quizzesMastered`, `totalQuizzesAttempted`), streak counts, and progress metrics.

**Solution:**  
Introduced `extractQuizIdFromStorageKey(key)` which safely determines the `quizId` by checking candidate key suffixes against canonical quiz IDs (`ALL_QUIZ_IDS`) and aliases (`QUIZ_ID_ALIASES`), using a last-underscore fallback for custom IDs. Added comprehensive unit and integration tests in `src/__tests__/utils/safeStorage.test.ts` covering user IDs with single/multiple underscores, hyphenated quiz IDs, malformed storage keys, and empty storage.

Fixes # (issue number)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

closes #3309
