### PR TITLE
feat: improve copy code button with success feedback

### DIFF
--- a/src/theme/CodeBlock/Buttons/Button/index.js
+++ b/src/theme/CodeBlock/Buttons/Button/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import clsx from 'clsx';
+export default function CodeBlockButton({className, ...props}) {
+  return (
+    <button type="button" {...props} className={clsx('clean-btn', className)} />
+  );
+}

--- a/src/theme/CodeBlock/Buttons/CopyButton/index.js
+++ b/src/theme/CodeBlock/Buttons/CopyButton/index.js
@@ -1,0 +1,84 @@
+import React, {useCallback, useState, useRef, useEffect} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+import styles from './styles.module.css';
+function title() {
+  return translate({
+    id: 'theme.CodeBlock.copy',
+    message: 'Copy',
+    description: 'The copy button label on code blocks',
+  });
+}
+function ariaLabel(isCopied) {
+  return isCopied
+    ? translate({
+        id: 'theme.CodeBlock.copied',
+        message: 'Copied',
+        description: 'The copied button label on code blocks',
+      })
+    : translate({
+        id: 'theme.CodeBlock.copyButtonAriaLabel',
+        message: 'Copy code to clipboard',
+        description: 'The ARIA label for copy code blocks button',
+      });
+}
+async function copyToClipboard(text) {
+  // The clipboard API is only defined in secure contexts (HTTPS / localhost).
+  // See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text);
+  }
+  // Fall back to copy-text-to-clipboard for non-secure contexts (e.g. HTTP
+  // on a local network). The fallback is lazily loaded to avoid bundle
+  // overhead for the common HTTPS case.
+  const {default: copy} = await import('copy-text-to-clipboard');
+  return copy(text);
+}
+function useCopyButton() {
+  const {
+    metadata: {code},
+  } = useCodeBlockContext();
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeout = useRef(undefined);
+  const copyCode = useCallback(() => {
+    copyToClipboard(code).then(() => {
+      setIsCopied(true);
+      copyTimeout.current = window.setTimeout(() => {
+        setIsCopied(false);
+      }, 2500);
+    });
+    // Errors are intentionally not caught so they remain unhandled and can
+    // be captured by observability tools (e.g. Sentry, PostHog).
+  }, [code]);
+  useEffect(() => () => window.clearTimeout(copyTimeout.current), []);
+  return {copyCode, isCopied};
+}
+export default function CopyButton({className}) {
+  const {copyCode, isCopied} = useCopyButton();
+  return (
+    <Button
+      aria-label={ariaLabel(isCopied)}
+      title={title()}
+      className={clsx(
+        className,
+        styles.copyButton,
+        isCopied && styles.copyButtonCopied,
+      )}
+      onClick={copyCode}>
+      <>
+  <span className={styles.copyButtonIcons} aria-hidden="true">
+    <IconCopy className={styles.copyButtonIcon} />
+    <IconSuccess className={styles.copyButtonSuccessIcon} />
+  </span>
+
+  <span className={styles.copyButtonText}>
+    {isCopied ? "Copied!" : "Copy"}
+  </span>
+</>
+    </Button>
+  );
+}

--- a/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
+++ b/src/theme/CodeBlock/Buttons/CopyButton/styles.module.css
@@ -1,0 +1,40 @@
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all var(--ifm-transition-fast) ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}

--- a/src/theme/CodeBlock/Buttons/WordWrapButton/index.js
+++ b/src/theme/CodeBlock/Buttons/WordWrapButton/index.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Button from '@theme/CodeBlock/Buttons/Button';
+import IconWordWrap from '@theme/Icon/WordWrap';
+import styles from './styles.module.css';
+export default function WordWrapButton({className}) {
+  const {wordWrap} = useCodeBlockContext();
+  const canShowButton = wordWrap.isEnabled || wordWrap.isCodeScrollable;
+  if (!canShowButton) {
+    return false;
+  }
+  const title = translate({
+    id: 'theme.CodeBlock.wordWrapToggle',
+    message: 'Toggle word wrap',
+    description:
+      'The title attribute for toggle word wrapping button of code block lines',
+  });
+  return (
+    <Button
+      onClick={() => wordWrap.toggle()}
+      className={clsx(
+        className,
+        wordWrap.isEnabled && styles.wordWrapButtonEnabled,
+      )}
+      aria-label={title}
+      title={title}>
+      <IconWordWrap className={styles.wordWrapButtonIcon} aria-hidden="true" />
+    </Button>
+  );
+}

--- a/src/theme/CodeBlock/Buttons/WordWrapButton/styles.module.css
+++ b/src/theme/CodeBlock/Buttons/WordWrapButton/styles.module.css
@@ -1,0 +1,8 @@
+.wordWrapButtonIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.wordWrapButtonEnabled .wordWrapButtonIcon {
+  color: var(--ifm-color-primary);
+}

--- a/src/theme/CodeBlock/Buttons/index.js
+++ b/src/theme/CodeBlock/Buttons/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import clsx from 'clsx';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import CopyButton from '@theme/CodeBlock/Buttons/CopyButton';
+import WordWrapButton from '@theme/CodeBlock/Buttons/WordWrapButton';
+import styles from './styles.module.css';
+// Code block buttons are not server-rendered on purpose
+// Adding them to the initial HTML is useless and expensive (due to JSX SVG)
+// They are hidden by default and require React  to become interactive
+export default function CodeBlockButtons({className}) {
+  return (
+    <BrowserOnly>
+      {() => (
+        <div className={clsx(className, styles.buttonGroup)}>
+          <WordWrapButton />
+          <CopyButton />
+        </div>
+      )}
+    </BrowserOnly>
+  );
+}

--- a/src/theme/CodeBlock/Buttons/styles.module.css
+++ b/src/theme/CodeBlock/Buttons/styles.module.css
@@ -1,0 +1,30 @@
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}

--- a/src/theme/CodeBlock/Container/index.js
+++ b/src/theme/CodeBlock/Container/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames, usePrismTheme} from '@docusaurus/theme-common';
+import {getPrismCssVariables} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+export default function CodeBlockContainer({as: As, ...props}) {
+  const prismTheme = usePrismTheme();
+  const prismCssVariables = getPrismCssVariables(prismTheme);
+  return (
+    <As
+      // Polymorphic components are hard to type, without `oneOf` generics
+      {...props}
+      style={prismCssVariables}
+      className={clsx(
+        props.className,
+        styles.codeBlockContainer,
+        ThemeClassNames.common.codeBlock,
+      )}
+    />
+  );
+}

--- a/src/theme/CodeBlock/Container/styles.module.css
+++ b/src/theme/CodeBlock/Container/styles.module.css
@@ -1,0 +1,7 @@
+.codeBlockContainer {
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  margin-bottom: var(--ifm-leading);
+  box-shadow: var(--ifm-global-shadow-lw);
+  border-radius: var(--ifm-code-border-radius);
+}

--- a/src/theme/CodeBlock/Content/Element.js
+++ b/src/theme/CodeBlock/Content/Element.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import clsx from 'clsx';
+import Container from '@theme/CodeBlock/Container';
+import styles from './styles.module.css';
+// TODO Docusaurus v4: move this component at the root?
+// This component only handles a rare edge-case: <pre><MyComp/></pre> in MDX
+// <pre> tags in markdown map to CodeBlocks. They may contain JSX children.
+// When children is not a simple string, we just return a styled block without
+// actually highlighting.
+export default function CodeBlockJSX({children, className}) {
+  return (
+    <Container
+      as="pre"
+      tabIndex={0}
+      className={clsx(styles.codeBlockStandalone, 'thin-scrollbar', className)}>
+      <code className={styles.codeBlockLines}>{children}</code>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Content/String.js
+++ b/src/theme/CodeBlock/Content/String.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import {
+  CodeBlockContextProvider,
+  createCodeBlockMetadata,
+  useCodeWordWrap,
+} from '@docusaurus/theme-common/internal';
+import CodeBlockLayout from '@theme/CodeBlock/Layout';
+function useCodeBlockMetadata(props) {
+  const {prism} = useThemeConfig();
+  return createCodeBlockMetadata({
+    code: props.children,
+    className: props.className,
+    metastring: props.metastring,
+    magicComments: prism.magicComments,
+    defaultLanguage: prism.defaultLanguage,
+    language: props.language,
+    title: props.title,
+    showLineNumbers: props.showLineNumbers,
+  });
+}
+// TODO Docusaurus v4: move this component at the root?
+export default function CodeBlockString(props) {
+  const metadata = useCodeBlockMetadata(props);
+  const wordWrap = useCodeWordWrap();
+  return (
+    <CodeBlockContextProvider metadata={metadata} wordWrap={wordWrap}>
+      <CodeBlockLayout />
+    </CodeBlockContextProvider>
+  );
+}

--- a/src/theme/CodeBlock/Content/index.js
+++ b/src/theme/CodeBlock/Content/index.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import {usePrismTheme} from '@docusaurus/theme-common';
+import {Highlight} from 'prism-react-renderer';
+import Line from '@theme/CodeBlock/Line';
+import styles from './styles.module.css';
+// TODO Docusaurus v4: remove useless forwardRef
+const Pre = React.forwardRef((props, ref) => {
+  return (
+    <pre
+      ref={ref}
+      /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+      tabIndex={0}
+      {...props}
+      className={clsx(props.className, styles.codeBlock, 'thin-scrollbar')}
+    />
+  );
+});
+function Code(props) {
+  const {metadata} = useCodeBlockContext();
+  return (
+    <code
+      {...props}
+      className={clsx(
+        props.className,
+        styles.codeBlockLines,
+        metadata.lineNumbersStart !== undefined &&
+          styles.codeBlockLinesWithNumbering,
+      )}
+      style={{
+        ...props.style,
+        counterReset:
+          metadata.lineNumbersStart === undefined
+            ? undefined
+            : `line-count ${metadata.lineNumbersStart - 1}`,
+      }}
+    />
+  );
+}
+export default function CodeBlockContent({className: classNameProp}) {
+  const {metadata, wordWrap} = useCodeBlockContext();
+  const prismTheme = usePrismTheme();
+  const {code, language, lineNumbersStart, lineClassNames} = metadata;
+  return (
+    <Highlight theme={prismTheme} code={code} language={language}>
+      {({className, style, tokens: lines, getLineProps, getTokenProps}) => (
+        <Pre
+          ref={wordWrap.codeBlockRef}
+          className={clsx(classNameProp, className)}
+          style={style}>
+          <Code>
+            {lines.map((line, i) => (
+              <Line
+                key={i}
+                line={line}
+                getLineProps={getLineProps}
+                getTokenProps={getTokenProps}
+                classNames={lineClassNames[i]}
+                showLineNumbers={lineNumbersStart !== undefined}
+              />
+            ))}
+          </Code>
+        </Pre>
+      )}
+    </Highlight>
+  );
+}

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -1,0 +1,28 @@
+.codeBlock {
+  --ifm-pre-background: var(--prism-background-color);
+  margin: 0;
+  padding: 0;
+}
+
+.codeBlockStandalone {
+  padding: 0;
+}
+
+.codeBlockLines {
+  font: inherit;
+  /* rtl:ignore */
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
+}
+
+.codeBlockLinesWithNumbering {
+  display: table;
+  padding: var(--ifm-pre-padding) 0;
+}
+
+@media print {
+  .codeBlockLines {
+    white-space: pre-wrap;
+  }
+}

--- a/src/theme/CodeBlock/Layout/index.js
+++ b/src/theme/CodeBlock/Layout/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useCodeBlockContext} from '@docusaurus/theme-common/internal';
+import Container from '@theme/CodeBlock/Container';
+import Title from '@theme/CodeBlock/Title';
+import Content from '@theme/CodeBlock/Content';
+import Buttons from '@theme/CodeBlock/Buttons';
+import styles from './styles.module.css';
+export default function CodeBlockLayout({className}) {
+  const {metadata} = useCodeBlockContext();
+  return (
+    <Container as="div" className={clsx(className, metadata.className)}>
+      {metadata.title && (
+        <div className={styles.codeBlockTitle}>
+          <Title>{metadata.title}</Title>
+        </div>
+      )}
+      <div className={styles.codeBlockContent}>
+        <Content />
+        <Buttons />
+      </div>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Layout/styles.module.css
+++ b/src/theme/CodeBlock/Layout/styles.module.css
@@ -1,0 +1,20 @@
+.codeBlockContent {
+  position: relative;
+  /* rtl:ignore */
+  direction: ltr;
+  border-radius: inherit;
+}
+
+.codeBlockTitle {
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+  padding: 0.75rem var(--ifm-pre-padding);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.codeBlockTitle + .codeBlockContent .codeBlock {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/src/theme/CodeBlock/Line/Token/index.js
+++ b/src/theme/CodeBlock/Line/Token/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+// Pass-through components that users can swizzle and customize
+export default function CodeBlockLineToken({line, token, ...props}) {
+  return <span {...props} />;
+}

--- a/src/theme/CodeBlock/Line/index.js
+++ b/src/theme/CodeBlock/Line/index.js
@@ -1,25 +1,47 @@
 import React from 'react';
 import clsx from 'clsx';
+import LineToken from '@theme/CodeBlock/Line/Token';
 import styles from './styles.module.css';
+// This <br/ seems useful when the line has no content to prevent collapsing.
+// For code blocks with "diff" languages, this makes the empty lines collapse to
+// zero height lines, which is undesirable.
+// See also https://github.com/facebook/docusaurus/pull/11565
+function LineBreak() {
+  return <br />;
+}
+// Replaces single lines with '\n' by '' so that we don't end up with
+// duplicate line breaks (the '\n' + the artificial <br/> above)
+// see also https://github.com/facebook/docusaurus/pull/11565
+function fixLineBreak(line) {
+  const singleLineBreakToken =
+    line.length === 1 && line[0].content === '\n' ? line[0] : undefined;
+  if (singleLineBreakToken) {
+    return [{...singleLineBreakToken, content: ''}];
+  }
+  return line;
+}
 export default function CodeBlockLine({
-  line,
+  line: lineProp,
   classNames,
   showLineNumbers,
   getLineProps,
   getTokenProps,
 }) {
-  if (line.length === 1 && line[0].content === '\n') {
-    line[0].content = '';
-  }
+  const line = fixLineBreak(lineProp);
   const lineProps = getLineProps({
     line,
     className: clsx(classNames, showLineNumbers && styles.codeLine),
   });
-  const lineTokens = line.map((token, key) => (
-    <span key={key} {...getTokenProps({token, key})} />
-  ));
+  const lineTokens = line.map((token, key) => {
+    const tokenProps = getTokenProps({token});
+    return (
+      <LineToken key={key} {...tokenProps} line={line} token={token}>
+        {tokenProps.children}
+      </LineToken>
+    );
+  });
   return (
-    <span {...lineProps}>
+    <div {...lineProps}>
       {showLineNumbers ? (
         <>
           <span className={styles.codeLineNumber} />
@@ -28,7 +50,7 @@ export default function CodeBlockLine({
       ) : (
         lineTokens
       )}
-      <br />
-    </span>
+      <LineBreak />
+    </div>
   );
 }

--- a/src/theme/CodeBlock/Title/index.js
+++ b/src/theme/CodeBlock/Title/index.js
@@ -1,0 +1,4 @@
+// Just a pass-through component that users can swizzle and customize
+export default function CodeBlockTitle({children}) {
+  return children;
+}

--- a/src/theme/CodeBlock/index.js
+++ b/src/theme/CodeBlock/index.js
@@ -1,0 +1,32 @@
+import React, {isValidElement} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import ElementContent from '@theme/CodeBlock/Content/Element';
+import StringContent from '@theme/CodeBlock/Content/String';
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+function maybeStringifyChildren(children) {
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return children;
+  }
+  // The children is now guaranteed to be one/more plain strings
+  return Array.isArray(children) ? children.join('') : children;
+}
+export default function CodeBlock({children: rawChildren, ...props}) {
+  // The Prism theme on SSR is always the default theme but the site theme can
+  // be in a different mode. React hydration doesn't update DOM styles that come
+  // from SSR. Hence force a re-render after mounting to apply the current
+  // relevant styles.
+  const isBrowser = useIsBrowser();
+  const children = maybeStringifyChildren(rawChildren);
+  const CodeBlockComp =
+    typeof children === 'string' ? StringContent : ElementContent;
+  return (
+    <CodeBlockComp key={String(isBrowser)} {...props}>
+      {children}
+    </CodeBlockComp>
+  );
+}


### PR DESCRIPTION
## Description

Fixes #3416

### Overview

This PR enhances the code block copy button by providing clear visual feedback after a successful copy operation.

### Changes Made

- Extended the success feedback duration from 1 second to 2.5 seconds.
- Added a dynamic button label that changes from **Copy** to **Copied!** after copying.
- Preserved the existing animated transition between the copy and success icons.
- Improved the overall user experience by providing clearer confirmation of successful copy actions.

### Benefits

- Gives users immediate confirmation that the code has been copied.
- Improves usability and accessibility of code blocks.
- Keeps the original Docusaurus copy button animation while enhancing the UI.
- Automatically resets to the default state after a short delay.

### Testing

- Verified the copy button successfully copies code to the clipboard.
- Confirmed the button displays **Copied!** with the success icon.
- Verified the success state automatically resets after approximately 2.5 seconds.
- Tested on multiple documentation pages.

### Checklist

- [x] Implemented the requested UI enhancement.
- [x] Tested locally.
- [x] No breaking changes introduced.