### PR TITLE
fix(doccard): use clsx for CardLink className composition

### DIFF
--- a/src/__tests__/__mocks__/docusaurusMock.js
+++ b/src/__tests__/__mocks__/docusaurusMock.js
@@ -1,23 +1,39 @@
 const React = require('react');
 
-module.exports = {
-  Link: ({ to, children, ...props }) =>
-    React.createElement('a', { href: to, ...props }, children),
-  BrowserOnly: ({ children, fallback }) => {
-    if (typeof children === 'function') {
-      try {
-        const res = children();
-        if (res) return res;
-      } catch {
-        return fallback;
-      }
+const Link = ({ to, children, ...props }) =>
+  React.createElement('a', { href: to, ...props }, children);
+
+const BrowserOnly = ({ children, fallback }) => {
+  if (typeof children === 'function') {
+    try {
+      const res = children();
+      if (res) return res;
+    } catch {
+      return fallback;
     }
-    return fallback;
-  },
+  }
+  return fallback;
+};
+
+const Translate = ({ children }) => children;
+const translate = ({ message }) => message;
+
+module.exports = {
+  __esModule: true,
+  default: Translate,
+  Translate,
+  translate,
+  Link,
+  BrowserOnly,
+  useColorMode: () => ({ colorMode: 'dark', setColorMode: () => {} }),
   useDocusaurusContext: () => ({
     siteConfig: {
       title: 'Algo',
       customFields: { apiBaseUrl: 'https://api.example.com' },
     },
   }),
+  useDocById: () => ({ description: 'Doc description' }),
+  findFirstSidebarItemLink: (item) => item.href || '/docs/fallback',
+  extractLeadingEmoji: (label) => ({ emoji: undefined, rest: label }),
+  useDocCardDescriptionCategoryItemsPlural: () => (count) => `${count} items`,
 };

--- a/src/__tests__/__mocks__/styleMock.js
+++ b/src/__tests__/__mocks__/styleMock.js
@@ -1,1 +1,8 @@
-module.exports = {};
+const handler = {
+  get: (target, prop) => {
+    if (prop === '__esModule') return true;
+    if (prop === 'default') return new Proxy({}, handler);
+    return typeof prop === 'string' ? prop : undefined;
+  },
+};
+module.exports = new Proxy({}, handler);

--- a/src/__tests__/__mocks__/themeMock.js
+++ b/src/__tests__/__mocks__/themeMock.js
@@ -1,5 +1,10 @@
 const React = require('react');
+
+const Layout = ({ children, title }) =>
+  React.createElement('div', { 'data-testid': 'docusaurus-layout', 'data-title': title }, children);
+
 module.exports = {
-  Layout: ({ children, title }) =>
-    React.createElement('div', { 'data-testid': 'docusaurus-layout', 'data-title': title }, children),
+  __esModule: true,
+  default: Layout,
+  Layout,
 };

--- a/src/__tests__/declarations.d.ts
+++ b/src/__tests__/declarations.d.ts
@@ -1,3 +1,12 @@
+declare module '@theme/DocCard' {
+  import type { PropSidebarItemCategory, PropSidebarItemLink } from '@docusaurus/plugin-content-docs';
+  import React from 'react';
+  export interface Props {
+    item: PropSidebarItemLink | PropSidebarItemCategory;
+  }
+  export default function DocCard(props: Props): React.ReactNode;
+}
+
 declare module '@theme/Layout' {
   import React from 'react';
   export interface Props {

--- a/src/__tests__/theme/DocCard.test.tsx
+++ b/src/__tests__/theme/DocCard.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DocCard from '../../theme/DocCard';
+import styles from '../../theme/DocCard/styles.module.css';
+import type { PropSidebarItemLink, PropSidebarItemCategory } from '@docusaurus/plugin-content-docs';
+
+describe('DocCard Component', () => {
+  test('CardLink applies styles.responsiveCardWrapper when item.className is undefined', () => {
+    const defaultLinkItem: PropSidebarItemLink = {
+      type: 'link',
+      label: 'Binary Search',
+      href: '/docs/binary-search',
+      docId: 'binary-search',
+    };
+
+    const { container } = render(<DocCard item={defaultLinkItem} />);
+    const wrapperDiv = container.firstElementChild as HTMLElement;
+
+    expect(wrapperDiv).toBeInTheDocument();
+    expect(wrapperDiv).toHaveClass(styles.responsiveCardWrapper);
+  });
+
+  test('CardCategory applies styles.responsiveCardWrapper when item.className is undefined', () => {
+    const defaultCategoryItem: PropSidebarItemCategory = {
+      type: 'category',
+      label: 'Algorithms',
+      href: '/docs/category/algorithms',
+      collapsed: false,
+      collapsible: true,
+      items: [],
+    };
+
+    const { container } = render(<DocCard item={defaultCategoryItem} />);
+    const wrapperDiv = container.firstElementChild as HTMLElement;
+
+    expect(wrapperDiv).toBeInTheDocument();
+    expect(wrapperDiv).toHaveClass(styles.responsiveCardWrapper);
+  });
+
+  test('CardLink composes both styles.responsiveCardWrapper and custom item.className when present', () => {
+    const customLinkItem: PropSidebarItemLink = {
+      type: 'link',
+      label: 'Array Data Structure',
+      href: '/docs/arrays',
+      docId: 'arrays',
+      className: 'custom-link-class',
+      description: 'Learn array operations and time complexities.',
+    };
+
+    const { container } = render(<DocCard item={customLinkItem} />);
+    const wrapperDiv = container.firstElementChild as HTMLElement;
+
+    expect(wrapperDiv).toBeInTheDocument();
+    expect(wrapperDiv).toHaveClass(styles.responsiveCardWrapper);
+    expect(wrapperDiv).toHaveClass('custom-link-class');
+  });
+
+  test('CardCategory composes both styles.responsiveCardWrapper and custom item.className when present', () => {
+    const customCategoryItem: PropSidebarItemCategory = {
+      type: 'category',
+      label: 'Data Structures',
+      href: '/docs/category/data-structures',
+      className: 'custom-category-class',
+      collapsed: false,
+      collapsible: true,
+      items: [
+        { type: 'link', label: 'Arrays', href: '/docs/arrays', docId: 'arrays' },
+      ],
+    };
+
+    const { container } = render(<DocCard item={customCategoryItem} />);
+    const wrapperDiv = container.firstElementChild as HTMLElement;
+
+    expect(wrapperDiv).toBeInTheDocument();
+    expect(wrapperDiv).toHaveClass(styles.responsiveCardWrapper);
+    expect(wrapperDiv).toHaveClass('custom-category-class');
+  });
+
+  test('CardLink wrapper class composition matches CardCategory behavior', () => {
+    const linkItem: PropSidebarItemLink = {
+      type: 'link',
+      label: 'Linked List',
+      href: '/docs/linked-list',
+      docId: 'linked-list',
+      className: 'shared-theme-class',
+    };
+
+    const categoryItem: PropSidebarItemCategory = {
+      type: 'category',
+      label: 'Linear Data Structures',
+      href: '/docs/category/linear',
+      className: 'shared-theme-class',
+      collapsed: false,
+      collapsible: true,
+      items: [],
+    };
+
+    const { container: linkContainer } = render(<DocCard item={linkItem} />);
+    const { container: categoryContainer } = render(<DocCard item={categoryItem} />);
+
+    const linkWrapper = linkContainer.firstElementChild as HTMLElement;
+    const categoryWrapper = categoryContainer.firstElementChild as HTMLElement;
+
+    expect(linkWrapper.className).toBe(categoryWrapper.className);
+    expect(linkWrapper).toHaveClass(styles.responsiveCardWrapper);
+    expect(linkWrapper).toHaveClass('shared-theme-class');
+  });
+});

--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -86,7 +86,7 @@ function CardCategory({ item }: { item: PropSidebarItemCategory }): ReactNode {
 function CardLink({ item }: { item: PropSidebarItemLink }): ReactNode {
   const doc = useDocById(item.docId ?? undefined);
   return (
-    <div className={styles.responsiveCardWrapper, item.className}>
+    <div className={clsx(styles.responsiveCardWrapper, item.className)}>
       <Layout
         item={item}
         href={item.href}


### PR DESCRIPTION

In `src/theme/DocCard/index.tsx`, the `CardLink` component composed its wrapper `className` using the JavaScript comma operator (`<div className={styles.responsiveCardWrapper, item.className}>`).

Because the JavaScript comma operator evaluates left-to-right and returns only the final operand, `styles.responsiveCardWrapper` was discarded. This caused document link cards to lose their responsive CSS grid layout wrapper rules (`display: flex`, `flex-direction: column`, `height: 100%`) while causing TypeScript to emit error `TS18007: JSX expressions may not use the comma operator`.

This PR replaces the comma operator with `clsx(styles.responsiveCardWrapper, item.className)`, matching the existing pattern in the neighboring `CardCategory` component. A dedicated unit test suite has been added in `src/__tests__/theme/DocCard.test.tsx`.

Fixes # (issue number)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

closes #3315