### PR TITLE
Fix #3403: Remove unused imports in MDXComponents.js

### DIFF
--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -1,6 +1,5 @@
-import "react-lite-youtube-embed/dist/LiteYouTubeEmbed.css";
+﻿import "react-lite-youtube-embed/dist/LiteYouTubeEmbed.css";
 import AdsComponent from "@site/src/components/AdsComponent";
-// import BrowserWindow from "@site/src/components/BrowserWindow";
 import ArrayVisualizations from "@site/src/components/DSA/arrays/ArrayVisualizations";
 import BubbleSortVisualization from "@site/src/components/DSA/arrays/BubbleSortVisualization";
 import InsertionSortVisualization from "@site/src/components/DSA/arrays/InsertionSortVisualization";
@@ -13,7 +12,6 @@ import DijkstraVisuzalizations from "@site/src/components/DSA/graphs/DijkstraVis
 import FloydWarshallVisualizations from "@site/src/components/DSA/graphs/FloydWarshallVisualizations";
 import Highlight from "@site/src/components/Highlight";
 import MDXComponents from "@theme-original/MDXComponents";
-// import Image from "@theme/IdealImage";
 import TabItem from "@theme/TabItem";
 import Tabs from "@theme/Tabs";
 import { FaReact } from "react-icons/fa";
@@ -45,10 +43,8 @@ export default {
   HeapSortVisualization,
   MergeSortVisualization,
   ShellSortVisualization,
-//   Image,
   LiteYouTubeEmbed,
   DocCardList,
-//   LinearSearchVisualizer,
   AdsComponent,
   GiscusComponent,
   Ads,


### PR DESCRIPTION
ðŸ“¥ Pull Request
### Description
This PR cleans up the codebase by removing commented-out, unused imports (like `BrowserWindow`, `Image`, etc.) in `src/theme/MDXComponents.js`.

Fixes #3403

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules