### PR TITLE
fix: Fix Broken Anchor Link Offset Calculation under Sticky Navbar (#3396)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -8,6 +8,16 @@
   }
 }
 
+/* Fix anchor heading offset calculation under sticky navbar (#3396) */
+h1[id],
+h2[id],
+h3[id],
+h4[id],
+h5[id],
+h6[id] {
+  scroll-margin-top: var(--ifm-navbar-height, 80px);
+}
+
 :root {
   --ifm-color-primary: #3b82f6;
   --ifm-color-primary-dark: #2563eb;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -9,13 +9,18 @@
 }
 
 /* Fix anchor heading offset calculation under sticky navbar (#3396) */
+html {
+  scroll-padding-top: var(--ifm-navbar-height, 80px);
+}
+
 h1[id],
 h2[id],
 h3[id],
 h4[id],
 h5[id],
-h6[id] {
-  scroll-margin-top: var(--ifm-navbar-height, 80px);
+h6[id],
+:target {
+  scroll-margin-top: calc(var(--ifm-navbar-height, 80px) + 12px);
 }
 
 :root {


### PR DESCRIPTION
## 📥 Pull Request

### Description
Fixes anchor heading targets getting obscured under the sticky navbar by setting CSS `scroll-margin-top: var(--ifm-navbar-height, 80px)` across headings.

Fixes #3396

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules