### PR TITLE
Add Daily Quiz Streak Tracker (Duolingo-style)

### DIFF
--- a/src/__tests__/hooks/useQuizStreak.test.tsx
+++ b/src/__tests__/hooks/useQuizStreak.test.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import { useQuizStreak } from "../../hooks/useQuizStreak";
+
+function TestComponent() {
+  const streak = useQuizStreak();
+  if (!streak.loaded) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <div data-testid="currentStreak">{streak.currentStreak}</div>
+      <div data-testid="longestStreak">{streak.longestStreak}</div>
+      <div data-testid="totalActiveDays">{streak.totalActiveDays}</div>
+      <div data-testid="practicedToday">{streak.practicedToday ? "true" : "false"}</div>
+      <div data-testid="last7Days">{streak.last7Days.map((b) => (b ? "1" : "0")).join(",")}</div>
+    </div>
+  );
+}
+
+describe("useQuizStreak hook", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("returns zeroes when no quiz attempts exist in localStorage", () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId("currentStreak").textContent).toBe("0");
+    expect(screen.getByTestId("longestStreak").textContent).toBe("0");
+    expect(screen.getByTestId("totalActiveDays").textContent).toBe("0");
+    expect(screen.getByTestId("practicedToday").textContent).toBe("false");
+    expect(screen.getByTestId("last7Days").textContent).toBe("0,0,0,0,0,0,0");
+  });
+
+  test("calculates active today correctly when a quiz attempt exists for today", () => {
+    const todayIso = new Date().toISOString();
+    const attempts = [{ score: 10, completedAt: todayIso }];
+    localStorage.setItem("quiz_attempts_user1_arrays", JSON.stringify(attempts));
+
+    render(<TestComponent />);
+    expect(screen.getByTestId("currentStreak").textContent).toBe("1");
+    expect(screen.getByTestId("longestStreak").textContent).toBe("1");
+    expect(screen.getByTestId("totalActiveDays").textContent).toBe("1");
+    expect(screen.getByTestId("practicedToday").textContent).toBe("true");
+    expect(screen.getByTestId("last7Days").textContent).toBe("0,0,0,0,0,0,1");
+  });
+
+  test("calculates multi-day streak across consecutive calendar days", () => {
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setUTCDate(today.getUTCDate() - 1);
+    const dayBefore = new Date();
+    dayBefore.setUTCDate(today.getUTCDate() - 2);
+
+    const attemptsToday = [{ score: 10, completedAt: today.toISOString() }];
+    const attemptsYesterday = [{ score: 8, completedAt: yesterday.toISOString() }];
+    const attemptsDayBefore = [{ score: 9, completedAt: dayBefore.toISOString() }];
+
+    localStorage.setItem("quiz_attempts_u1_arrays", JSON.stringify(attemptsToday));
+    localStorage.setItem("quiz_attempts_u1_stacks", JSON.stringify(attemptsYesterday));
+    localStorage.setItem("quiz_attempts_u1_queues", JSON.stringify(attemptsDayBefore));
+
+    render(<TestComponent />);
+    expect(screen.getByTestId("currentStreak").textContent).toBe("3");
+    expect(screen.getByTestId("longestStreak").textContent).toBe("3");
+    expect(screen.getByTestId("totalActiveDays").textContent).toBe("3");
+    expect(screen.getByTestId("practicedToday").textContent).toBe("true");
+    expect(screen.getByTestId("last7Days").textContent).toBe("0,0,0,0,1,1,1");
+  });
+});

--- a/src/components/QuizStreakWidget.tsx
+++ b/src/components/QuizStreakWidget.tsx
@@ -1,0 +1,201 @@
+/**
+ * QuizStreakWidget
+ * ---------------
+ * Duolingo-style daily streak counter driven entirely by quiz-attempt
+ * timestamps from localStorage.  No new data is written.
+ *
+ * Shows:
+ *  - Flame icon + current streak (days)
+ *  - Longest streak
+ *  - Total active days
+ *  - 7-day mini-heatmap (last 7 calendar days)
+ *  - "Practice today" badge when the user has already attempted a quiz today
+ */
+
+// @ts-nocheck
+import React from "react";
+import { motion } from "framer-motion";
+import { useQuizStreak } from "../hooks/useQuizStreak";
+
+// --- Day labels for the week heatmap -----------------------------------------
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function getLastSevenDayLabels(): string[] {
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date();
+    d.setDate(d.getDate() - (6 - i));
+    return DAY_LABELS[d.getDay()];
+  });
+}
+
+// --- Stat pill ---------------------------------------------------------------
+
+function StatPill({
+  value,
+  label,
+  color,
+}: {
+  value: string | number;
+  label: string;
+  color: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-0.5">
+      <span className={`text-xl font-black font-mono leading-none ${color}`}>
+        {value}
+      </span>
+      <span className="text-[9px] font-bold tracking-widest uppercase text-slate-400">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+// --- Component ---------------------------------------------------------------
+
+export default function QuizStreakWidget() {
+  const streak = useQuizStreak();
+
+  // Don't render until localStorage has been read
+  if (!streak.loaded) return null;
+
+  const dayLabels = getLastSevenDayLabels();
+
+  const flameColor = streak.currentStreak === 0
+    ? "text-slate-400 dark:text-slate-600"
+    : streak.practicedToday
+    ? "text-orange-500"
+    : "text-amber-400";
+
+  const flameShadow = streak.practicedToday
+    ? "drop-shadow(0 0 6px rgba(249,115,22,0.5))"
+    : "none";
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: 0.1 }}
+      className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden shadow-sm"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-3.5 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/60">
+        <div className="flex items-center gap-2">
+          {/* Flame SVG — avoids any icon-library bundle concerns */}
+          <svg
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            className={`w-4 h-4 ${flameColor} transition-colors duration-300`}
+            style={{ filter: flameShadow }}
+            aria-hidden="true"
+          >
+            <path d="M12 2c0 0-4 4-4 8a4 4 0 0 0 8 0c0-1.5-.5-3-1.5-4C14 8 14 10 12 10c-1.1 0-2-.9-2-2 0-2 2-6 2-6zm0 20a6 6 0 0 1-6-6c0-3.3 2.4-6 4-8 .5 1.5.5 3 0 4a4 4 0 0 0 4 4c1.1 0 2.1-.4 2.8-1.1A6 6 0 0 1 12 22z" />
+          </svg>
+          <span className="text-[10px] font-black tracking-widest text-slate-500 dark:text-slate-400 uppercase">
+            Quiz Streak
+          </span>
+        </div>
+
+        {streak.practicedToday && (
+          <motion.span
+            initial={{ scale: 0.8, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            className="flex items-center gap-1 text-[9px] font-black tracking-widest uppercase px-2 py-0.5 rounded-full bg-orange-100 dark:bg-orange-900/30 text-orange-600 dark:text-orange-400 border border-orange-200 dark:border-orange-800/40"
+          >
+            <span className="w-1.5 h-1.5 rounded-full bg-orange-500 animate-pulse" />
+            Active Today
+          </motion.span>
+        )}
+
+        {!streak.practicedToday && streak.currentStreak > 0 && (
+          <span className="text-[9px] font-mono text-amber-500 dark:text-amber-400 font-bold">
+            Take a quiz to keep it alive!
+          </span>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="px-5 py-4 space-y-4">
+        {/* Stats row */}
+        <div className="flex items-center justify-around gap-4">
+          {/* Big flame + streak number */}
+          <div className="flex items-center gap-2.5">
+            <motion.svg
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className={`w-10 h-10 ${flameColor} shrink-0`}
+              style={{ filter: flameShadow }}
+              animate={streak.practicedToday ? { scale: [1, 1.12, 1] } : {}}
+              transition={{ duration: 1.2, repeat: Infinity, ease: "easeInOut" }}
+              aria-hidden="true"
+            >
+              <path d="M12 2c0 0-4 4-4 8a4 4 0 0 0 8 0c0-1.5-.5-3-1.5-4C14 8 14 10 12 10c-1.1 0-2-.9-2-2 0-2 2-6 2-6zm0 20a6 6 0 0 1-6-6c0-3.3 2.4-6 4-8 .5 1.5.5 3 0 4a4 4 0 0 0 4 4c1.1 0 2.1-.4 2.8-1.1A6 6 0 0 1 12 22z" />
+            </motion.svg>
+            <div>
+              <div className={`text-3xl font-black font-mono leading-none ${streak.currentStreak > 0 ? "text-orange-500 dark:text-orange-400" : "text-slate-400 dark:text-slate-600"}`}>
+                {streak.currentStreak}
+              </div>
+              <div className="text-[9px] font-bold tracking-widest uppercase text-slate-400 mt-0.5">
+                day streak
+              </div>
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="w-px h-12 bg-slate-100 dark:bg-slate-800 shrink-0" />
+
+          {/* Longest + Active days */}
+          <div className="flex gap-5">
+            <StatPill
+              value={streak.longestStreak}
+              label="Best"
+              color="text-amber-500 dark:text-amber-400"
+            />
+            <StatPill
+              value={streak.totalActiveDays}
+              label="Total Days"
+              color="text-blue-500 dark:text-blue-400"
+            />
+          </div>
+        </div>
+
+        {/* 7-day heatmap */}
+        <div>
+          <div className="flex items-end justify-between gap-1">
+            {streak.last7Days.map((active, i) => (
+              <div key={i} className="flex flex-col items-center gap-1 flex-1">
+                <motion.div
+                  initial={{ scaleY: 0 }}
+                  animate={{ scaleY: 1 }}
+                  transition={{ duration: 0.35, delay: i * 0.04 }}
+                  style={{ originY: 1 }}
+                  className={`w-full rounded-md transition-colors duration-300 ${
+                    i === 6
+                      ? active
+                        ? "bg-orange-500 h-6 shadow-[0_0_8px_rgba(249,115,22,0.4)]"
+                        : "bg-slate-200 dark:bg-slate-700 h-6 border-2 border-dashed border-orange-300 dark:border-orange-700"
+                      : active
+                      ? "bg-amber-400 dark:bg-amber-500 h-5"
+                      : "bg-slate-100 dark:bg-slate-800 h-5"
+                  }`}
+                  title={`${dayLabels[i]}: ${active ? "practiced" : "no quiz"}`}
+                />
+                <span className={`text-[8px] font-mono font-bold ${i === 6 ? "text-orange-500 dark:text-orange-400" : "text-slate-400"}`}>
+                  {dayLabels[i]}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Zero-state nudge */}
+        {streak.currentStreak === 0 && streak.totalActiveDays === 0 && (
+          <p className="text-center text-[10px] font-medium text-slate-400 dark:text-slate-600 pt-1">
+            Complete a quiz to start your streak ??
+          </p>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/hooks/useQuizStreak.ts
+++ b/src/hooks/useQuizStreak.ts
@@ -1,0 +1,195 @@
+/**
+ * useQuizStreak
+ * -------------
+ * Derives a Duolingo-style daily-streak counter purely from the
+ * quiz-attempt timestamps already stored in localStorage.
+ *
+ * localStorage key pattern (written by saveQuizAttemptLocal):
+ *   quiz_attempts_<uid>_<quizId>  ->  JSON array of { score, completedAt, ... }
+ *
+ * Algorithm
+ * ---------
+ * 1. Scan every localStorage key that starts with "quiz_attempts_".
+ * 2. Collect all `completedAt` ISO strings across every quiz / user combo.
+ * 3. Normalise each timestamp to a UTC calendar date (YYYY-MM-DD string).
+ * 4. De-duplicate: only one activity "tick" per calendar day.
+ * 5. Sort descending and walk consecutive days to count the current streak.
+ * 6. Walk the entire sorted set to find the all-time longest streak.
+ * 7. Build a "last 7 days" boolean array for the mini-heatmap.
+ *
+ * SSG-safe: localStorage is only touched inside a useEffect.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { safeJsonParse } from "../utils/safeStorage";
+
+// --- Types -------------------------------------------------------------------
+
+export interface QuizStreakData {
+  /** Consecutive calendar days (up to and including today) with >= 1 quiz attempt. */
+  currentStreak: number;
+  /** Longest consecutive-day run ever recorded. */
+  longestStreak: number;
+  /** Total distinct calendar days on which any quiz was attempted. */
+  totalActiveDays: number;
+  /** True if the user has already attempted a quiz today (UTC). */
+  practicedToday: boolean;
+  /**
+   * Activity flags for the last 7 days, index 0 = 6 days ago, index 6 = today.
+   * Used to render the mini week-heatmap.
+   */
+  last7Days: boolean[];
+  /** Whether the hook has finished reading from localStorage. */
+  loaded: boolean;
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+/** Returns "YYYY-MM-DD" in UTC for a given Date. */
+function toUtcDateStr(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Returns the UTC date string for "today". */
+function todayUtc(): string {
+  return toUtcDateStr(new Date());
+}
+
+/** Returns "YYYY-MM-DD" for a day that is `offsetDays` before today (UTC). */
+function offsetDayUtc(offsetDays: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - offsetDays);
+  return toUtcDateStr(d);
+}
+
+/**
+ * Given a sorted (descending) array of unique date strings,
+ * compute the current streak (consecutive days ending at/after today)
+ * and the all-time longest streak.
+ */
+function computeStreaks(sortedDescDates: string[]): {
+  currentStreak: number;
+  longestStreak: number;
+} {
+  if (sortedDescDates.length === 0) return { currentStreak: 0, longestStreak: 0 };
+
+  const today = todayUtc();
+  const yesterday = offsetDayUtc(1);
+
+  // -- Current streak --
+  // Starts only if the most recent activity was today or yesterday.
+  let currentStreak = 0;
+  const mostRecent = sortedDescDates[0];
+  if (mostRecent === today || mostRecent === yesterday) {
+    currentStreak = 1;
+    for (let i = 1; i < sortedDescDates.length; i++) {
+      const prev = sortedDescDates[i - 1];
+      const curr = sortedDescDates[i];
+      // Check that curr is exactly one day before prev
+      const prevMs = new Date(prev).getTime();
+      const currMs = new Date(curr).getTime();
+      const diffDays = Math.round((prevMs - currMs) / 86_400_000);
+      if (diffDays === 1) {
+        currentStreak++;
+      } else {
+        break;
+      }
+    }
+  }
+
+  // -- Longest streak --
+  let longestStreak = 0;
+  let run = 1;
+  for (let i = 1; i < sortedDescDates.length; i++) {
+    const prev = sortedDescDates[i - 1];
+    const curr = sortedDescDates[i];
+    const diffDays = Math.round(
+      (new Date(prev).getTime() - new Date(curr).getTime()) / 86_400_000
+    );
+    if (diffDays === 1) {
+      run++;
+    } else {
+      longestStreak = Math.max(longestStreak, run);
+      run = 1;
+    }
+  }
+  longestStreak = Math.max(longestStreak, run);
+
+  return { currentStreak, longestStreak };
+}
+
+// --- Hook --------------------------------------------------------------------
+
+const INITIAL_STATE: QuizStreakData = {
+  currentStreak: 0,
+  longestStreak: 0,
+  totalActiveDays: 0,
+  practicedToday: false,
+  last7Days: [false, false, false, false, false, false, false],
+  loaded: false,
+};
+
+export function useQuizStreak(): QuizStreakData {
+  const [data, setData] = useState<QuizStreakData>(INITIAL_STATE);
+
+  const compute = useCallback(() => {
+    if (typeof window === "undefined" || !window.localStorage) return;
+
+    // 1. Gather every completedAt timestamp from all quiz_attempts_* keys
+    const activeDateSet = new Set<string>();
+
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !key.startsWith("quiz_attempts_")) continue;
+
+      const attempts = safeJsonParse<Array<{ completedAt?: string }>>(key, []);
+      if (!Array.isArray(attempts)) continue;
+
+      for (const attempt of attempts) {
+        if (!attempt.completedAt) continue;
+        const d = new Date(attempt.completedAt);
+        if (!Number.isNaN(d.getTime())) {
+          activeDateSet.add(toUtcDateStr(d));
+        }
+      }
+    }
+
+    // 2. Sort descending
+    const sortedDates = Array.from(activeDateSet).sort((a, b) =>
+      b.localeCompare(a)
+    );
+
+    // 3. Compute streaks
+    const { currentStreak, longestStreak } = computeStreaks(sortedDates);
+
+    // 4. Today flag
+    const practicedToday = activeDateSet.has(todayUtc());
+
+    // 5. Last-7-days heatmap (index 0 = 6 days ago, index 6 = today)
+    const last7Days: boolean[] = Array.from({ length: 7 }, (_, i) =>
+      activeDateSet.has(offsetDayUtc(6 - i))
+    );
+
+    setData({
+      currentStreak,
+      longestStreak,
+      totalActiveDays: sortedDates.length,
+      practicedToday,
+      last7Days,
+      loaded: true,
+    });
+  }, []);
+
+  useEffect(() => {
+    compute();
+    // Re-compute whenever any quiz is completed or storage changes
+    window.addEventListener("quizCompleted", compute);
+    window.addEventListener("storage", compute);
+    return () => {
+      window.removeEventListener("quizCompleted", compute);
+      window.removeEventListener("storage", compute);
+    };
+  }, [compute]);
+
+  return data;
+}

--- a/src/pages/quizzes/index.tsx
+++ b/src/pages/quizzes/index.tsx
@@ -10,6 +10,7 @@ import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { useQuizProgress, QuizStat, GlobalQuizStats } from "../../hooks/useQuizProgress";
+import QuizStreakWidget from "../../components/QuizStreakWidget";
 import { QUIZZES_CONFIG, QUESTION_COUNTS, QUIZ_IDS, type QuizCardConfig } from "../../data/quizzesConfig";
 
 const FILTER_CATEGORIES = ["All", "Linear", "Non-Linear", "Balanced Tree", "Disk Storage"] as const;
@@ -64,7 +65,7 @@ function ProgressDashboard({ globalStats, userId, loaded }: ProgressDashboardPro
       initial={{ opacity: 0, y: 12 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.35 }}
-      className="max-w-7xl mx-auto px-4 mt-10 mb-2"
+      className="w-full"
     >
       <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl overflow-hidden shadow-sm">
 
@@ -355,7 +356,14 @@ const Quizzes: React.FC = () => {
               const { stats, globalStats, userId, loaded } = useQuizProgress(QUIZ_IDS, QUESTION_COUNTS);
               return (
                 <>
-                  <ProgressDashboard globalStats={globalStats} userId={userId} loaded={loaded} />
+                  <div className="max-w-7xl mx-auto px-4 mt-10 mb-2 grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
+                    <div className="lg:col-span-2">
+                      <ProgressDashboard globalStats={globalStats} userId={userId} loaded={loaded} />
+                    </div>
+                    <div className="lg:col-span-1">
+                      <QuizStreakWidget />
+                    </div>
+                  </div>
 
                   {/* Search + filters */}
                   <div className="max-w-7xl mx-auto px-4 mt-8 space-y-6">


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces a Daily Quiz Streak Tracker that encourages consistent learning by displaying a user's current consecutive-day quiz streak, similar to Duolingo.

The implementation reuses the existing quiz attempt timestamps already stored in localStorage, requiring no backend changes or new persistence layer.

useQuizStreak Hook (

useQuizStreak.ts
)

Scans existing quiz_attempts_<uid>_<quizId> records in localStorage.
Extracts all completedAt ISO timestamps and normalizes them into distinct UTC calendar dates (YYYY-MM-DD).
Computes:
Current streak: Consecutive calendar days up to and including today.
Longest streak: All-time maximum consecutive days.
Total active days: Total distinct calendar days with quiz attempts.
Practiced today: Flag indicating if a quiz has been taken today.
Last 7 days heatmap: Boolean array for rendering the 7-day mini-activity bar.

Fixes #3393 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
