### PR TITLE
feat: add Personal Weak Topics Dashboard with targeted practice recommendations

### DIFF
--- a/src/__tests__/components/WeakTopicsChart.test.tsx
+++ b/src/__tests__/components/WeakTopicsChart.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen } from "../testUtils";
+import WeakTopicsChart from "../../components/WeakTopicsChart";
+import type { WeakTopicEntry } from "../../utils/weakTopics";
+import type { QuizStat } from "../../hooks/useQuizProgress";
+
+function makeStat(quizId: string, overrides: Partial<QuizStat> = {}): QuizStat {
+  return {
+    quizId,
+    attempts: [],
+    bestScore: 0,
+    bestPercent: 0,
+    latestScore: 0,
+    latestPercent: 0,
+    latestAttemptAt: null,
+    totalAttempts: 0,
+    totalQuestions: 10,
+    averagePercent: 0,
+    status: "not-started",
+    ...overrides,
+  };
+}
+
+const entries: WeakTopicEntry[] = [
+  {
+    quiz: { id: "graphs", title: "Quiz on Graphs", category: "Non-Linear", description: "", path: "/quizzes/graph", questionCount: 12 },
+    stat: makeStat("graphs", { totalAttempts: 2, bestPercent: 30, status: "in-progress" }),
+  },
+  {
+    quiz: { id: "bst", title: "Quiz on Binary Search Trees", category: "Non-Linear", description: "", path: "/quizzes/binary-search-tree", questionCount: 10 },
+    stat: makeStat("bst", { totalAttempts: 0 }),
+  },
+];
+
+describe("WeakTopicsChart", () => {
+  test("renders an empty state when there are no entries", () => {
+    render(<WeakTopicsChart entries={[]} />);
+    expect(screen.getByText(/no quiz history yet/i)).toBeInTheDocument();
+  });
+
+  test("renders a row per topic with score and attempt count", () => {
+    render(<WeakTopicsChart entries={entries} />);
+
+    expect(screen.getByText("Graphs")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+    expect(screen.getByText("2 attempts")).toBeInTheDocument();
+
+    expect(screen.getByText("Binary Search Trees")).toBeInTheDocument();
+    expect(screen.getByText("Not attempted yet")).toBeInTheDocument();
+  });
+
+  test('renders a "Practice this" link to each quiz path', () => {
+    render(<WeakTopicsChart entries={entries} />);
+
+    const links = screen.getAllByRole("link", { name: /practice this/i });
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", "/quizzes/graph");
+    expect(links[1]).toHaveAttribute("href", "/quizzes/binary-search-tree");
+  });
+});

--- a/src/__tests__/utils/weakTopics.test.ts
+++ b/src/__tests__/utils/weakTopics.test.ts
@@ -1,0 +1,96 @@
+import { rankWeakTopics, MIN_WEAK_TOPICS, MAX_WEAK_TOPICS } from "../../utils/weakTopics";
+import type { QuizCardConfig } from "../../data/quizzesConfig";
+import type { QuizStat } from "../../hooks/useQuizProgress";
+
+const mockQuizzes: QuizCardConfig[] = [
+  { id: "arrays", title: "Quiz on Arrays", category: "Linear", description: "", path: "/quizzes/arrays", questionCount: 10 },
+  { id: "graphs", title: "Quiz on Graphs", category: "Non-Linear", description: "", path: "/quizzes/graph", questionCount: 12 },
+  { id: "sorting", title: "Quiz on Sorting Algorithms", category: "Linear", description: "", path: "/quizzes/sorting", questionCount: 12 },
+  { id: "recursion", title: "Quiz on Recursion Fundamentals", category: "Linear", description: "", path: "/quizzes/recursion", questionCount: 12 },
+  { id: "bst", title: "Quiz on Binary Search Trees", category: "Non-Linear", description: "", path: "/quizzes/binary-search-tree", questionCount: 10 },
+  { id: "isam", title: "Quiz on ISAM", category: "Disk Storage", description: "", path: "/quizzes/isam", questionCount: 12 },
+];
+
+function makeStat(overrides: Partial<QuizStat> & { quizId: string }): QuizStat {
+  return {
+    attempts: [],
+    bestScore: 0,
+    bestPercent: 0,
+    latestScore: 0,
+    latestPercent: 0,
+    latestAttemptAt: null,
+    totalAttempts: 0,
+    totalQuestions: 10,
+    averagePercent: 0,
+    status: "not-started",
+    ...overrides,
+  };
+}
+
+describe("rankWeakTopics", () => {
+  test("ranks attempted topics by ascending best score", () => {
+    const stats: Record<string, QuizStat> = {
+      arrays: makeStat({ quizId: "arrays", totalAttempts: 2, bestPercent: 90, status: "mastered" }),
+      graphs: makeStat({ quizId: "graphs", totalAttempts: 1, bestPercent: 30, status: "in-progress" }),
+      sorting: makeStat({ quizId: "sorting", totalAttempts: 3, bestPercent: 55, status: "in-progress" }),
+      recursion: makeStat({ quizId: "recursion", totalAttempts: 1, bestPercent: 70, status: "passed" }),
+      bst: makeStat({ quizId: "bst", totalAttempts: 0 }),
+      isam: makeStat({ quizId: "isam", totalAttempts: 0 }),
+    };
+
+    const result = rankWeakTopics(stats, mockQuizzes);
+
+    // Weakest attempted topic first.
+    expect(result[0].quiz.id).toBe("graphs");
+    expect(result[1].quiz.id).toBe("sorting");
+    expect(result[2].quiz.id).toBe("recursion");
+    expect(result[3].quiz.id).toBe("arrays");
+    // All 4 attempted topics are returned since that's >= MIN_WEAK_TOPICS.
+    expect(result).toHaveLength(4);
+  });
+
+  test("pads with never-attempted topics when fewer than MIN_WEAK_TOPICS were attempted", () => {
+    const stats: Record<string, QuizStat> = {
+      arrays: makeStat({ quizId: "arrays", totalAttempts: 1, bestPercent: 40 }),
+      graphs: makeStat({ quizId: "graphs", totalAttempts: 0 }),
+      sorting: makeStat({ quizId: "sorting", totalAttempts: 0 }),
+      recursion: makeStat({ quizId: "recursion", totalAttempts: 0 }),
+      bst: makeStat({ quizId: "bst", totalAttempts: 0 }),
+      isam: makeStat({ quizId: "isam", totalAttempts: 0 }),
+    };
+
+    const result = rankWeakTopics(stats, mockQuizzes);
+
+    expect(result.length).toBeGreaterThanOrEqual(MIN_WEAK_TOPICS);
+    expect(result[0].quiz.id).toBe("arrays");
+    // The rest should be never-attempted topics (totalAttempts === 0).
+    result.slice(1).forEach((entry) => expect(entry.stat.totalAttempts).toBe(0));
+  });
+
+  test("never returns more than MAX_WEAK_TOPICS entries", () => {
+    const stats: Record<string, QuizStat> = Object.fromEntries(
+      mockQuizzes.map((q, i) => [q.id, makeStat({ quizId: q.id, totalAttempts: 1, bestPercent: i * 10 })]),
+    );
+
+    const result = rankWeakTopics(stats, mockQuizzes);
+
+    expect(result.length).toBeLessThanOrEqual(MAX_WEAK_TOPICS);
+  });
+
+  test("skips quizzes with no stat entry at all", () => {
+    const stats: Record<string, QuizStat> = {
+      arrays: makeStat({ quizId: "arrays", totalAttempts: 1, bestPercent: 40 }),
+    };
+
+    const result = rankWeakTopics(stats, mockQuizzes);
+
+    // Only "arrays" has a stat; everything else is missing from `stats`
+    // entirely (simulating a partial/loading state) and should be skipped
+    // rather than crashing.
+    expect(result.every((entry) => entry.quiz.id === "arrays")).toBe(true);
+  });
+
+  test("returns an empty array when there is no data at all", () => {
+    expect(rankWeakTopics({}, mockQuizzes)).toEqual([]);
+  });
+});

--- a/src/components/WeakTopicsChart.tsx
+++ b/src/components/WeakTopicsChart.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { motion } from "framer-motion";
+import Link from "@docusaurus/Link";
+import { FiArrowRight } from "react-icons/fi";
+import type { WeakTopicEntry } from "../utils/weakTopics";
+
+interface WeakTopicsChartProps {
+  entries: WeakTopicEntry[];
+}
+
+function barColor(bestPercent: number, hasAttempts: boolean): string {
+  if (!hasAttempts) return "bg-slate-300 dark:bg-slate-700";
+  if (bestPercent < 40) return "bg-rose-500";
+  if (bestPercent < 60) return "bg-amber-500";
+  return "bg-blue-500";
+}
+
+export default function WeakTopicsChart({ entries }: WeakTopicsChartProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="text-center py-12 border border-dashed border-slate-200 dark:border-slate-800 rounded-2xl">
+        <p className="text-slate-500 dark:text-slate-400 font-semibold m-0">
+          No quiz history yet — take a quiz to see your weak topics here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {entries.map((entry, index) => {
+        const hasAttempts = entry.stat.totalAttempts > 0;
+        const pct = hasAttempts ? entry.stat.bestPercent : 0;
+
+        return (
+          <div key={entry.quiz.id} className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
+            <div className="sm:w-48 shrink-0">
+              <div className="text-sm font-bold text-slate-800 dark:text-slate-100">
+                {entry.quiz.title.replace("Quiz on ", "")}
+              </div>
+              <div className="text-[11px] font-mono text-slate-400 dark:text-slate-500">
+                {hasAttempts
+                  ? `${entry.stat.totalAttempts} attempt${entry.stat.totalAttempts === 1 ? "" : "s"}`
+                  : "Not attempted yet"}
+              </div>
+            </div>
+
+            <div className="flex-1 flex items-center gap-3">
+              <div className="flex-1 h-3 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden">
+                <motion.div
+                  initial={{ width: 0 }}
+                  animate={{ width: `${pct}%` }}
+                  transition={{ duration: 0.6, delay: index * 0.05, ease: "easeOut" }}
+                  className={`h-full rounded-full ${barColor(pct, hasAttempts)}`}
+                />
+              </div>
+              <span className="w-10 text-right text-xs font-mono font-bold text-slate-600 dark:text-slate-300">
+                {hasAttempts ? `${pct}%` : "—"}
+              </span>
+            </div>
+
+            <Link
+              to={entry.quiz.path}
+              className="inline-flex items-center gap-1 shrink-0 text-xs font-bold px-3 py-1.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-400 border border-blue-200 dark:border-blue-800/40 no-underline hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
+            >
+              Practice this
+              <FiArrowRight size={12} />
+            </Link>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/data/generated/dsaProblemsIndex.json
+++ b/src/data/generated/dsaProblemsIndex.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-30T04:19:21.208Z",
+  "generatedAt": "2026-07-31T04:26:49.638Z",
   "count": 85,
   "difficulties": [
     "Easy",

--- a/src/data/quizzesConfig.ts
+++ b/src/data/quizzesConfig.ts
@@ -1,0 +1,39 @@
+export interface QuizCardConfig {
+  id: string;
+  title: string;
+  category: "Linear" | "Non-Linear" | "Balanced Tree" | "Disk Storage";
+  description: string;
+  path: string;
+  questionCount: number;
+}
+
+// Source of truth for every quiz's id, title, and route. Originally lived
+// only inside src/pages/quizzes/index.tsx — extracted here so it can be
+// reused by src/pages/dashboard (weak topics) without duplicating this list.
+export const QUIZZES_CONFIG: QuizCardConfig[] = [
+  { id: "arrays",          title: "Quiz on Arrays",                  category: "Linear",        description: "Evaluate your foundational knowledge on sequential storage, index shifting, allocation footprints, and contiguous multi-dimensional matrices.", path: "/quizzes/arrays",          questionCount: 10 },
+  { id: "stacks",          title: "Quiz on Stacks",                  category: "Linear",        description: "Analyze LIFO processing infrastructure, recursion execution flow behaviors, frame call stacks, and parentheses balancing validation rules.", path: "/quizzes/stack",           questionCount: 8  },
+  { id: "queues",          title: "Quiz on Queues",                  category: "Linear",        description: "Challenge your skills on asynchronous FIFO task piping, sliding window architectures, priority schedulers, and circular double-ended buffers.", path: "/quizzes/queue",           questionCount: 16 },
+  { id: "linked-lists",    title: "Quiz on Linked Lists",            category: "Linear",        description: "Test your grasp of singly, doubly, and circular linked list structures, pointer-based operations, and traversal/complexity trade-offs.", path: "/quizzes/linked-list",     questionCount: 12 },
+  { id: "deques",          title: "Quiz on Deques",                  category: "Linear",        description: "Evaluate your understanding of double-ended queue operations, sliding window applications, and front/rear insertion-deletion complexity.", path: "/quizzes/deque",           questionCount: 12 },
+  { id: "priority-queues", title: "Quiz on Priority Queues",         category: "Linear",        description: "Test your knowledge of heap-based priority scheduling, min/max-heap operations, and real-world applications like Dijkstra's algorithm.", path: "/quizzes/priority-queue",  questionCount: 12 },
+  { id: "linear-search",   title: "Quiz on Linear Search",           category: "Linear",        description: "Assess your understanding of sequential search mechanics, best/average/worst case analysis, and when linear search is the right tool.", path: "/quizzes/linear-search",   questionCount: 12 },
+  { id: "sorting",         title: "Quiz on Sorting Algorithms",      category: "Linear",        description: "Challenge your sorting skills: stability behaviors, complexity bounds (best/average/worst cases), in-place operations, and hybrid algorithms.", path: "/quizzes/sorting",         questionCount: 12 },
+  { id: "recursion",       title: "Quiz on Recursion Fundamentals",  category: "Linear",        description: "Examine call stack behavior, base and recursive case design, and the time/space complexity implications of recursive algorithms.", path: "/quizzes/recursion",        questionCount: 12 },
+  { id: "binary-trees",    title: "Quiz on Binary Trees",            category: "Non-Linear",    description: "Test your parsing logic across hierarchical node trees, DFS/BFS traversal sequences, depth diagnostics, and structural serialization patterns.", path: "/quizzes/binary-tree",     questionCount: 12 },
+  { id: "bst",             title: "Quiz on Binary Search Trees",     category: "Non-Linear",    description: "Review specific sorting properties, target node deletion edge-cases, inline predecessor tracking, and computational lookup bounds.", path: "/quizzes/binary-search-tree", questionCount: 10 },
+  { id: "graphs",          title: "Quiz on Graphs",                  category: "Non-Linear",    description: "Test your knowledge of graph types, vertex/edge terminology, adjacency representations, BFS, DFS traversal algorithms, and real-world applications.", path: "/quizzes/graph",           questionCount: 12 },
+  { id: "avl-trees",       title: "Quiz on AVL Trees",               category: "Balanced Tree", description: "Examine self-balancing data structures, compute strict height imbalance factors, and trace complex Single/Double node rotation loops.", path: "/quizzes/avl-tree",        questionCount: 8  },
+  { id: "red-black-trees", title: "Quiz on Red-Black Trees",         category: "Balanced Tree", description: "Test your understanding of strict node coloring rules, balancing bounds during insertions, recoloring mechanisms, and rotation limits.", path: "/quizzes/red-black-tree",  questionCount: 8  },
+  { id: "b-trees",         title: "Quiz on B-Trees",                 category: "Disk Storage",  description: "Evaluate external indexing structures, block storage node split workflows, high fan-out properties, and direct multi-way search trees.", path: "/quizzes/b-tree",          questionCount: 10 },
+  { id: "bplus-trees",     title: "Quiz on B+ Trees",                category: "Disk Storage",  description: "Test your knowledge of internal vs leaf node organization, range queries, linked leaf nodes, and database indexing applications.", path: "/quizzes/bplus-tree",      questionCount: 12 },
+  { id: "isam",            title: "Quiz on ISAM",                    category: "Disk Storage",  description: "Evaluate static indexing concepts, overflow pages, search performance trade-offs, and how ISAM compares to dynamic B-Tree structures.", path: "/quizzes/isam",            questionCount: 12 },
+  { id: "hash-indexing",   title: "Quiz on Hash Indexing",           category: "Disk Storage",  description: "Test your understanding of static and dynamic hashing, extendible and linear hashing, and collision handling techniques.", path: "/quizzes/hash-indexing",   questionCount: 12 },
+  { id: "external-hashing",title: "Quiz on External Hashing",        category: "Disk Storage",  description: "Assess your knowledge of bucket organization, disk block management, overflow handling, and disk-based performance analysis.", path: "/quizzes/external-hashing", questionCount: 12 },
+];
+
+export const QUESTION_COUNTS: Record<string, number> = Object.fromEntries(
+  QUIZZES_CONFIG.map((q) => [q.id, q.questionCount]),
+);
+
+export const QUIZ_IDS: string[] = QUIZZES_CONFIG.map((q) => q.id);

--- a/src/pages/quizzes/index.tsx
+++ b/src/pages/quizzes/index.tsx
@@ -10,45 +10,7 @@ import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { useQuizProgress, QuizStat, GlobalQuizStats } from "../../hooks/useQuizProgress";
-
-// ─── Quiz config ──────────────────────────────────────────────────────────────
-
-interface QuizCardConfig {
-  id: string;
-  title: string;
-  category: "Linear" | "Non-Linear" | "Balanced Tree" | "Disk Storage";
-  description: string;
-  path: string;
-  questionCount: number;
-}
-
-const QUIZZES_CONFIG: QuizCardConfig[] = [
-  { id: "arrays",          title: "Quiz on Arrays",                  category: "Linear",        description: "Evaluate your foundational knowledge on sequential storage, index shifting, allocation footprints, and contiguous multi-dimensional matrices.", path: "/quizzes/arrays",          questionCount: 10 },
-  { id: "stacks",          title: "Quiz on Stacks",                  category: "Linear",        description: "Analyze LIFO processing infrastructure, recursion execution flow behaviors, frame call stacks, and parentheses balancing validation rules.", path: "/quizzes/stack",           questionCount: 8  },
-  { id: "queues",          title: "Quiz on Queues",                  category: "Linear",        description: "Challenge your skills on asynchronous FIFO task piping, sliding window architectures, priority schedulers, and circular double-ended buffers.", path: "/quizzes/queue",           questionCount: 16 },
-  { id: "linked-lists",    title: "Quiz on Linked Lists",            category: "Linear",        description: "Test your grasp of singly, doubly, and circular linked list structures, pointer-based operations, and traversal/complexity trade-offs.", path: "/quizzes/linked-list",     questionCount: 12 },
-  { id: "deques",          title: "Quiz on Deques",                  category: "Linear",        description: "Evaluate your understanding of double-ended queue operations, sliding window applications, and front/rear insertion-deletion complexity.", path: "/quizzes/deque",           questionCount: 12 },
-  { id: "priority-queues", title: "Quiz on Priority Queues",         category: "Linear",        description: "Test your knowledge of heap-based priority scheduling, min/max-heap operations, and real-world applications like Dijkstra's algorithm.", path: "/quizzes/priority-queue",  questionCount: 12 },
-  { id: "linear-search",   title: "Quiz on Linear Search",           category: "Linear",        description: "Assess your understanding of sequential search mechanics, best/average/worst case analysis, and when linear search is the right tool.", path: "/quizzes/linear-search",   questionCount: 12 },
-  { id: "sorting",         title: "Quiz on Sorting Algorithms",      category: "Linear",        description: "Challenge your sorting skills: stability behaviors, complexity bounds (best/average/worst cases), in-place operations, and hybrid algorithms.", path: "/quizzes/sorting",         questionCount: 12 },
-  { id: "recursion",       title: "Quiz on Recursion Fundamentals",  category: "Linear",        description: "Examine call stack behavior, base and recursive case design, and the time/space complexity implications of recursive algorithms.", path: "/quizzes/recursion",        questionCount: 12 },
-  { id: "binary-trees",    title: "Quiz on Binary Trees",            category: "Non-Linear",    description: "Test your parsing logic across hierarchical node trees, DFS/BFS traversal sequences, depth diagnostics, and structural serialization patterns.", path: "/quizzes/binary-tree",     questionCount: 12 },
-  { id: "bst",             title: "Quiz on Binary Search Trees",     category: "Non-Linear",    description: "Review specific sorting properties, target node deletion edge-cases, inline predecessor tracking, and computational lookup bounds.", path: "/quizzes/binary-search-tree", questionCount: 10 },
-  { id: "graphs",          title: "Quiz on Graphs",                  category: "Non-Linear",    description: "Test your knowledge of graph types, vertex/edge terminology, adjacency representations, BFS, DFS traversal algorithms, and real-world applications.", path: "/quizzes/graph",           questionCount: 12 },
-  { id: "avl-trees",       title: "Quiz on AVL Trees",               category: "Balanced Tree", description: "Examine self-balancing data structures, compute strict height imbalance factors, and trace complex Single/Double node rotation loops.", path: "/quizzes/avl-tree",        questionCount: 8  },
-  { id: "red-black-trees", title: "Quiz on Red-Black Trees",         category: "Balanced Tree", description: "Test your understanding of strict node coloring rules, balancing bounds during insertions, recoloring mechanisms, and rotation limits.", path: "/quizzes/red-black-tree",  questionCount: 8  },
-  { id: "b-trees",         title: "Quiz on B-Trees",                 category: "Disk Storage",  description: "Evaluate external indexing structures, block storage node split workflows, high fan-out properties, and direct multi-way search trees.", path: "/quizzes/b-tree",          questionCount: 10 },
-  { id: "bplus-trees",     title: "Quiz on B+ Trees",                category: "Disk Storage",  description: "Test your knowledge of internal vs leaf node organization, range queries, linked leaf nodes, and database indexing applications.", path: "/quizzes/bplus-tree",      questionCount: 12 },
-  { id: "isam",            title: "Quiz on ISAM",                    category: "Disk Storage",  description: "Evaluate static indexing concepts, overflow pages, search performance trade-offs, and how ISAM compares to dynamic B-Tree structures.", path: "/quizzes/isam",            questionCount: 12 },
-  { id: "hash-indexing",   title: "Quiz on Hash Indexing",           category: "Disk Storage",  description: "Test your understanding of static and dynamic hashing, extendible and linear hashing, and collision handling techniques.", path: "/quizzes/hash-indexing",   questionCount: 12 },
-  { id: "external-hashing",title: "Quiz on External Hashing",        category: "Disk Storage",  description: "Assess your knowledge of bucket organization, disk block management, overflow handling, and disk-based performance analysis.", path: "/quizzes/external-hashing", questionCount: 12 },
-];
-
-const QUESTION_COUNTS: Record<string, number> = Object.fromEntries(
-  QUIZZES_CONFIG.map(q => [q.id, q.questionCount])
-);
-
-const QUIZ_IDS = QUIZZES_CONFIG.map(q => q.id);
+import { QUIZZES_CONFIG, QUESTION_COUNTS, QUIZ_IDS, type QuizCardConfig } from "../../data/quizzesConfig";
 
 const FILTER_CATEGORIES = ["All", "Linear", "Non-Linear", "Balanced Tree", "Disk Storage"] as const;
 
@@ -196,11 +158,19 @@ function ProgressDashboard({ globalStats, userId, loaded }: ProgressDashboardPro
           {/* Needs review section */}
           {globalStats.weakTopics.length > 0 && (
             <div className="mt-4 p-3.5 rounded-xl bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800/30">
-              <div className="flex items-center gap-2 mb-2">
-                <FaExclamationTriangle className="text-amber-500 text-xs" />
-                <span className="text-[10px] font-black tracking-widest text-amber-700 dark:text-amber-400 uppercase">
-                  Needs Review
-                </span>
+              <div className="flex items-center justify-between mb-2">
+                <div className="flex items-center gap-2">
+                  <FaExclamationTriangle className="text-amber-500 text-xs" />
+                  <span className="text-[10px] font-black tracking-widest text-amber-700 dark:text-amber-400 uppercase">
+                    Needs Review
+                  </span>
+                </div>
+                <Link
+                  to="/dashboard"
+                  className="text-[10px] font-bold text-amber-700 dark:text-amber-400 hover:underline no-underline"
+                >
+                  View full dashboard →
+                </Link>
               </div>
               <div className="flex flex-wrap gap-1.5">
                 {globalStats.weakTopics.slice(0, 6).map(id => {

--- a/src/utils/weakTopics.ts
+++ b/src/utils/weakTopics.ts
@@ -1,0 +1,51 @@
+import type { QuizStat } from "../hooks/useQuizProgress";
+import { QUIZZES_CONFIG, type QuizCardConfig } from "../data/quizzesConfig";
+
+export interface WeakTopicEntry {
+  quiz: QuizCardConfig;
+  stat: QuizStat;
+}
+
+export const MIN_WEAK_TOPICS = 3;
+export const MAX_WEAK_TOPICS = 5;
+
+/**
+ * Ranks the topics a learner should practice next, weakest first.
+ *
+ * - Topics with at least one attempt are ranked by best score % (ascending —
+ *   lowest score first), since "weakest" should reflect demonstrated
+ *   performance, not just an untried topic.
+ * - If fewer than MIN_WEAK_TOPICS have been attempted at all, the list is
+ *   padded with never-attempted topics so the dashboard still has something
+ *   useful to suggest to a newer learner, rather than showing an empty state.
+ * - Returns at most MAX_WEAK_TOPICS entries.
+ */
+export function rankWeakTopics(
+  stats: Record<string, QuizStat>,
+  quizzes: QuizCardConfig[] = QUIZZES_CONFIG,
+): WeakTopicEntry[] {
+  const attempted: WeakTopicEntry[] = [];
+  const notAttempted: WeakTopicEntry[] = [];
+
+  quizzes.forEach((quiz) => {
+    const stat = stats[quiz.id];
+    if (!stat) return;
+
+    if (stat.totalAttempts > 0) {
+      attempted.push({ quiz, stat });
+    } else {
+      notAttempted.push({ quiz, stat });
+    }
+  });
+
+  attempted.sort((a, b) => a.stat.bestPercent - b.stat.bestPercent);
+
+  const result = attempted.slice(0, MAX_WEAK_TOPICS);
+
+  if (result.length < MIN_WEAK_TOPICS) {
+    const needed = MIN_WEAK_TOPICS - result.length;
+    result.push(...notAttempted.slice(0, needed));
+  }
+
+  return result;
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR introduces a Personal Weak Topics Dashboard that analyzes a user's historical quiz performance and surfaces the topics where they need the most improvement. The dashboard aggregates existing quiz history from useQuizData.ts (Supabase-backed) and presents personalized practice recommendations without requiring any backend changes.

By identifying weak areas and linking users directly to relevant learning resources, this feature creates a more adaptive and efficient learning experience.
Added a dedicated dashboard section that summarizes historical quiz performance by topic, including:

Arrays
Strings
Linked Lists
Stacks & Queues
Trees
Graphs
Dynamic Programming
Greedy
Backtracking
Recursion
Searching
Sorting
Other supported quiz categories

Fixes #3285 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
