### PR TITLE
feat: add bookmark support for DSA problems with "My Bookmarks" filter

### DIFF
--- a/src/__tests__/components/ProblemFilterGrid.test.tsx
+++ b/src/__tests__/components/ProblemFilterGrid.test.tsx
@@ -46,6 +46,10 @@ const mockData: DsaProblemsIndex = {
   ],
 };
 
+beforeEach(() => {
+  localStorage.clear();
+});
+
 describe('ProblemFilterGrid', () => {
   test('renders all problems by default', () => {
     render(<ProblemFilterGrid data={mockData} />);
@@ -114,5 +118,29 @@ describe('ProblemFilterGrid', () => {
     expect(screen.getByText('Two Sum')).toBeInTheDocument();
     expect(screen.getByText('Course Schedule')).toBeInTheDocument();
     expect(screen.getByText('Edit Distance')).toBeInTheDocument();
+  });
+
+  test('renders a "My Bookmarks" filter chip', () => {
+    render(<ProblemFilterGrid data={mockData} />);
+    expect(screen.getByRole('button', { name: /my bookmarks/i })).toBeInTheDocument();
+  });
+
+  test('bookmarking a problem then toggling My Bookmarks shows only that problem', async () => {
+    const user = userEvent.setup();
+    render(<ProblemFilterGrid data={mockData} />);
+
+    // Bookmark "Two Sum" via its star button
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /bookmark two sum/i }));
+    });
+
+    // Activate the My Bookmarks chip
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /my bookmarks/i }));
+    });
+
+    expect(screen.getByText('Two Sum')).toBeInTheDocument();
+    expect(screen.queryByText('Course Schedule')).not.toBeInTheDocument();
+    expect(screen.queryByText('Edit Distance')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/hooks/useBookmarks.test.ts
+++ b/src/__tests__/hooks/useBookmarks.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the useBookmarks hook.
+ *
+ * jsdom provides localStorage, so we can exercise the real persistence path.
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useBookmarks } from '../../hooks/useBookmarks';
+
+const STORAGE_KEY = 'algo.dsa.bookmarks.v1';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useBookmarks', () => {
+  test('starts with an empty bookmark set', () => {
+    const { result } = renderHook(() => useBookmarks());
+    // After mount the effect fires synchronously in renderHook
+    expect(result.current.bookmarks.size).toBe(0);
+  });
+
+  test('toggleBookmark adds an ID that was not present', () => {
+    const { result } = renderHook(() => useBookmarks());
+
+    act(() => {
+      result.current.toggleBookmark('two-sum-problem');
+    });
+
+    expect(result.current.isBookmarked('two-sum-problem')).toBe(true);
+    expect(result.current.bookmarks.size).toBe(1);
+  });
+
+  test('toggleBookmark removes an ID that was already bookmarked', () => {
+    const { result } = renderHook(() => useBookmarks());
+
+    act(() => {
+      result.current.toggleBookmark('two-sum-problem');
+    });
+    act(() => {
+      result.current.toggleBookmark('two-sum-problem');
+    });
+
+    expect(result.current.isBookmarked('two-sum-problem')).toBe(false);
+    expect(result.current.bookmarks.size).toBe(0);
+  });
+
+  test('persists bookmarks to localStorage', () => {
+    const { result } = renderHook(() => useBookmarks());
+
+    act(() => {
+      result.current.toggleBookmark('two-sum-problem');
+      result.current.toggleBookmark('merge-intervals-problem');
+    });
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    expect(stored).toContain('two-sum-problem');
+    expect(stored).toContain('merge-intervals-problem');
+  });
+
+  test('hydrates from existing localStorage value on mount', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(['two-sum-problem']));
+
+    const { result } = renderHook(() => useBookmarks());
+
+    // useEffect fires synchronously in renderHook wrapper
+    expect(result.current.isBookmarked('two-sum-problem')).toBe(true);
+  });
+
+  test('recovers gracefully from corrupt localStorage value', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{{');
+
+    const { result } = renderHook(() => useBookmarks());
+
+    expect(result.current.bookmarks.size).toBe(0);
+    // Corrupt key should be removed
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/components/ProblemCard.tsx
+++ b/src/components/ProblemCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import clsx from 'clsx';
-import { ArrowUpRight } from 'lucide-react';
+import { ArrowUpRight, Star } from 'lucide-react';
 import type { DsaProblem } from '../data/dsaProblemsTypes';
 
 const DIFFICULTY_STYLES: Record<string, string> = {
@@ -15,9 +15,11 @@ const MAX_VISIBLE_TAGS = 3;
 interface ProblemCardProps {
   problem: DsaProblem;
   tagLabels: Map<string, string>;
+  isBookmarked: boolean;
+  onToggleBookmark: (id: string) => void;
 }
 
-export default function ProblemCard({ problem, tagLabels }: ProblemCardProps) {
+export default function ProblemCard({ problem, tagLabels, isBookmarked, onToggleBookmark }: ProblemCardProps) {
   const visibleTags = problem.tags.slice(0, MAX_VISIBLE_TAGS);
   const extraTagCount = problem.tags.length - visibleTags.length;
 
@@ -42,6 +44,30 @@ export default function ProblemCard({ problem, tagLabels }: ProblemCardProps) {
             >
               {problem.difficulty}
             </span>
+
+            {/* Bookmark star — stops the Link navigation */}
+            <button
+              type="button"
+              aria-label={isBookmarked ? `Remove ${problem.title} from bookmarks` : `Bookmark ${problem.title}`}
+              aria-pressed={isBookmarked}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onToggleBookmark(problem.id);
+              }}
+              className={clsx(
+                'flex-shrink-0 p-0.5 rounded transition-colors',
+                isBookmarked
+                  ? 'text-amber-400'
+                  : 'text-[var(--ifm-color-emphasis-400)] hover:text-amber-400',
+              )}
+            >
+              <Star
+                className="h-4 w-4 transition-transform duration-150 group-hover:scale-100"
+                fill={isBookmarked ? 'currentColor' : 'none'}
+                strokeWidth={2}
+              />
+            </button>
           </div>
 
           <h3 className="m-0 text-base font-bold tracking-tight transition-colors text-[var(--ifm-heading-color)] group-hover:text-[var(--ifm-color-primary)]">

--- a/src/components/ProblemFilterGrid.tsx
+++ b/src/components/ProblemFilterGrid.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo, useState } from 'react';
 import clsx from 'clsx';
-import { Search, X } from 'lucide-react';
+import { Bookmark, Search, X } from 'lucide-react';
 import ProblemCard from './ProblemCard';
 import type { DsaProblemsIndex } from '../data/dsaProblemsTypes';
+import { useBookmarks } from '../hooks/useBookmarks';
 
 interface ProblemFilterGridProps {
   data: DsaProblemsIndex;
@@ -24,6 +25,9 @@ export default function ProblemFilterGrid({ data }: ProblemFilterGridProps) {
   const [selectedDifficulties, setSelectedDifficulties] = useState<Set<string>>(new Set());
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
   const [showAllTags, setShowAllTags] = useState(false);
+  const [showOnlyBookmarks, setShowOnlyBookmarks] = useState(false);
+
+  const { bookmarks, isBookmarked, toggleBookmark } = useBookmarks();
 
   const tagLabels = useMemo(() => new Map(data.tags.map((t) => [t.value, t.label])), [data.tags]);
 
@@ -62,12 +66,16 @@ export default function ProblemFilterGrid({ data }: ProblemFilterGridProps) {
     setQuery('');
     setSelectedDifficulties(new Set());
     setSelectedTags(new Set());
+    setShowOnlyBookmarks(false);
   };
 
   const filteredProblems = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
 
     return data.problems.filter((problem) => {
+      if (showOnlyBookmarks && !bookmarks.has(problem.id)) {
+        return false;
+      }
       if (selectedDifficulties.size > 0 && !selectedDifficulties.has(problem.difficulty)) {
         return false;
       }
@@ -79,9 +87,10 @@ export default function ProblemFilterGrid({ data }: ProblemFilterGridProps) {
       }
       return true;
     });
-  }, [data.problems, query, selectedDifficulties, selectedTags]);
+  }, [data.problems, query, selectedDifficulties, selectedTags, showOnlyBookmarks, bookmarks]);
 
-  const hasActiveFilters = query.trim() !== '' || selectedDifficulties.size > 0 || selectedTags.size > 0;
+  const hasActiveFilters =
+    query.trim() !== '' || selectedDifficulties.size > 0 || selectedTags.size > 0 || showOnlyBookmarks;
 
   return (
     <div>
@@ -159,6 +168,37 @@ export default function ProblemFilterGrid({ data }: ProblemFilterGridProps) {
         )}
       </div>
 
+      {/* My Bookmarks chip */}
+      <div className="flex flex-wrap items-center gap-2 mt-3 mb-2">
+        <span className="text-xs font-bold uppercase tracking-wider text-[var(--ifm-color-emphasis-600)] mr-1">
+          Saved
+        </span>
+        <button
+          type="button"
+          aria-pressed={showOnlyBookmarks}
+          onClick={() => setShowOnlyBookmarks((v) => !v)}
+          className={clsx(
+            'inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-full border transition-colors',
+            showOnlyBookmarks
+              ? 'bg-amber-400/15 text-amber-600 border-amber-400/40 dark:text-amber-400'
+              : 'border-[var(--ifm-toc-border-color)] text-[var(--ifm-color-emphasis-700)] hover:border-amber-400',
+          )}
+        >
+          <Bookmark className="h-3.5 w-3.5" fill={showOnlyBookmarks ? 'currentColor' : 'none'} strokeWidth={2} />
+          My Bookmarks
+          {bookmarks.size > 0 && (
+            <span
+              className={clsx(
+                'ml-0.5 rounded-full px-1.5 py-0 text-[10px] font-bold',
+                showOnlyBookmarks ? 'bg-amber-400/30' : 'bg-[var(--ifm-color-emphasis-200)]',
+              )}
+            >
+              {bookmarks.size}
+            </span>
+          )}
+        </button>
+      </div>
+
       {hasActiveFilters && (
         <button
           type="button"
@@ -179,7 +219,13 @@ export default function ProblemFilterGrid({ data }: ProblemFilterGridProps) {
       {filteredProblems.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-5">
           {filteredProblems.map((problem) => (
-            <ProblemCard key={problem.url} problem={problem} tagLabels={tagLabels} />
+            <ProblemCard
+              key={problem.url}
+              problem={problem}
+              tagLabels={tagLabels}
+              isBookmarked={isBookmarked(problem.id)}
+              onToggleBookmark={toggleBookmark}
+            />
           ))}
         </div>
       ) : (

--- a/src/hooks/useBookmarks.ts
+++ b/src/hooks/useBookmarks.ts
@@ -1,0 +1,72 @@
+/**
+ * useBookmarks
+ * ------------
+ * Persists bookmarked DSA-problem IDs to localStorage under
+ * "algo.dsa.bookmarks.v1" (a JSON array of strings).
+ *
+ * SSG-safe: localStorage is only accessed inside useEffect / callbacks,
+ * so the initial render always starts with an empty set and hydrates
+ * silently after mount.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+
+const STORAGE_KEY = 'algo.dsa.bookmarks.v1';
+
+function readFromStorage(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return new Set(parsed as string[]);
+  } catch {
+    // Corrupt value — reset silently
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+  return new Set();
+}
+
+function writeToStorage(ids: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(ids)));
+  } catch {
+    // Storage full or unavailable — ignore
+  }
+}
+
+export interface UseBookmarksReturn {
+  /** The set of bookmarked problem IDs */
+  bookmarks: Set<string>;
+  /** Returns true if the given problem ID is bookmarked */
+  isBookmarked: (id: string) => boolean;
+  /** Toggles the bookmark state for the given problem ID */
+  toggleBookmark: (id: string) => void;
+}
+
+export function useBookmarks(): UseBookmarksReturn {
+  const [bookmarks, setBookmarks] = useState<Set<string>>(new Set());
+
+  // Hydrate from localStorage after mount (SSG-safe)
+  useEffect(() => {
+    setBookmarks(readFromStorage());
+  }, []);
+
+  const toggleBookmark = useCallback((id: string) => {
+    setBookmarks((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      writeToStorage(next);
+      return next;
+    });
+  }, []);
+
+  const isBookmarked = useCallback((id: string) => bookmarks.has(id), [bookmarks]);
+
+  return { bookmarks, isBookmarked, toggleBookmark };
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces a bookmarking system for the DSA Problems Browser, allowing users to save problems they want to revisit later. Bookmarked problems are stored locally using localStorage, providing a personalized experience without requiring any backend changes.

A new "My Bookmarks" filter has also been added, enabling users to quickly view and practice their saved problems.

Consumes useBookmarks and threads isBookmarked/toggleBookmark down to each card
Adds a "My Bookmarks" filter chip (amber-tinted when active) with a live count badge showing how many problems are starred
clearFilters also resets the bookmarks filter
hasActiveFilters is true when the bookmarks chip is active, so the "Clear filters" button appears

Fixes #3386 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
