### PR TITLE
fix(theme): resolve circular type import in Info admonition wrapper

### DIFF
--- a/src/__tests__/theme/AdmonitionIconInfo.test.tsx
+++ b/src/__tests__/theme/AdmonitionIconInfo.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import InfoWrapper from '../../theme/Admonition/Icon/Info';
+
+jest.mock(
+  '@theme-original/Admonition/Icon/Info',
+  () => {
+    return function MockOriginalInfo(props: Record<string, unknown>) {
+      return <svg data-testid="original-info-icon" {...props} />;
+    };
+  },
+  { virtual: true }
+);
+
+describe('InfoWrapper', () => {
+  it('renders successfully and forwards props to original Info icon component', () => {
+    render(<InfoWrapper className="custom-icon-class" aria-hidden="true" />);
+
+    const icon = screen.getByTestId('original-info-icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass('custom-icon-class');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/src/theme/Admonition/Icon/Info.tsx
+++ b/src/theme/Admonition/Icon/Info.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Info from '@theme-original/Admonition/Icon/Info';
-import type InfoType from '@theme/Admonition/Icon/Info';
+import type InfoType from '@theme-original/Admonition/Icon/Info';
 import type {WrapperProps} from '@docusaurus/types';
 
 type Props = WrapperProps<typeof InfoType>;


### PR DESCRIPTION


This pull request resolves a circular type reference in the swizzled `Info` admonition icon component ([Info.tsx](file:///Users/tanvitiwari/algo/src/theme/Admonition/Icon/Info.tsx)).

#### Root Cause
`src/theme/Admonition/Icon/Info.tsx` was importing `type InfoType` from `@theme/Admonition/Icon/Info`. Because Docusaurus resolves `@theme/Admonition/Icon/Info` to the swizzled file itself, the component created a circular type reference resulting in TypeScript compiler errors:
- `TS2456: Type alias 'Props' circularly references itself.`
- `TS2502: 'props' is referenced directly or indirectly in its own type annotation.`

#### Fix & Context
- Updated `InfoType` import to derive from `@theme-original/Admonition/Icon/Info`.
- Preserved existing runtime behavior and prop forwarding.
- Added a unit test in `src/__tests__/theme/AdmonitionIconInfo.test.tsx` to verify component rendering and prop forwarding.
- Validated via `npx tsc --noEmit` (`TS2456` and `TS2502` resolved) and `npx jest src/__tests__/theme/AdmonitionIconInfo.test.tsx` (all tests passing).

Fixes # (issue number)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

closes #3317