### PR TITLE
Add "Related Problems" Recommendations to DSA Problem Pages

### DIFF
--- a/src/__tests__/components/RelatedProblems.test.tsx
+++ b/src/__tests__/components/RelatedProblems.test.tsx
@@ -1,0 +1,107 @@
+import {
+  getRelatedDsaProblems,
+  formatTagLabel,
+  DsaProblemsIndexData,
+} from "../../components/RelatedProblems";
+
+const mockIndexData: DsaProblemsIndexData = {
+  generatedAt: "2026-08-01T00:00:00.000Z",
+  count: 4,
+  difficulties: ["Easy", "Medium", "Hard"],
+  tags: [
+    { value: "array", label: "Array" },
+    { value: "linked-list", label: "Linked List" },
+    { value: "two-pointers", label: "Two Pointers" },
+    { value: "dfs", label: "DFS" },
+  ],
+  companies: [],
+  problems: [
+    {
+      id: "add-two-numbers",
+      title: "Add Two Numbers",
+      description: "Add two numbers as linked lists",
+      difficulty: "Medium",
+      tags: ["linked-list"],
+      companies: [],
+      url: "/docs/dsa-problems/medium/add-two-numbers",
+    },
+    {
+      id: "reverse-linked-list",
+      title: "Reverse Linked List",
+      description: "Reverse a singly linked list",
+      difficulty: "Easy",
+      tags: ["linked-list"],
+      companies: [],
+      url: "/docs/dsa-problems/easy/reverse-linked-list",
+    },
+    {
+      id: "delete-node-linked-list",
+      title: "Delete Node in a Linked List",
+      description: "Delete node from linked list",
+      difficulty: "Medium",
+      tags: ["linked-list"],
+      companies: [],
+      url: "/docs/dsa-problems/medium/delete-node-linked-list",
+    },
+    {
+      id: "two-sum",
+      title: "Two Sum",
+      description: "Find two indices that sum to target",
+      difficulty: "Easy",
+      tags: ["array", "two-pointers"],
+      companies: [],
+      url: "/docs/dsa-problems/easy/two-sum",
+    },
+  ],
+};
+
+describe("RelatedProblems logic", () => {
+  test("formatTagLabel formats tag values to human readable labels", () => {
+    expect(formatTagLabel("linked-list")).toBe("Linked List");
+    expect(formatTagLabel("dfs")).toBe("DFS");
+  });
+
+  test("returns empty array for non-DSA problem documents", () => {
+    const doc = {
+      id: "basic-data-structures/array",
+      permalink: "/docs/basic-data-structures/array",
+      title: "Arrays in DSA",
+    };
+    const results = getRelatedDsaProblems(doc, mockIndexData);
+    expect(results).toEqual([]);
+  });
+
+  test("auto-suggests 2-3 related problems sharing a topic tag", () => {
+    const doc = {
+      id: "add-two-numbers",
+      permalink: "/docs/dsa-problems/medium/add-two-numbers",
+      title: "Add Two Numbers",
+      tags: ["linked-list"],
+    };
+
+    const results = getRelatedDsaProblems(doc, mockIndexData);
+
+    // Should return 2 matching linked-list problems (excluding add-two-numbers itself)
+    expect(results.length).toBe(2);
+
+    const ids = results.map((r) => r.problem.id);
+    expect(ids).not.toContain("add-two-numbers");
+    expect(ids).toContain("delete-node-linked-list");
+    expect(ids).toContain("reverse-linked-list");
+
+    // Medium difficulty problem should be ranked higher due to difficulty match bonus
+    expect(results[0].problem.id).toBe("delete-node-linked-list");
+    expect(results[0].sharedTags).toEqual(["linked-list"]);
+  });
+
+  test("respects limit parameter", () => {
+    const doc = {
+      id: "add-two-numbers",
+      permalink: "/docs/dsa-problems/medium/add-two-numbers",
+      title: "Add Two Numbers",
+    };
+
+    const results = getRelatedDsaProblems(doc, mockIndexData, 1);
+    expect(results.length).toBe(1);
+  });
+});

--- a/src/components/RelatedProblems.tsx
+++ b/src/components/RelatedProblems.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import Link from '@docusaurus/Link';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import dsaProblemsIndex from '../data/generated/dsaProblemsIndex.json';
+
+export interface DsaProblemIndexItem {
+  id: string;
+  title: string;
+  description: string;
+  difficulty: 'Easy' | 'Medium' | 'Hard';
+  tags: string[];
+  companies: string[];
+  url: string;
+}
+
+export interface DsaTagIndexItem {
+  value: string;
+  label: string;
+}
+
+export interface DsaProblemsIndexData {
+  generatedAt: string;
+  count: number;
+  difficulties: string[];
+  tags: DsaTagIndexItem[];
+  companies: string[];
+  problems: DsaProblemIndexItem[];
+}
+
+const indexData = dsaProblemsIndex as DsaProblemsIndexData;
+
+// Create tag label lookup map
+const TAG_LABEL_MAP: Record<string, string> = {};
+(indexData.tags || []).forEach((t) => {
+  TAG_LABEL_MAP[t.value] = t.label;
+});
+
+export function formatTagLabel(tagValue: string): string {
+  if (TAG_LABEL_MAP[tagValue]) return TAG_LABEL_MAP[tagValue];
+  return tagValue
+    .split('-')
+    .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : ''))
+    .join(' ');
+}
+
+function difficultyColor(difficulty: string): { bg: string; text: string; border: string } {
+  switch (difficulty) {
+    case 'Easy':
+      return {
+        bg: 'bg-emerald-500/10 dark:bg-emerald-500/20',
+        text: 'text-emerald-700 dark:text-emerald-400',
+        border: 'border-emerald-500/20 dark:border-emerald-500/30',
+      };
+    case 'Hard':
+      return {
+        bg: 'bg-rose-500/10 dark:bg-rose-500/20',
+        text: 'text-rose-700 dark:text-rose-400',
+        border: 'border-rose-500/20 dark:border-rose-500/30',
+      };
+    case 'Medium':
+    default:
+      return {
+        bg: 'bg-amber-500/10 dark:bg-amber-500/20',
+        text: 'text-amber-700 dark:text-amber-400',
+        border: 'border-amber-500/20 dark:border-amber-500/30',
+      };
+  }
+}
+
+export function getRelatedDsaProblems(
+  currentDoc: {
+    id?: string;
+    permalink?: string;
+    title?: string;
+    tags?: Array<{ label?: string; [key: string]: any } | string>;
+  },
+  data: DsaProblemsIndexData = indexData,
+  limit: number = 3
+): { problem: DsaProblemIndexItem; sharedTags: string[] }[] {
+  if (!currentDoc || !data || !data.problems) return [];
+
+  const permalink = currentDoc.permalink || '';
+  const docId = currentDoc.id || '';
+
+  // Check if current doc is a DSA problem doc
+  const isDsaProblemDoc =
+    permalink.includes('/docs/dsa-problems/') ||
+    docId.startsWith('dsa-problems/') ||
+    data.problems.some((p) => p.url === permalink || (permalink && permalink.endsWith(p.url)));
+
+  if (!isDsaProblemDoc) return [];
+
+  // Match current problem in index
+  const currentProblem = data.problems.find(
+    (p) =>
+      p.url === permalink ||
+      (permalink && permalink.endsWith(p.url)) ||
+      p.id === docId ||
+      (docId && docId.endsWith(p.id))
+  );
+
+  let targetTags: string[] = [];
+  if (currentProblem && currentProblem.tags && currentProblem.tags.length > 0) {
+    targetTags = currentProblem.tags;
+  } else if (currentDoc.tags && Array.isArray(currentDoc.tags)) {
+    targetTags = currentDoc.tags
+      .map((t) => {
+        const raw = typeof t === 'string' ? t : t.label || '';
+        return raw
+          .toLowerCase()
+          .trim()
+          .replace(/[^a-z0-9\s-]/g, '')
+          .replace(/\s+/g, '-');
+      })
+      .filter(Boolean);
+  }
+
+  if (targetTags.length === 0) return [];
+
+  const currentId = currentProblem ? currentProblem.id : docId;
+
+  const matches: { problem: DsaProblemIndexItem; sharedTags: string[]; score: number }[] = [];
+
+  for (const p of data.problems) {
+    if (p.id === currentId || p.url === permalink) continue;
+
+    const shared = p.tags.filter((t) => targetTags.includes(t));
+    if (shared.length > 0) {
+      let score = shared.length * 10;
+      if (currentProblem && p.difficulty === currentProblem.difficulty) {
+        score += 2;
+      }
+      matches.push({
+        problem: p,
+        sharedTags: shared,
+        score,
+      });
+    }
+  }
+
+  matches.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.problem.title.localeCompare(b.problem.title);
+  });
+
+  return matches.slice(0, limit).map((m) => ({
+    problem: m.problem,
+    sharedTags: m.sharedTags,
+  }));
+}
+
+export default function RelatedProblems(): React.ReactElement | null {
+  const { metadata } = useDoc();
+
+  const related = getRelatedDsaProblems(metadata);
+
+  if (related.length === 0) return null;
+
+  return (
+    <div className="no-print margin-top--lg pt-6 border-t border-slate-200 dark:border-slate-800">
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2.5">
+          <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-blue-500/10 text-blue-600 dark:text-blue-400 border border-blue-500/20">
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+              />
+            </svg>
+          </div>
+          <div>
+            <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 m-0 tracking-tight leading-snug">
+              Related Practice Problems
+            </h3>
+            <p className="text-xs text-slate-500 dark:text-slate-400 m-0 font-medium">
+              Handpicked problems sharing similar algorithmic topic tags
+            </p>
+          </div>
+        </div>
+        <Link
+          to="/docs/dsa-problems"
+          className="text-xs font-bold font-mono text-blue-600 dark:text-blue-400 hover:underline no-underline shrink-0 hidden sm:block"
+        >
+          View All Problems ?
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {related.map(({ problem, sharedTags }) => {
+          const diffStyle = difficultyColor(problem.difficulty);
+
+          return (
+            <Link
+              key={problem.id}
+              to={problem.url}
+              className="group relative flex flex-col justify-between p-4 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/60 hover:bg-slate-50 dark:hover:bg-slate-900 hover:border-blue-500/40 dark:hover:border-blue-500/40 transition-all duration-200 shadow-2xs hover:shadow-md hover:-translate-y-0.5 no-underline decoration-none"
+            >
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <span
+                    className={`text-[10px] font-mono font-bold px-2 py-0.5 rounded-md border ${diffStyle.bg} ${diffStyle.text} ${diffStyle.border}`}
+                  >
+                    {problem.difficulty}
+                  </span>
+                  <div className="flex flex-wrap gap-1 justify-end">
+                    {sharedTags.slice(0, 2).map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-[9px] font-mono font-semibold px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border border-slate-200/60 dark:border-slate-700/60"
+                      >
+                        #{formatTagLabel(tag)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <h4 className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors leading-snug">
+                  {problem.title}
+                </h4>
+
+                {problem.description && (
+                  <p className="text-xs text-slate-500 dark:text-slate-400 m-0 line-clamp-2 leading-relaxed font-normal">
+                    {problem.description}
+                  </p>
+                )}
+              </div>
+
+              <div className="mt-3 pt-2.5 border-t border-slate-100 dark:border-slate-800/80 flex items-center justify-between text-[11px] font-mono font-bold text-blue-600 dark:text-blue-400 group-hover:translate-x-0.5 transition-transform">
+                <span>Solve Problem</span>
+                <span>?</span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RelatedProblems.tsx
+++ b/src/components/RelatedProblems.tsx
@@ -185,12 +185,7 @@ export default function RelatedProblems(): React.ReactElement | null {
             </p>
           </div>
         </div>
-        <Link
-          to="/docs/dsa-problems"
-          className="text-xs font-bold font-mono text-blue-600 dark:text-blue-400 hover:underline no-underline shrink-0 hidden sm:block"
-        >
-          View All Problems ?
-        </Link>
+
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -6,6 +6,7 @@ import TagsListInline from '@theme/TagsListInline';
 type Props = Record<string, never>;
 import ProgressTracker from '@site/src/components/ProgressTracker';
 import DocInlineQuiz from '@site/src/components/DocInlineQuiz';
+import RelatedProblems from '@site/src/components/RelatedProblems';
 
 export default function DocItemFooter(props: Props): JSX.Element | null {
   const { metadata } = useDoc();
@@ -21,6 +22,7 @@ export default function DocItemFooter(props: Props): JSX.Element | null {
       <>
         <DocInlineQuiz />
         <ProgressTracker topicId={topicId} topicTitle={topicTitle} />
+        <RelatedProblems />
       </>
     );
   }
@@ -30,6 +32,8 @@ export default function DocItemFooter(props: Props): JSX.Element | null {
       <DocInlineQuiz />
 
       <ProgressTracker topicId={topicId} topicTitle={topicTitle} />
+
+      <RelatedProblems />
 
       <footer
         className={clsx(


### PR DESCRIPTION
## 📥 Pull Request

### Description


This PR adds a "Related Problems" section to every DSA problem page, helping users seamlessly discover similar questions after finishing a problem.

Instead of introducing new metadata or APIs, the feature leverages the existing tag index and browser-side problem metadata to automatically recommend 2–3 problems that share one or more topic tags with the current problem.

✨ What Changed
Added a Related Problems footer to every DSA problem page.
Automatically recommends 2–3 similar problems based on shared topic tags.
Reuses the existing browser-side tag index—no new data source required.
Excludes the currently viewed problem from recommendations.
Falls back gracefully if fewer than three related problems exist.
Each recommendation links directly to its problem page.


Fixes #3394 

<img width="1718" height="786" alt="image" src="https://github.com/user-attachments/assets/372a99d8-ab00-4b66-986b-58351b0101de" />


### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
