### PR TITLE
fix: persist mock exam review to localStorage on submit

### DIFF
--- a/src/pages/mock-exam.tsx
+++ b/src/pages/mock-exam.tsx
@@ -25,7 +25,14 @@ import {
 import QuestionNavigator from "../components/Quiz/QuestionNavigator";
 import QuestionProgress from "../components/Quiz/QuestionProgress";
 import MockExamTimer, { formatTime } from "../components/Quiz/MockExamTimer";
-import { saveQuizAttemptLocal, getUserId } from "../utils/safeStorage";
+import {
+  saveQuizAttemptLocal,
+  getUserId,
+  saveMockExamReview,
+  getLastMockExamReview,
+  clearMockExamReview,
+  type MockExamReviewRecord,
+} from "../utils/safeStorage";
 import {
   buildMockExamQuestions,
   getRandom30Preset,
@@ -60,6 +67,19 @@ function MockExamContent() {
   const [showConfirmSubmit, setShowConfirmSubmit] = useState<boolean>(false);
   const [showConfirmExit, setShowConfirmExit] = useState<boolean>(false);
 
+  // Restore the last completed exam review from localStorage on first mount.
+  // This lets the user navigate away and come back to their results.
+  useEffect(() => {
+    const saved = getLastMockExamReview();
+    if (saved) {
+      setQuestions(saved.questions as MockExamQuestion[]);
+      setUserAnswers(saved.userAnswers);
+      setTimeSpentSeconds(saved.timeSpentSeconds);
+      setWasAutoSubmitted(saved.wasAutoSubmitted);
+      setMode("result");
+    }
+  }, []);
+
   // Handle Preset Selections
   const handleLaunchPreset = (preset: "random30" | "quick10" | "marathon50") => {
     let qList: MockExamQuestion[] = [];
@@ -88,6 +108,7 @@ function MockExamContent() {
     setTimeLimitMinutes(timerMins);
     setTimeSpentSeconds(0);
     setWasAutoSubmitted(false);
+    clearMockExamReview();
     setMode("active");
   };
 
@@ -101,6 +122,7 @@ function MockExamContent() {
     setCurrentQuestionIndex(0);
     setTimeSpentSeconds(0);
     setWasAutoSubmitted(false);
+    clearMockExamReview();
     setMode("active");
   };
 
@@ -179,8 +201,31 @@ function MockExamContent() {
           completedAt: now,
         });
       });
+
+      // Persist the full review so it survives navigation away from this page
+      const reviewRecord: MockExamReviewRecord = {
+        completedAt: now,
+        totalScore,
+        totalQuestions: questions.length,
+        timeSpentSeconds,
+        wasAutoSubmitted: autoSubmitted,
+        questions: questions.map((q) => ({
+          uniqueId: q.uniqueId,
+          topicId: q.topicId,
+          topicTitle: q.topicTitle,
+          question: q.question,
+          options: q.options,
+          answer: q.answer,
+          explanation: q.explanation,
+          difficulty: q.difficulty,
+          codeSnippet: q.codeSnippet,
+        })),
+        userAnswers,
+        topicPerformance: topicPerformanceList,
+      };
+      saveMockExamReview(reviewRecord);
     },
-    [totalScore, questions.length, timeSpentSeconds, topicPerformanceList]
+    [totalScore, questions, timeSpentSeconds, topicPerformanceList, userAnswers]
   );
 
   const currentQuestion = questions[currentQuestionIndex];

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -421,6 +421,73 @@ function computeQuizStats(): { passed: number; mastered: number; attempted: numb
   return { passed, mastered, attempted };
 }
 
+// ---------------------------------------------------------------------------
+// Mock Exam Review Persistence
+// ---------------------------------------------------------------------------
+
+export interface MockExamReviewQuestion {
+  uniqueId: string;
+  topicId: string;
+  topicTitle: string;
+  question: string;
+  options: string[];
+  answer: string;
+  explanation: string;
+  difficulty?: string;
+  codeSnippet?: string;
+}
+
+export interface MockExamTopicPerformance {
+  topicId: string;
+  topicTitle: string;
+  correct: number;
+  total: number;
+  percentage: number;
+}
+
+export interface MockExamReviewRecord {
+  completedAt: string;
+  totalScore: number;
+  totalQuestions: number;
+  timeSpentSeconds: number;
+  wasAutoSubmitted: boolean;
+  questions: MockExamReviewQuestion[];
+  userAnswers: string[];
+  topicPerformance: MockExamTopicPerformance[];
+}
+
+const MOCK_EXAM_REVIEW_KEY = 'mock_exam_last_review';
+
+/**
+ * Persists the completed mock exam state so the review page can be restored
+ * after navigation away from /mock-exam.
+ */
+export function saveMockExamReview(record: MockExamReviewRecord): void {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    localStorage.setItem(MOCK_EXAM_REVIEW_KEY, JSON.stringify(record));
+  } catch (err) {
+    console.warn('[Algo] Could not save mock exam review to localStorage:', err);
+  }
+}
+
+/**
+ * Returns the last saved mock exam review, or null if none exists.
+ */
+export function getLastMockExamReview(): MockExamReviewRecord | null {
+  return safeJsonParse<MockExamReviewRecord | null>(MOCK_EXAM_REVIEW_KEY, null);
+}
+
+/**
+ * Clears the stored mock exam review (e.g. when the user starts a new exam).
+ */
+export function clearMockExamReview(): void {
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try {
+    localStorage.removeItem(MOCK_EXAM_REVIEW_KEY);
+  } catch {}
+}
+
 export function getAchievementSnapshot(progress: AlgoProgressData = readAlgoProgress()): AchievementSnapshot {
   const completedTopics = Object.entries(progress)
     .filter(([key, value]) => typeof value === 'boolean' && value === true && !key.endsWith('_title') && !key.endsWith('_updatedAt'))


### PR DESCRIPTION
Fixes #3463

## Problem
Once a user completed a mock exam and viewed their results, navigating away from `/mock-exam` (or clicking "Take Another Mock Exam") permanently lost the question-by-question review. All result state was held only in React memory and was never persisted anywhere.

## Solution
Added `MockExamReviewRecord` interface and three helpers to `safeStorage.ts`:
- `saveMockExamReview()` - serializes the full exam result to `mock_exam_last_review` in `localStorage`
- `getLastMockExamReview()` - reads it back on page load
- `clearMockExamReview()` - wipes it when the user starts a new exam

In `mock-exam.tsx`:
- `handleSubmitExam` now calls `saveMockExamReview()` with questions, user answers, topic performance, score, and time
- A `useEffect` on mount calls `getLastMockExamReview()` and, if a saved review exists, restores all result state and jumps directly to the results screen
- Both `handleLaunchPreset` and `handleStartCustomExam` call `clearMockExamReview()` so starting a new exam always wipes the previous review first

## Files Changed
- `safeStorage.ts`
- `mock-exam.tsx`

## Testing
1. Go to `/mock-exam` and complete any preset
2. View the results and question-by-question review
3. Click "Take Another Mock Exam" or navigate to a different page, then come back to `/mock-exam`
4. Results from the previous attempt should be restored automatically
5. Starting a new exam clears the restored review and shows the setup screen normally