### PR TITLE
fix: move misplaced OOP docs and fix invalid frontmatter IDs

### DIFF
--- a/docs/programming-fundamentals/cpp-pointers-references.md
+++ b/docs/programming-fundamentals/cpp-pointers-references.md
@@ -1,10 +1,10 @@
 ---
-id: programming-fundamentals
-title:  References and Pointers in C++
-sidebar_label: Introduction to  References and Pointers
-sidebar_position: 2
-description: 'Both references and pointers are powerful features in C++ that allow you to manipulate memory and create more efficient programs. Understanding the differences between them and knowing when to use each is crucial for effective C++ programming'
-tags: [dsa, data-structures,  Pointers]
+id: cpp-pointers-references
+title: References and Pointers in C++
+sidebar_label: Pointers and References
+sidebar_position: 5
+description: 'Both references and pointers are powerful features in C++ that allow you to manipulate memory and create more efficient programs. Understanding the differences between them and knowing when to use each is crucial for effective C++ programming.'
+tags: [cpp, pointers, references, memory, programming-fundamentals]
 ---
 
 ## Learning Information
@@ -141,7 +141,7 @@ int *ptr = &a;  // Pointer to a
 ptr = &b;       // Pointer reassigned to b
 ```
 
-### 5. Null Values
+### 4. Null Values
 
 - **References**: Cannot be null.
 - **Pointers**: Can be null (useful to indicate that they are not pointing to any valid memory).
@@ -156,7 +156,7 @@ int *ptr = nullptr;  // Pointer can be null
 ptr = &a;            // Pointer assigned to a valid address
 ```
 
-### 6. Memory Address
+### 5. Memory Address
 
 - **References**: Implicitly provide the memory address of the referenced variable.
 - **Pointers**: Explicitly hold and can be used to manipulate memory addresses.
@@ -173,7 +173,7 @@ cout << "Address using ref: " << &ref << endl;
 cout << "Address using ptr: " << ptr << endl;
 ```
 
-## 7. When to Use References and Pointers
+## 5. When to Use References and Pointers
 
 ### Use References:
 - When you need an alias for another variable.
@@ -185,7 +185,7 @@ cout << "Address using ptr: " << ptr << endl;
 - When you need to implement data structures like linked lists, trees, etc.
 - When you need to use null values to indicate "no object".
 
-## 8. Examples
+## 6. Examples
 
 ### Example 1: Using References
 
@@ -204,13 +204,17 @@ int main() {
     return 0;
 }
 ```
+
 ### Example 2: Using Pointers
+
 ```cpp
 #include <iostream>
 using namespace std;
+
 void increment(int *ptr) {
     (*ptr)++;
 }
+
 int main() {
     int a = 10;
     increment(&a);
@@ -219,6 +223,6 @@ int main() {
 }
 ```
 
-## 9. Conclusion
+## 7. Conclusion
 
-Both references and pointers are powerful features in C++ that allow you to manipulate memory and create more efficient programs. Understanding the differences between them and knowing when to use each is crucial for effective C++ programming
+Both references and pointers are powerful features in C++ that allow you to manipulate memory and create more efficient programs. Understanding the differences between them and knowing when to use each is crucial for effective C++ programming.

--- a/docs/programming-fundamentals/oop-basics/method-overriding.md
+++ b/docs/programming-fundamentals/oop-basics/method-overriding.md
@@ -1,10 +1,10 @@
 ---
 id: method-overriding
 title: Method Overriding
-sidebar_label: Introduction to Method Overriding
-sidebar_position: 2
+sidebar_label: Method Overriding
+sidebar_position: 11
 description: 'Method overriding allows a derived class to provide a specific implementation of a method that is already defined in its base class. This feature enables runtime polymorphism in object-oriented programming.'
-tags: [dsa, data-structures, Method Overriding]
+tags: [oop, cpp, method-overriding, polymorphism, programming-fundamentals]
 ---
 
 ## Method Overriding

--- a/docs/programming-fundamentals/oop-basics/operator-overloading.md
+++ b/docs/programming-fundamentals/oop-basics/operator-overloading.md
@@ -1,10 +1,10 @@
 ---
-id: basic dsa
-title: Operator overloading
-sidebar_label: Introduction to Operator Overloading
-sidebar_position: 2
+id: operator-overloading
+title: Operator Overloading
+sidebar_label: Operator Overloading
+sidebar_position: 10
 description: 'Operator overloading allows you to redefine the way operators work for user-defined types (classes and structs). It enables you to specify more intuitive ways to perform operations on objects of your classes.'
-tags: [dsa, data-structures, Operator Overloading]
+tags: [oop, cpp, operator-overloading, programming-fundamentals]
 ---
 
 ## Operator Overloading


### PR DESCRIPTION
Fixes #3390

## Problem

Three files were placed under `docs/basic-data-structures/` despite covering OOP and C++ language concepts - not data structures. They also had broken frontmatter IDs that cause routing collisions and would fail the `validate-frontmatter.js` duplicate-ID check on any PR that touches them.

| File | Issue |
|---|---|
| `Operator Overloading.md` | `id: basic dsa` - space in ID is invalid |
| `pointer.md` | `id: programming-fundamentals` - duplicate of the section index ID |
| `Method Overriding.md` | Wrong section, tags misclassified |

## Changes

- Moved `Operator Overloading.md` → `programming-fundamentals/oop-basics/operator-overloading.md`, fixed `id` to `operator-overloading`
- Moved `Method Overriding.md` → `programming-fundamentals/oop-basics/method-overriding.md`, updated tags
- Moved `pointer.md` → `programming-fundamentals/cpp-pointers-references.md`, fixed `id` to `cpp-pointers-references`
