### PR TITLE
feat: enhance estimated reading time display on documentation pages

### DIFF
--- a/src/components/CustomDocItems/DocsInfo.jsx
+++ b/src/components/CustomDocItems/DocsInfo.jsx
@@ -50,10 +50,23 @@ function DocsInfo({ docsPluginId, ...props }) {
               </span>
             )}
             {props.readingTimeInWords && (
-              <span className={styles.metaItem}>
-                <FiClock className={styles.icon} /> {props.readingTimeInWords}
-              </span>
-            )}
+  <span
+    className={styles.metaItem}
+    style={{
+      background: "rgba(37, 99, 235, 0.1)",
+      border: "1px solid rgba(37, 99, 235, 0.25)",
+      borderRadius: "9999px",
+      padding: "6px 12px",
+      fontWeight: 600,
+      display: "inline-flex",
+      alignItems: "center",
+      gap: "6px",
+    }}
+  >
+    <FiClock className={styles.icon} />
+    Estimated: {props.readingTimeInWords}
+  </span>
+)}
             {props.lastUpdatedBy && (
               <span className={styles.metaItem}>
                 <FiUser className={styles.icon} />


### PR DESCRIPTION
## Description

Fixes #3415

### Overview

This PR enhances the presentation of the estimated reading time on documentation pages by improving its visual appearance while preserving the existing reading time calculation.

### Changes Made

- Enhanced the reading time display with a styled badge.
- Improved the visibility of the reading time using a rounded UI element.
- Kept the existing reading time calculation logic unchanged.
- Maintained compatibility with the current documentation layout.

### Benefits

- Makes the estimated reading time easier to notice.
- Improves the overall documentation UI and readability.
- Provides a cleaner and more modern user experience.

### Testing

- Verified the reading time badge appears on documentation pages.
- Confirmed existing reading time calculations remain unchanged.
- Tested the UI in both light and dark modes.
- Confirmed no regressions in the documentation metadata section.

### Checklist

- [x] Feature implemented.
- [x] Tested locally.
- [x] No breaking changes introduced.