### PR TITLE
feat: add shareable result cards for quiz scores

### DIFF
--- a/src/__tests__/components/QuizResultActions.test.tsx
+++ b/src/__tests__/components/QuizResultActions.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '../testUtils';
+import userEvent from '@testing-library/user-event';
+import QuizResultActions from '../../components/Quiz/QuizResultActions';
+
+jest.mock('../../utils/shareResultImage', () => ({
+  __esModule: true,
+  renderShareCardToPngBlob: jest.fn(async () => new Blob(['mock-png'], { type: 'image/png' })),
+}));
+
+describe('QuizResultActions', () => {
+  test('renders back link, retry, and share buttons', () => {
+    render(<QuizResultActions onRetry={jest.fn()} topic="Graph Algorithms" score={9} total={10} />);
+
+    expect(screen.getByRole('link', { name: /back to quizzes/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share result/i })).toBeInTheDocument();
+  });
+
+  test('calls onRetry when "Try Again" is clicked', async () => {
+    const onRetry = jest.fn();
+    const user = userEvent.setup();
+    render(<QuizResultActions onRetry={onRetry} topic="Graph Algorithms" score={9} total={10} />);
+
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  test('opens the share modal with the correct topic and score when "Share Result" is clicked', async () => {
+    const user = userEvent.setup();
+    render(<QuizResultActions onRetry={jest.fn()} topic="Graph Algorithms" score={9} total={10} />);
+
+    expect(screen.queryByText('Share your result')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /share result/i }));
+
+    expect(screen.getByText('Share your result')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: /scored 9 out of 10 on the graph algorithms quiz/i })).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/ShareResultModal.test.tsx
+++ b/src/__tests__/components/ShareResultModal.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, waitFor } from '../testUtils';
+import userEvent from '@testing-library/user-event';
+import ShareResultModal from '../../components/Quiz/ShareResultModal';
+
+const mockBlob = new Blob(['mock-png'], { type: 'image/png' });
+const renderShareCardToPngBlobMock = jest.fn(async (_topic?: string, _score?: number, _total?: number, _siteName?: string) => mockBlob);
+
+jest.mock('../../utils/shareResultImage', () => ({
+  __esModule: true,
+  renderShareCardToPngBlob: (topic: string, score: number, total: number, siteName?: string) =>
+    renderShareCardToPngBlobMock(topic, score, total, siteName),
+}));
+
+const defaultProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+  topic: 'Graph Algorithms',
+  score: 9,
+  total: 10,
+};
+
+describe('ShareResultModal', () => {
+  let openSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+  });
+
+  test('renders nothing when closed', () => {
+    render(<ShareResultModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('Share your result')).not.toBeInTheDocument();
+  });
+
+  test('renders the preview card and action buttons when open', () => {
+    render(<ShareResultModal {...defaultProps} />);
+
+    expect(screen.getByText('Share your result')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /download png/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy image/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share on x/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /share on linkedin/i })).toBeInTheDocument();
+    // The live preview renders an accessible SVG describing the result.
+    expect(screen.getByRole('img', { name: /scored 9 out of 10 on the graph algorithms quiz/i })).toBeInTheDocument();
+  });
+
+  test('downloads a PNG using the shared rendering utility', async () => {
+    const user = userEvent.setup();
+    render(<ShareResultModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /download png/i }));
+
+    await waitFor(() => expect(renderShareCardToPngBlobMock).toHaveBeenCalledWith('Graph Algorithms', 9, 10, 'Algo'));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /downloaded/i })).toBeInTheDocument(),
+    );
+  });
+
+  test('opens the X (Twitter) share intent with the score in the tweet text', async () => {
+    const user = userEvent.setup();
+    render(<ShareResultModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /share on x/i }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [url] = openSpy.mock.calls[0];
+    expect(url).toContain('twitter.com/intent/tweet');
+    expect(decodeURIComponent(url)).toContain('I scored 9/10 on the Graph Algorithms quiz on Algo!');
+  });
+
+  test('opens the LinkedIn share endpoint', async () => {
+    const user = userEvent.setup();
+    render(<ShareResultModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /share on linkedin/i }));
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [url] = openSpy.mock.calls[0];
+    expect(url).toContain('linkedin.com/sharing/share-offsite');
+  });
+
+  test('calls onClose when clicking the backdrop or close button', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    render(<ShareResultModal {...defaultProps} onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: /close share dialog/i }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/Quiz/QuizResultActions.tsx
+++ b/src/components/Quiz/QuizResultActions.tsx
@@ -1,27 +1,53 @@
-import React from "react";
+import React, { useState } from "react";
 import Link from "@docusaurus/Link";
+import { FiShare2 } from "react-icons/fi";
+import ShareResultModal from "./ShareResultModal";
 
 interface QuizResultActionsProps {
   onRetry: () => void;
+  /** Human-readable topic name, e.g. "Graph Algorithms". Used in the shareable result card. */
+  topic: string;
+  score: number;
+  total: number;
 }
 
-const QuizResultActions: React.FC<QuizResultActionsProps> = ({ onRetry }) => {
+const QuizResultActions: React.FC<QuizResultActionsProps> = ({ onRetry, topic, score, total }) => {
+  const [isShareOpen, setIsShareOpen] = useState(false);
+
   return (
-    <nav className="mt-6 flex flex-col sm:flex-row gap-3 justify-center" aria-label="Quiz navigation actions">
-      <Link
-        to="/quizzes"
-        className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600 transition-colors"
-      >
-        <span aria-hidden="true" className="mr-1">&larr;</span> Back to Quizzes
-      </Link>
-      <button
-        type="button"
-        onClick={onRetry}
-        className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-500 transition-colors border-none cursor-pointer"
-      >
-        Try Again
-      </button>
-    </nav>
+    <>
+      <nav className="mt-6 flex flex-col sm:flex-row gap-3 justify-center" aria-label="Quiz navigation actions">
+        <Link
+          to="/quizzes"
+          className="inline-flex items-center justify-center rounded-lg bg-gray-200 px-4 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600 transition-colors"
+        >
+          <span aria-hidden="true" className="mr-1">&larr;</span> Back to Quizzes
+        </Link>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-blue-500 transition-colors border-none cursor-pointer"
+        >
+          Try Again
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsShareOpen(true)}
+          className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-indigo-600 px-4 py-2.5 text-sm font-semibold text-white hover:bg-indigo-500 transition-colors border-none cursor-pointer"
+        >
+          <FiShare2 size={16} />
+          Share Result
+        </button>
+      </nav>
+
+      <ShareResultModal
+        isOpen={isShareOpen}
+        onClose={() => setIsShareOpen(false)}
+        topic={topic}
+        score={score}
+        total={total}
+      />
+    </>
   );
 };
 

--- a/src/components/Quiz/ShareResultCard.tsx
+++ b/src/components/Quiz/ShareResultCard.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+
+export interface ShareResultCardProps {
+  topic: string;
+  score: number;
+  total: number;
+  siteName?: string;
+  tagline?: string;
+}
+
+// Standard OG-image aspect ratio so the exported PNG looks right when
+// unfurled on Twitter/X and LinkedIn.
+export const SHARE_CARD_WIDTH = 1200;
+export const SHARE_CARD_HEIGHT = 630;
+
+function resultLabelFor(percentage: number): string {
+  if (percentage === 100) return 'Perfect score!';
+  if (percentage >= 80) return 'Great job!';
+  if (percentage >= 50) return 'Nice work!';
+  return 'Keep practicing!';
+}
+
+/**
+ * Purpose-built SVG "result card" — deliberately not a screenshot of the
+ * quiz UI. Rendering our own fixed layout means the shared image always
+ * looks the same regardless of the reader's theme, viewport, or whatever
+ * CSS happens to be on the quiz page, and it rasterizes safely to a canvas
+ * (no external fonts/images that could taint the canvas).
+ */
+export default function ShareResultCard({
+  topic,
+  score,
+  total,
+  siteName = 'Algo',
+  tagline = 'Practice DSA for free',
+}: ShareResultCardProps) {
+  const percentage = total > 0 ? Math.round((score / total) * 100) : 0;
+  const resultLabel = resultLabelFor(percentage);
+
+  return (
+    <svg
+      width={SHARE_CARD_WIDTH}
+      height={SHARE_CARD_HEIGHT}
+      viewBox={`0 0 ${SHARE_CARD_WIDTH} ${SHARE_CARD_HEIGHT}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fontFamily="Arial, Helvetica, sans-serif"
+      role="img"
+      aria-label={`I scored ${score} out of ${total} on the ${topic} quiz on ${siteName}`}
+    >
+      <defs>
+        <linearGradient id="share-card-bg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#0f172a" />
+          <stop offset="100%" stopColor="#1e1b4b" />
+        </linearGradient>
+        <linearGradient id="share-card-accent" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="#6366f1" />
+          <stop offset="100%" stopColor="#a855f7" />
+        </linearGradient>
+      </defs>
+
+      <rect width={SHARE_CARD_WIDTH} height={SHARE_CARD_HEIGHT} fill="url(#share-card-bg)" />
+
+      {/* Subtle dot grid backdrop */}
+      <g opacity="0.12">
+        {Array.from({ length: 10 }).map((_, row) =>
+          Array.from({ length: 20 }).map((__, col) => (
+            <circle key={`${row}-${col}`} cx={col * 64 + 30} cy={row * 64 + 30} r="1.5" fill="#ffffff" />
+          )),
+        )}
+      </g>
+
+      {/* Brand */}
+      <text x="64" y="96" fontSize="32" fontWeight="900" fill="#ffffff" letterSpacing="1">
+        {siteName.toUpperCase()}
+      </text>
+      <rect x="64" y="110" width="64" height="6" rx="3" fill="url(#share-card-accent)" />
+
+      {/* Topic */}
+      <text x="64" y="230" fontSize="46" fontWeight="800" fill="#ffffff">
+        {topic}
+      </text>
+      <text x="64" y="266" fontSize="22" fontWeight="500" fill="#c7d2fe">
+        Quiz Result
+      </text>
+
+      {/* Score */}
+      <text x="64" y="410" fontSize="150" fontWeight="900" fill="#ffffff">
+        {score}
+        <tspan fontSize="64" fill="#a5b4fc">
+          {' '}
+          / {total}
+        </tspan>
+      </text>
+
+      {/* Percentage badge */}
+      <rect x="64" y="438" width="130" height="50" rx="25" fill="url(#share-card-accent)" />
+      <text x="94" y="472" fontSize="24" fontWeight="800" fill="#ffffff">
+        {percentage}%
+      </text>
+
+      {/* Result label */}
+      <text x="212" y="472" fontSize="26" fontWeight="700" fill="#ffffff">
+        {resultLabel}
+      </text>
+
+      {/* Footer */}
+      <text x="64" y="580" fontSize="20" fontWeight="500" fill="#94a3b8">
+        {tagline} — learn more at {siteName}
+      </text>
+    </svg>
+  );
+}

--- a/src/components/Quiz/ShareResultModal.module.css
+++ b/src/components/Quiz/ShareResultModal.module.css
@@ -1,0 +1,134 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  background-color: rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(4px);
+}
+
+.modal {
+  width: 100%;
+  max-width: 640px;
+  max-height: 90vh;
+  overflow-y: auto;
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  padding: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--ifm-toc-border-color);
+  background: transparent;
+  color: var(--ifm-color-emphasis-700);
+  cursor: pointer;
+}
+
+.closeButton:hover {
+  color: var(--ifm-color-primary);
+  border-color: var(--ifm-color-primary);
+}
+
+.preview {
+  width: 100%;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 20px;
+  line-height: 0;
+}
+
+.preview svg {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 14px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--ifm-font-color-base);
+  background-color: var(--ifm-card-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.button:hover:not(:disabled) {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+.button:disabled {
+  cursor: progress;
+  opacity: 0.75;
+}
+
+.twitterButton:hover {
+  border-color: #000;
+  color: #000;
+}
+
+:global([data-theme='dark']) .twitterButton:hover {
+  border-color: #fff;
+  color: #fff;
+}
+
+.linkedinButton:hover {
+  border-color: #0a66c2;
+  color: #0a66c2;
+}
+
+.errorText {
+  font-size: 0.8rem;
+  color: var(--ifm-color-danger);
+  margin: 10px 0 0;
+}
+
+.spin {
+  animation: share-result-spin 0.9s linear infinite;
+}
+
+@keyframes share-result-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Quiz/ShareResultModal.tsx
+++ b/src/components/Quiz/ShareResultModal.tsx
@@ -1,0 +1,183 @@
+import React, { useCallback, useRef, useState } from 'react';
+import clsx from 'clsx';
+import { FiDownload, FiImage, FiCheck, FiAlertCircle, FiLoader, FiX } from 'react-icons/fi';
+import { FaXTwitter } from 'react-icons/fa6';
+import { FaLinkedin } from 'react-icons/fa';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import ShareResultCard from './ShareResultCard';
+import { renderShareCardToPngBlob } from '../../utils/shareResultImage';
+import styles from './ShareResultModal.module.css';
+
+export interface ShareResultModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  topic: string;
+  score: number;
+  total: number;
+  siteName?: string;
+}
+
+type ActionStatus = 'idle' | 'working' | 'done' | 'error';
+const RESET_DELAY_MS = 2500;
+
+function slugify(value: string): string {
+  return (
+    value
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-|-$)/g, '') || 'quiz-result'
+  );
+}
+
+export default function ShareResultModal({
+  isOpen,
+  onClose,
+  topic,
+  score,
+  total,
+  siteName = 'Algo',
+}: ShareResultModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(modalRef, { isOpen, onClose });
+
+  const [downloadStatus, setDownloadStatus] = useState<ActionStatus>('idle');
+  const [copyStatus, setCopyStatus] = useState<ActionStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const shareText = `I scored ${score}/${total} on the ${topic} quiz on ${siteName}! 🎯`;
+  const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
+
+  const handleDownload = useCallback(async () => {
+    setDownloadStatus('working');
+    setErrorMessage('');
+    try {
+      const blob = await renderShareCardToPngBlob(topic, score, total, siteName);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `${slugify(topic)}-quiz-result.png`;
+      link.click();
+      URL.revokeObjectURL(url);
+      setDownloadStatus('done');
+    } catch (err) {
+      console.error('[ShareResultModal] Download failed:', err);
+      setErrorMessage(err instanceof Error ? err.message : 'Download failed.');
+      setDownloadStatus('error');
+    } finally {
+      setTimeout(() => setDownloadStatus('idle'), RESET_DELAY_MS);
+    }
+  }, [topic, score, total, siteName]);
+
+  const handleCopyImage = useCallback(async () => {
+    setCopyStatus('working');
+    setErrorMessage('');
+    try {
+      const blob = await renderShareCardToPngBlob(topic, score, total, siteName);
+      const ClipboardItemCtor = typeof window !== 'undefined' ? (window as any).ClipboardItem : undefined;
+
+      if (navigator.clipboard && ClipboardItemCtor) {
+        await navigator.clipboard.write([new ClipboardItemCtor({ 'image/png': blob })]);
+      } else {
+        // Clipboard image writes aren't supported everywhere (e.g. Firefox) —
+        // fall back to a direct PNG download so the action still succeeds.
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = `${slugify(topic)}-quiz-result.png`;
+        link.click();
+        URL.revokeObjectURL(url);
+      }
+      setCopyStatus('done');
+    } catch (err) {
+      console.error('[ShareResultModal] Copy failed:', err);
+      setErrorMessage(err instanceof Error ? err.message : 'Copy failed.');
+      setCopyStatus('error');
+    } finally {
+      setTimeout(() => setCopyStatus('idle'), RESET_DELAY_MS);
+    }
+  }, [topic, score, total, siteName]);
+
+  const openShareWindow = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer,width=600,height=500');
+  };
+
+  const handleShareTwitter = () => {
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(
+      shareUrl,
+    )}`;
+    openShareWindow(url);
+  };
+
+  const handleShareLinkedIn = () => {
+    // LinkedIn's share endpoint only accepts a URL — it doesn't support
+    // prefilled post text, so the caption is left for the user to add.
+    const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+    openShareWindow(url);
+  };
+
+  if (!isOpen) return null;
+
+  const downloadLabel = { idle: 'Download PNG', working: 'Preparing…', done: 'Downloaded!', error: 'Try again' }[
+    downloadStatus
+  ];
+  const copyLabel = { idle: 'Copy image', working: 'Copying…', done: 'Copied!', error: 'Try again' }[copyStatus];
+
+  const renderStatusIcon = (status: ActionStatus, IdleIcon: React.ComponentType<{ size?: number }>) => {
+    if (status === 'working') return <FiLoader size={16} className={styles.spin} />;
+    if (status === 'done') return <FiCheck size={16} />;
+    if (status === 'error') return <FiAlertCircle size={16} />;
+    return <IdleIcon size={16} />;
+  };
+
+  return (
+    <div onClick={onClose} className={styles.overlay}>
+      <div
+        ref={modalRef}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-result-modal-title"
+        className={styles.modal}
+      >
+        <div className={styles.header}>
+          <h2 id="share-result-modal-title" className={styles.title}>
+            Share your result
+          </h2>
+          <button type="button" onClick={onClose} aria-label="Close share dialog" className={styles.closeButton}>
+            <FiX size={18} />
+          </button>
+        </div>
+
+        <div className={styles.preview}>
+          <ShareResultCard topic={topic} score={score} total={total} siteName={siteName} />
+        </div>
+
+        <div className={styles.actions}>
+          <button type="button" onClick={handleDownload} disabled={downloadStatus === 'working'} className={styles.button}>
+            {renderStatusIcon(downloadStatus, FiDownload)}
+            <span>{downloadLabel}</span>
+          </button>
+          <button type="button" onClick={handleCopyImage} disabled={copyStatus === 'working'} className={styles.button}>
+            {renderStatusIcon(copyStatus, FiImage)}
+            <span>{copyLabel}</span>
+          </button>
+          <button type="button" onClick={handleShareTwitter} className={clsx(styles.button, styles.twitterButton)}>
+            <FaXTwitter size={16} />
+            <span>Share on X</span>
+          </button>
+          <button type="button" onClick={handleShareLinkedIn} className={clsx(styles.button, styles.linkedinButton)}>
+            <FaLinkedin size={16} />
+            <span>Share on LinkedIn</span>
+          </button>
+        </div>
+
+        {errorMessage && (downloadStatus === 'error' || copyStatus === 'error') && (
+          <p className={styles.errorText} role="status">
+            {errorMessage}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/data/generated/dsaProblemsIndex.json
+++ b/src/data/generated/dsaProblemsIndex.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-07-26T12:51:07.470Z",
-  "count": 84,
+  "generatedAt": "2026-07-30T04:19:21.208Z",
+  "count": 85,
   "difficulties": [
     "Easy",
     "Medium",
@@ -74,6 +74,10 @@
     {
       "value": "dfs",
       "label": "DFS"
+    },
+    {
+      "value": "dijkstras",
+      "label": "Dijkstras"
     },
     {
       "value": "divide-and-conquer",
@@ -914,6 +918,21 @@
       ],
       "companies": [],
       "url": "/docs/dsa-problems/medium/partition-equal-subset-sum"
+    },
+    {
+      "id": "path-with-minimum-effort",
+      "title": "Path With Minimum Effort",
+      "description": "Solution for LeetCode 1631: Path With Minimum Effort, utilizing Dijkstra's Algorithm with a Min-Priority Queue on a 2D grid.",
+      "difficulty": "Medium",
+      "tags": [
+        "graph",
+        "dijkstras",
+        "shortest-path",
+        "matrix",
+        "binary-search"
+      ],
+      "companies": [],
+      "url": "/docs/dsa-problems/medium/path-with-minimum-effort"
     },
     {
       "id": "plus-one",

--- a/src/pages/quizzes/avl-tree.tsx
+++ b/src/pages/quizzes/avl-tree.tsx
@@ -418,7 +418,7 @@ const AVLTreeQuiz: React.FC = () => {
                       {score === QUESTIONS.length ? "Perfect balance metrics verified! Rotations perfectly managed across every case configuration." : score >= 6 ? "Solid conceptual comprehension of AVL conditions. Your height bounds look secure." : "Imbalance detected in sub-nodes. Trace rotation strategies and re-verify calculation parameters."}
                     </p>
 
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="AVL Tree" score={score} total={QUESTIONS.length} />
                   </div>
 
                   {/* Static Explanatory Logs */}

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -454,7 +454,7 @@ const BTreeQuiz: React.FC = () => {
                       {score === QUESTIONS.length ? "Invariants fully satisfied! All node capacity guidelines and structural divisions executed perfectly." : score >= 6 ? "Good evaluation trace! You have a solid grasp on disk-optimized tree metrics." : "Imbalance detected. Review minimum structural constraints, boundary degree calculations, and parent-promotion operations."}
                     </p>
 
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="B-Tree" score={score} total={QUESTIONS.length} />
                   </div>
 
                   {/* Solutions list */}

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -423,7 +423,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
                       {score === QUESTIONS.length ? "Perfect state invariants! Your binary search tree algorithms are flawlessly organized." : score >= 6 ? "Solid baseline metrics! You understand lookups, sorting logic, and average path behavior well." : "Asymmetry found. Spend extra time analyzing leaf assignments, worst-case linear degressions, and node removal processes."}
                     </p>
 
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Binary Search Tree" score={score} total={QUESTIONS.length} />
                   </div>
 
                   {/* Debug Log Trace Details */}

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -417,7 +417,7 @@ const BinaryTreeQuiz: React.FC = () => {
                       {score === QUESTIONS.length ? "Structural integrity complete. All pointers, leaf paths, and look-up runtimes match their target specifications exactly." : score >= 7 ? "High tree balance density verified! Your logic surrounding depth tracking and common ancestors is highly proficient." : "Asymmetry encountered. Review standard tree-height definitions, complete layout constraints, and descending reverse pathways."}
                     </p>
 
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Binary Tree" score={score} total={QUESTIONS.length} />
                   </div>
 
                   {/* Solutions Trace Mapping Stack */}

--- a/src/pages/quizzes/bplus-tree.tsx
+++ b/src/pages/quizzes/bplus-tree.tsx
@@ -469,7 +469,7 @@ const BPlusTreeQuiz: React.FC = () => {
                             ? "Good effort! Review leaf-node linking, split/merge behavior, and how B+ Trees differ from B-Trees."
                             : "Keep practicing! Focus on the difference between internal and leaf nodes, and how range queries are handled."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="B+ Tree" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/deque.tsx
+++ b/src/pages/quizzes/deque.tsx
@@ -469,7 +469,7 @@ const DequeQuiz: React.FC = () => {
                             ? "Good effort! Review deque operations and sliding window applications."
                             : "Keep practicing! Focus on the difference between deques, stacks, and queues."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Deque" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/external-hashing.tsx
+++ b/src/pages/quizzes/external-hashing.tsx
@@ -469,7 +469,7 @@ const ExternalHashingQuiz: React.FC = () => {
                             ? "Good effort! Review bucket/overflow block organization and how load factor affects disk I/O."
                             : "Keep practicing! Focus on why disk-block-aligned buckets matter and how overflow chains impact performance."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="External Hashing" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/graph.tsx
+++ b/src/pages/quizzes/graph.tsx
@@ -474,7 +474,7 @@ const GraphQuiz: React.FC = () => {
                             ? "Good effort! Review cycle detection, adjacency representations, and Dijkstra's algorithm."
                             : "Keep practicing! Focus on graph basics, BFS vs DFS differences, and adjacency list vs matrix."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Graph Algorithms" score={score} total={QUESTIONS.length} />
                   </div>
 
                   {/* Detailed Breakdown */}

--- a/src/pages/quizzes/hash-indexing.tsx
+++ b/src/pages/quizzes/hash-indexing.tsx
@@ -469,7 +469,7 @@ const HashIndexingQuiz: React.FC = () => {
                             ? "Good effort! Review collision handling techniques and how extendible/linear hashing manage growth."
                             : "Keep practicing! Focus on the difference between static and dynamic hashing, and why hash indexes don't suit range queries."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Hash Indexing" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/isam.tsx
+++ b/src/pages/quizzes/isam.tsx
@@ -469,7 +469,7 @@ const IsamQuiz: React.FC = () => {
                             ? "Good effort! Review overflow page handling and how ISAM compares to dynamically balanced structures."
                             : "Keep practicing! Focus on why ISAM's static index degrades over time and how reorganization restores performance."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="ISAM" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/linear-search.tsx
+++ b/src/pages/quizzes/linear-search.tsx
@@ -469,7 +469,7 @@ const LinearSearchQuiz: React.FC = () => {
                             ? "Good effort! Review best/average/worst case scenarios and how linear search compares to other algorithms."
                             : "Keep practicing! Focus on time/space complexity fundamentals and when linear search is appropriate."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Linear Search" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/linked-list.tsx
+++ b/src/pages/quizzes/linked-list.tsx
@@ -466,7 +466,7 @@ const LinkedListQuiz: React.FC = () => {
                             ? "Good effort! Review pointer manipulation and complexity trade-offs."
                             : "Keep practicing! Focus on singly vs doubly linked list operations and traversal techniques."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Linked List" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/priority-queue.tsx
+++ b/src/pages/quizzes/priority-queue.tsx
@@ -469,7 +469,7 @@ const PriorityQueueQuiz: React.FC = () => {
                             ? "Good effort! Review heap operations and the difference between priority queues and regular queues."
                             : "Keep practicing! Focus on heap-based insertion, extraction, and real-world scheduling use cases."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Priority Queue" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/recursion.tsx
+++ b/src/pages/quizzes/recursion.tsx
@@ -466,7 +466,7 @@ const RecursionQuiz: React.FC = () => {
                             ? "Good effort! Review base cases, recursive cases, and how the call stack manages recursive calls."
                             : "Keep practicing! Focus on tracing the call stack and analyzing recursive time/space complexity."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Recursion" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/pages/quizzes/sorting.tsx
+++ b/src/pages/quizzes/sorting.tsx
@@ -493,7 +493,7 @@ const SortingQuiz: React.FC = () => {
                             ? "Good effort! Review stable vs unstable sorts and fallback mechanisms in hybrid sorts."
                             : "Keep practicing! Focus on worst-case complexities, heap operations, and recursive partitions."}
                     </p>
-                    <QuizResultActions onRetry={handleRetry} />
+                    <QuizResultActions onRetry={handleRetry} topic="Sorting Algorithms" score={score} total={QUESTIONS.length} />
                   </div>
 
                   <div className="text-left space-y-6">

--- a/src/utils/shareResultImage.tsx
+++ b/src/utils/shareResultImage.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import ShareResultCard, { SHARE_CARD_WIDTH, SHARE_CARD_HEIGHT } from '../components/Quiz/ShareResultCard';
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Could not render the share card image.'));
+    img.src = src;
+  });
+}
+
+/**
+ * Renders <ShareResultCard /> to a PNG Blob by serializing it to SVG markup
+ * (via react-dom/server, dynamically imported so it isn't part of the main
+ * bundle) and rasterizing that SVG onto a canvas at 2x scale.
+ *
+ * Deliberately not a screenshot of the live quiz page — this produces a
+ * fixed, predictable image regardless of the reader's theme/viewport.
+ */
+export async function renderShareCardToPngBlob(
+  topic: string,
+  score: number,
+  total: number,
+  siteName?: string,
+): Promise<Blob> {
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const markup = renderToStaticMarkup(
+    <ShareResultCard topic={topic} score={score} total={total} siteName={siteName} />,
+  );
+  const svgMarkup = `<?xml version="1.0" encoding="UTF-8"?>${markup}`;
+
+  const svgBlob = new Blob([svgMarkup], { type: 'image/svg+xml;charset=utf-8' });
+  const svgUrl = URL.createObjectURL(svgBlob);
+
+  try {
+    const img = await loadImage(svgUrl);
+    const scale = 2; // render at 2x for crisper downloads/clipboard copies
+    const canvas = document.createElement('canvas');
+    canvas.width = SHARE_CARD_WIDTH * scale;
+    canvas.height = SHARE_CARD_HEIGHT * scale;
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) throw new Error('Canvas rendering is not supported in this browser.');
+
+    ctx.scale(scale, scale);
+    ctx.drawImage(img, 0, 0, SHARE_CARD_WIDTH, SHARE_CARD_HEIGHT);
+
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => (blob ? resolve(blob) : reject(new Error('Could not encode the image.'))), 'image/png');
+    });
+  } finally {
+    URL.revokeObjectURL(svgUrl);
+  }
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description
Adds a shareable "result card" to quiz results screens, so a completed quiz becomes something worth posting — cheap organic growth for the project, and a small reward for the learner.

ShareResultCard.tsx: a purpose-built SVG card (1200×630, OG-image aspect ratio) showing the topic, score, percentage, and a result label ("Perfect score!", "Great job!", etc.). This is deliberately not a screenshot of the quiz page — a fixed, self-contained SVG (system fonts only, no external assets) means the shared image looks identical regardless of the reader's theme or viewport, and rasterizes safely to canvas with no cross-origin taint risk.

shareResultImage.tsx: serializes that SVG via react-dom/server (dynamically imported so it's not in the main bundle) and rasterizes it onto a canvas at 2x scale for crisp PNG output. Extracted into its own module specifically so it can be cleanly mocked in tests, independent of the modal UI.

ShareResultModal.tsx: shows a live preview of the card plus four actions — Download PNG, Copy image (Clipboard API where supported, falls back to a direct download in browsers like Firefox that don't support clipboard image writes), Share on X, and Share on LinkedIn (pre-filled tweet text incl. score; LinkedIn's share endpoint only accepts a URL, so no prefilled caption there — noted in a comment). Reuses the existing useFocusTrap hook for accessible modal behavior, consistent with KeyboardShortcutsModal.

QuizResultActions.tsx: added a "Share Result" button alongside the existing "Back to Quizzes" / "Try Again" actions; now requires topic, score, and total props to build the card.
Updated all 15 quiz pages that use QuizResultActions (graph, binary-tree, avl-tree, linked-list, recursion, sorting, b-tree, bplus-tree, deque, external-hashing, hash-indexing, isam, linear-search, priority-queue, binary-search-tree) to pass a human-readable topic name plus the existing score/QUESTIONS.length values — a mechanical, one-line change per file

Fixes #3272 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
