### PR TITLE
Add Reading-Time-Aware "Continue Where You Left Off" Widget

### DIFF
--- a/src/__tests__/components/ContinueLearningWidget.test.tsx
+++ b/src/__tests__/components/ContinueLearningWidget.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for getLastVisited / recordLastVisited in safeStorage
+ * and the ContinueLearningWidget component.
+ */
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+
+/* ---------- mocks ---------- */
+
+// Mock Docusaurus Link
+jest.mock('@docusaurus/Link', () =>
+  ({ to, children, ...rest }: { to: string; children: React.ReactNode; [k: string]: unknown }) => (
+    <a href={to} {...rest}>{children}</a>
+  )
+);
+
+// Minimal localStorage mock
+const store: Record<string, string> = {};
+const mockLocalStorage = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v; },
+  removeItem: (k: string) => { delete store[k]; },
+  clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+  get length() { return Object.keys(store).length; },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+};
+
+Object.defineProperty(window, 'localStorage', { value: mockLocalStorage, writable: true });
+
+import {
+  recordLastVisited,
+  getLastVisited,
+  safeJsonParse,
+} from '../../utils/safeStorage';
+import ContinueLearningWidget from '../../components/Homepage/ContinueLearningWidget';
+
+/* ---------- helpers ---------- */
+
+function resetStore() {
+  mockLocalStorage.clear();
+}
+
+/* ============================= */
+/*  safeStorage helper tests     */
+/* ============================= */
+
+describe('recordLastVisited / getLastVisited', () => {
+  beforeEach(resetStore);
+
+  it('returns null when localStorage is empty', () => {
+    expect(getLastVisited()).toBeNull();
+  });
+
+  it('round-trips a doc item correctly', () => {
+    const now = new Date().toISOString();
+    recordLastVisited({
+      id: 'arrays',
+      title: 'Arrays',
+      url: '/docs/arrays',
+      type: 'doc',
+      readingTime: '3 min read',
+      isCompleted: false,
+      visitedAt: now,
+    });
+
+    const result = getLastVisited();
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('arrays');
+    expect(result!.title).toBe('Arrays');
+    expect(result!.type).toBe('doc');
+    expect(result!.readingTime).toBe('3 min read');
+    expect(result!.isCompleted).toBe(false);
+  });
+
+  it('round-trips a quiz item correctly', () => {
+    const now = new Date().toISOString();
+    recordLastVisited({
+      id: 'graphs',
+      title: 'Quiz on Graphs',
+      url: '/quizzes/graphs',
+      type: 'quiz',
+      readingTime: '5 min quiz',
+      isCompleted: true,
+      visitedAt: now,
+    });
+
+    const result = getLastVisited();
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('quiz');
+    expect(result!.isCompleted).toBe(true);
+  });
+
+  it('defaults visitedAt to current time when not provided', () => {
+    const before = Date.now();
+    recordLastVisited({
+      id: 'stacks',
+      title: 'Stacks',
+      url: '/docs/stacks',
+      type: 'doc',
+    });
+    const after = Date.now();
+
+    const stored = safeJsonParse<{ visitedAt: string }>('algo_last_visited', null as any);
+    const ts = new Date(stored.visitedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('falls back to algo_progress scan when algo_last_visited is absent', () => {
+    const now = new Date().toISOString();
+    const progress = {
+      arrays: true,
+      arrays_title: 'Arrays Deep Dive',
+      arrays_updatedAt: now,
+    };
+    store['algo_progress'] = JSON.stringify(progress);
+
+    const result = getLastVisited();
+    expect(result).not.toBeNull();
+    expect(result!.title).toBe('Arrays Deep Dive');
+    expect(result!.type).toBe('doc');
+    expect(result!.isCompleted).toBe(true);
+  });
+
+  it('falls back to quiz_attempts_* scan when algo_last_visited is absent', () => {
+    const now = new Date().toISOString();
+    const attempts = [{ score: 8, completedAt: now }];
+    store['quiz_attempts_user123_graphs'] = JSON.stringify(attempts);
+
+    const result = getLastVisited();
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe('quiz');
+  });
+
+  it('picks the most recent item among multiple candidates', () => {
+    const older = new Date(Date.now() - 3_600_000).toISOString(); // 1h ago
+    const newer = new Date().toISOString();
+
+    // doc from 1h ago
+    const progress = {
+      sorting: true,
+      sorting_title: 'Sorting Algorithms',
+      sorting_updatedAt: older,
+    };
+    store['algo_progress'] = JSON.stringify(progress);
+
+    // last_visited record is newer
+    store['algo_last_visited'] = JSON.stringify({
+      id: 'queues',
+      title: 'Queues',
+      url: '/docs/queues',
+      type: 'doc',
+      readingTime: '4 min read',
+      isCompleted: false,
+      visitedAt: newer,
+    });
+
+    const result = getLastVisited();
+    expect(result!.id).toBe('queues'); // newer one should win
+  });
+});
+
+/* ============================= */
+/*  ContinueLearningWidget tests */
+/* ============================= */
+
+describe('ContinueLearningWidget', () => {
+  beforeEach(() => {
+    resetStore();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders nothing when no last-visited item exists', () => {
+    const { container } = render(<ContinueLearningWidget />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the widget when a last-visited item is present', async () => {
+    store['algo_last_visited'] = JSON.stringify({
+      id: 'binary-trees',
+      title: 'Binary Trees',
+      url: '/docs/binary-trees',
+      type: 'doc',
+      readingTime: '5 min read',
+      isCompleted: false,
+      visitedAt: new Date().toISOString(),
+    });
+
+    await act(async () => {
+      render(<ContinueLearningWidget />);
+    });
+
+    expect(screen.getByText('Binary Trees')).toBeInTheDocument();
+    expect(screen.getByText(/5 min read/)).toBeInTheDocument();
+    expect(screen.getByText(/In Progress/i)).toBeInTheDocument();
+    expect(screen.getByText(/Continue where you left off/i)).toBeInTheDocument();
+  });
+
+  it('shows "Mastered" pill when isCompleted is true', async () => {
+    store['algo_last_visited'] = JSON.stringify({
+      id: 'graphs',
+      title: 'Graph Algorithms',
+      url: '/quizzes/graphs',
+      type: 'quiz',
+      readingTime: '5 min quiz',
+      isCompleted: true,
+      visitedAt: new Date().toISOString(),
+    });
+
+    await act(async () => {
+      render(<ContinueLearningWidget />);
+    });
+
+    expect(screen.getByText(/Mastered/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Quiz/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('links to the correct URL', async () => {
+    store['algo_last_visited'] = JSON.stringify({
+      id: 'stacks',
+      title: 'Stacks',
+      url: '/docs/stacks',
+      type: 'doc',
+      readingTime: '3 min read',
+      isCompleted: false,
+      visitedAt: new Date().toISOString(),
+    });
+
+    await act(async () => {
+      render(<ContinueLearningWidget />);
+    });
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/docs/stacks');
+  });
+});

--- a/src/components/Homepage/ContinueLearningWidget.tsx
+++ b/src/components/Homepage/ContinueLearningWidget.tsx
@@ -1,0 +1,226 @@
+import React, { useState, useEffect } from 'react';
+import Link from '@docusaurus/Link';
+import { getLastVisited, type LastVisitedItem } from '../../utils/safeStorage';
+
+/* ------------------------------------------------------------------ */
+/*  Relative time formatter (no extra deps)                            */
+/* ------------------------------------------------------------------ */
+function formatRelativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime();
+  if (Number.isNaN(diff)) return '';
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return 'just now';
+  if (m < 60) return `${m} min ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} hour${h > 1 ? 's' : ''} ago`;
+  const d = Math.floor(h / 24);
+  return `${d} day${d > 1 ? 's' : ''} ago`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+export default function ContinueLearningWidget(): React.ReactElement | null {
+  const [item, setItem] = useState<LastVisitedItem | null>(null);
+  const [relTime, setRelTime] = useState<string>('');
+  const [visible, setVisible] = useState(false);
+
+  const refresh = () => {
+    const latest = getLastVisited();
+    setItem(latest);
+    if (latest) setRelTime(formatRelativeTime(latest.visitedAt));
+  };
+
+  // Initial load + listen for navigation updates
+  useEffect(() => {
+    refresh();
+    const handler = () => refresh();
+    window.addEventListener('lastVisitedUpdated', handler);
+    window.addEventListener('progressUpdated', handler);
+    window.addEventListener('quizCompleted', handler);
+    return () => {
+      window.removeEventListener('lastVisitedUpdated', handler);
+      window.removeEventListener('progressUpdated', handler);
+      window.removeEventListener('quizCompleted', handler);
+    };
+  }, []);
+
+  // Animate in after first paint
+  useEffect(() => {
+    if (item) {
+      const t = setTimeout(() => setVisible(true), 80);
+      return () => clearTimeout(t);
+    } else {
+      setVisible(false);
+    }
+  }, [item?.id]);
+
+  // Keep relative time ticking
+  useEffect(() => {
+    if (!item) return;
+    const interval = setInterval(() => {
+      setRelTime(formatRelativeTime(item.visitedAt));
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, [item]);
+
+  if (!item) return null;
+
+  const isDoc = item.type === 'doc';
+
+  return (
+    <div
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(12px)',
+        transition: 'opacity 0.45s ease, transform 0.45s ease',
+      }}
+    >
+      <Link
+        to={item.url}
+        style={{ textDecoration: 'none', display: 'block' }}
+      >
+        <div
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            borderRadius: '16px',
+            padding: '20px 24px',
+            background: 'linear-gradient(135deg, var(--ifm-color-primary-darkest) 0%, var(--ifm-color-primary-dark) 100%)',
+            border: '1px solid var(--ifm-color-primary-dark)',
+            boxShadow: '0 8px 32px rgba(0,0,0,0.18)',
+            cursor: 'pointer',
+            transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+          }}
+          onMouseEnter={(e) => {
+            (e.currentTarget as HTMLDivElement).style.transform = 'translateY(-2px)';
+            (e.currentTarget as HTMLDivElement).style.boxShadow = '0 14px 40px rgba(0,0,0,0.26)';
+          }}
+          onMouseLeave={(e) => {
+            (e.currentTarget as HTMLDivElement).style.transform = 'translateY(0)';
+            (e.currentTarget as HTMLDivElement).style.boxShadow = '0 8px 32px rgba(0,0,0,0.18)';
+          }}
+        >
+          {/* Decorative glow blob */}
+          <div
+            aria-hidden
+            style={{
+              position: 'absolute',
+              top: '-40px',
+              right: '-40px',
+              width: '160px',
+              height: '160px',
+              borderRadius: '50%',
+              background: 'radial-gradient(circle, rgba(255,255,255,0.08) 0%, transparent 70%)',
+              pointerEvents: 'none',
+            }}
+          />
+
+          {/* Header row */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginBottom: '12px',
+              flexWrap: 'wrap',
+              gap: '6px',
+            }}
+          >
+            <span
+              style={{
+                fontSize: '0.65rem',
+                fontWeight: 800,
+                letterSpacing: '0.12em',
+                textTransform: 'uppercase',
+                color: 'rgba(255,255,255,0.55)',
+              }}
+            >
+              ↩ Continue where you left off
+            </span>
+
+            <span
+              style={{
+                fontSize: '0.72rem',
+                color: 'rgba(255,255,255,0.45)',
+                fontWeight: 500,
+              }}
+            >
+              {relTime}
+            </span>
+          </div>
+
+          {/* Title */}
+          <p
+            style={{
+              margin: '0 0 12px',
+              fontSize: '1.05rem',
+              fontWeight: 700,
+              color: '#ffffff',
+              lineHeight: 1.35,
+              maxWidth: '90%',
+            }}
+          >
+            {item.title}
+          </p>
+
+          {/* Footer row: reading time + status pill */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
+            {item.readingTime && (
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                  fontSize: '0.78rem',
+                  fontWeight: 600,
+                  color: 'rgba(255,255,255,0.65)',
+                  background: 'rgba(255,255,255,0.08)',
+                  borderRadius: '8px',
+                  padding: '3px 10px',
+                }}
+              >
+                ⏱ {item.readingTime}
+              </span>
+            )}
+
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+                fontSize: '0.78rem',
+                fontWeight: 700,
+                color: item.isCompleted ? 'rgba(74,222,128,0.95)' : 'rgba(250,204,21,0.95)',
+                background: item.isCompleted
+                  ? 'rgba(74,222,128,0.12)'
+                  : 'rgba(250,204,21,0.12)',
+                border: `1px solid ${item.isCompleted ? 'rgba(74,222,128,0.3)' : 'rgba(250,204,21,0.3)'}`,
+                borderRadius: '8px',
+                padding: '3px 10px',
+              }}
+            >
+              {item.isCompleted ? '✓ Mastered' : '● In Progress'}
+            </span>
+
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+                fontSize: '0.78rem',
+                fontWeight: 600,
+                color: 'rgba(255,255,255,0.5)',
+                background: 'rgba(255,255,255,0.07)',
+                borderRadius: '8px',
+                padding: '3px 10px',
+              }}
+            >
+              {isDoc ? '📄 Doc' : '🧠 Quiz'}
+            </span>
+          </div>
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/src/components/Homepage/index.tsx
+++ b/src/components/Homepage/index.tsx
@@ -11,6 +11,7 @@ import GetInvolvedSection from "./GetInvolvedSection";
 import CallToActionSection from "./CallToActionSection";
 import CookieConsent from "./CookieConsent";
 import DailyChallengeWidget from "../DailyChallengeWidget";
+import ContinueLearningWidget from "./ContinueLearningWidget";
 
 const Homepage: React.FC = () => {
   return (
@@ -23,7 +24,8 @@ const Homepage: React.FC = () => {
         {/* PHASE 2: IMMEDIATE VALUE */}
         <AlgorithmOfTheDaySection />
         <section className="mx-auto max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
-          <div className="mx-auto max-w-3xl">
+          <div className="mx-auto max-w-3xl" style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <ContinueLearningWidget />
             <DailyChallengeWidget />
           </div>
         </section>
@@ -38,10 +40,7 @@ const Homepage: React.FC = () => {
 
         {/* PHASE 5: ECOSYSTEM CONVERSION */}
         <ContributeSection />
-        <GetInvolvedSection
-          title="Get Involved"
-          description="Explore ways to contribute, join the community, and help shape the future of our platform."
-        />
+        <GetInvolvedSection />
         <CallToActionSection />
       </main>
 

--- a/src/components/ProgressTracker/index.tsx
+++ b/src/components/ProgressTracker/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import clsx from 'clsx';
 import { FiCheckCircle, FiCircle, FiTrendingUp, FiAward } from 'react-icons/fi';
-import { safeJsonParse, writeAlgoProgress } from '../../utils/safeStorage';
+import { safeJsonParse, writeAlgoProgress, recordLastVisited } from '../../utils/safeStorage';
 
 interface Props {
   topicId: string;
@@ -16,11 +16,22 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
   useEffect(() => {
     try {
       const progress = safeJsonParse<{ [key: string]: any }>('algo_progress', {});
-      setIsCompleted(!!progress[topicId]);
+      const completed = !!progress[topicId];
+      setIsCompleted(completed);
+
+      // Record this doc as last visited so the homepage widget can surface it
+      recordLastVisited({
+        id: topicId,
+        title: topicTitle,
+        url: typeof window !== 'undefined' ? window.location.pathname : `/docs/${topicId}`,
+        type: 'doc',
+        readingTime: '4 min read',
+        isCompleted: completed,
+      });
     } catch (error) {
       console.error('[Algo Progress] Failed to parse engine storage state:', error);
     }
-  }, [topicId]);
+  }, [topicId, topicTitle]);
 
   // Handle local state modification and sync globally
   const toggleProgress = useCallback(() => {
@@ -39,6 +50,16 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
       progress[`${topicId}_updatedAt`] = new Date().toISOString();
       
       writeAlgoProgress(progress);
+
+      // Update last visited whenever the user interacts with this doc
+      recordLastVisited({
+        id: topicId,
+        title: topicTitle,
+        url: typeof window !== 'undefined' ? window.location.pathname : `/docs/${topicId}`,
+        type: 'doc',
+        readingTime: '4 min read',
+        isCompleted: nextState,
+      });
 
       // Dispatch unified pipeline context updates across component domains
       window.dispatchEvent(

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -156,11 +156,134 @@ export function saveQuizAttemptLocal(
 
   localStorage.setItem(key, JSON.stringify(updated));
 
+  const quizTitle = canonicalId.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+  recordLastVisited({
+    id: canonicalId,
+    title: `Quiz on ${quizTitle}`,
+    url: `/quizzes/${canonicalId}`,
+    type: 'quiz',
+    readingTime: '5 min quiz',
+    isCompleted: true,
+  });
+
   window.dispatchEvent(
     new CustomEvent('quizCompleted', {
       detail: { quizId: canonicalId, userId, score: attempt.score },
     })
   );
+}
+
+export interface LastVisitedItem {
+  id: string;
+  title: string;
+  url: string;
+  visitedAt: string; // ISO string
+  type: 'doc' | 'quiz';
+  readingTime?: string;
+  isCompleted?: boolean;
+}
+
+export function recordLastVisited(item: Omit<LastVisitedItem, 'visitedAt'> & { visitedAt?: string }): void {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  const fullItem: LastVisitedItem = {
+    ...item,
+    visitedAt: item.visitedAt || new Date().toISOString(),
+  };
+  localStorage.setItem('algo_last_visited', JSON.stringify(fullItem));
+  window.dispatchEvent(new CustomEvent('lastVisitedUpdated', { detail: fullItem }));
+}
+
+export function getLastVisited(): LastVisitedItem | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+
+  // 1. Check direct last_visited record
+  const recorded = safeJsonParse<LastVisitedItem | null>('algo_last_visited', null);
+
+  // 2. Scan algo_progress for doc activity timestamps
+  const progress = readAlgoProgress();
+  let latestDocTopic: { id: string; title: string; updatedAt: string; url: string; isCompleted: boolean } | null = null;
+
+  for (const [key, value] of Object.entries(progress)) {
+    if (key.endsWith('_updatedAt') && typeof value === 'string') {
+      const topicId = key.slice(0, -'_updatedAt'.length);
+      const title = typeof progress[`${topicId}_title`] === 'string' ? (progress[`${topicId}_title`] as string) : topicId;
+      const isCompleted = !!progress[topicId];
+      const updatedAt = value;
+
+      if (!latestDocTopic || new Date(updatedAt).getTime() > new Date(latestDocTopic.updatedAt).getTime()) {
+        let url = `/docs/${topicId.replace(/-/g, '/')}`;
+        if (topicId.includes('dsa-problems')) {
+          url = `/docs/${topicId.replace(/^dsa-problems-/, 'dsa-problems/')}`;
+        }
+        latestDocTopic = { id: topicId, title, updatedAt, url, isCompleted };
+      }
+    }
+  }
+
+  // 3. Scan quiz_attempts_* keys for quiz activity timestamps
+  let latestQuiz: { id: string; title: string; updatedAt: string; url: string } | null = null;
+
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (!key || !key.startsWith('quiz_attempts_')) continue;
+
+    const attempts = safeJsonParse<Array<{ completedAt?: string }>>(key, []);
+    if (!Array.isArray(attempts) || attempts.length === 0) continue;
+
+    const quizId = extractQuizIdFromStorageKey(key);
+    if (!quizId) continue;
+
+    for (const attempt of attempts) {
+      if (!attempt.completedAt) continue;
+      const attemptTime = new Date(attempt.completedAt).getTime();
+      if (!Number.isNaN(attemptTime)) {
+        if (!latestQuiz || attemptTime > new Date(latestQuiz.updatedAt).getTime()) {
+          const formattedTitle = `Quiz on ${quizId.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')}`;
+          latestQuiz = {
+            id: quizId,
+            title: formattedTitle,
+            updatedAt: attempt.completedAt,
+            url: `/quizzes/${quizId}`,
+          };
+        }
+      }
+    }
+  }
+
+  const candidates: LastVisitedItem[] = [];
+
+  if (recorded && recorded.title && recorded.url) {
+    candidates.push(recorded);
+  }
+
+  if (latestDocTopic) {
+    candidates.push({
+      id: latestDocTopic.id,
+      title: latestDocTopic.title,
+      url: latestDocTopic.url,
+      visitedAt: latestDocTopic.updatedAt,
+      type: 'doc',
+      readingTime: '4 min read',
+      isCompleted: latestDocTopic.isCompleted,
+    });
+  }
+
+  if (latestQuiz) {
+    candidates.push({
+      id: latestQuiz.id,
+      title: latestQuiz.title,
+      url: latestQuiz.url,
+      visitedAt: latestQuiz.updatedAt,
+      type: 'quiz',
+      readingTime: '5 min quiz',
+      isCompleted: true,
+    });
+  }
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => new Date(b.visitedAt).getTime() - new Date(a.visitedAt).getTime());
+  return candidates[0];
 }
 
 function computeStreak(progress: AlgoProgressData): number {


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces a "Continue Where You Left Off" widget on the homepage that helps users seamlessly resume their learning journey.

The widget leverages the existing ProgressTracker data to identify the most recently visited documentation page or quiz and presents a contextual shortcut back to that content. If the user left a documentation page before finishing, the widget also displays an estimated remaining reading time to encourage completion.

This feature is built entirely on top of the application's existing progress-tracking infrastructure, requiring no new backend endpoints or database changes.

Fixes #3395 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
