### PR TITLE
feat: add difficulty badges for algorithm documentation

### DIFF
--- a/docs/basic-data-structures/array/radix-sort.md
+++ b/docs/basic-data-structures/array/radix-sort.md
@@ -9,6 +9,8 @@ tags:
   - Java
   - Sorting
 
+difficulty: Medium
+
 description: "This page explains Radix sort, with code implementations and resources for further learning."
 ---
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -983,3 +983,43 @@ html.dark .theme-doc-toc-desktop::before {
 :root[data-accent-theme="neon"] code {
   color: #f0abfc;
 }
+/* ==========================================================
+   Difficulty Badge
+   ========================================================== */
+
+.difficulty-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 12px;
+  margin-top: 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.difficulty-badge.easy {
+  background-color: #16a34a;
+}
+
+.difficulty-badge.medium {
+  background-color: #f59e0b;
+}
+
+.difficulty-badge.hard {
+  background-color: #dc2626;
+}
+
+[data-theme='dark'] .difficulty-badge.easy {
+  background-color: #22c55e;
+}
+
+[data-theme='dark'] .difficulty-badge.medium {
+  background-color: #fbbf24;
+}
+
+[data-theme='dark'] .difficulty-badge.hard {
+  background-color: #ef4444;
+}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -10,7 +10,19 @@ export default function DocItemContent({ children }: { children?: React.ReactNod
   const [readingTimeInWords, setReadingTimeInWords] = useState<string>('');
   
   const { metadata } = useDoc();
-  const { title, editUrl, lastUpdatedAt, lastUpdatedBy, frontMatter } = metadata;
+
+const {
+  title,
+  editUrl,
+  lastUpdatedAt,
+  lastUpdatedBy,
+  frontMatter,
+} = metadata;
+
+const difficulty =
+  typeof (frontMatter as any).difficulty === "string"
+    ? (frontMatter as any).difficulty
+    : undefined;
 
   // We hide the default title if specified by front matter
   const hideTitle = frontMatter.hide_title;
@@ -33,6 +45,16 @@ export default function DocItemContent({ children }: { children?: React.ReactNod
       {!hideTitle && (
         <header className="doc-header-banner">
           <Heading as="h1">{title}</Heading>
+
+{difficulty && (
+  <div style={{ marginTop: "10px" }}>
+    <span
+      className={`difficulty-badge ${difficulty?.toLowerCase()}`}
+    >
+      {difficulty}
+    </span>
+  </div>
+)}
         </header>
       )}
 


### PR DESCRIPTION
## Related Issue

Closes #3417

## Description

### What changed

- Added support for displaying difficulty badges on documentation pages.
- Introduced a `difficulty` frontmatter field for algorithm documentation.
- Rendered difficulty badges below the page title.
- Added reusable badge styling for Easy, Medium, and Hard difficulty levels.
- Updated the Radix Sort documentation to demonstrate the new feature.

### Benefits

- Helps learners quickly identify the complexity level of each algorithm.
- Improves navigation through the learning roadmap.
- Provides a consistent visual indicator across documentation pages.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Breaking change
