### PR TITLE
fix: scope quiz streak to current user's localStorage keys

### DIFF
--- a/src/hooks/useQuizStreak.ts
+++ b/src/hooks/useQuizStreak.ts
@@ -9,8 +9,12 @@
  *
  * Algorithm
  * ---------
- * 1. Scan every localStorage key that starts with "quiz_attempts_".
- * 2. Collect all `completedAt` ISO strings across every quiz / user combo.
+ * 1. Resolve the current user ID via getUserId().
+ *    - If a UID is found, only scan keys that start with
+ *      "quiz_attempts_<uid>_" to avoid mixing in other users' attempts.
+ *    - If no UID is available (unauthenticated / anonymous), fall back to
+ *      scanning all "quiz_attempts_*" keys so the widget still works.
+ * 2. Collect all `completedAt` ISO strings across every matching quiz key.
  * 3. Normalise each timestamp to a UTC calendar date (YYYY-MM-DD string).
  * 4. De-duplicate: only one activity "tick" per calendar day.
  * 5. Sort descending and walk consecutive days to count the current streak.
@@ -21,7 +25,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import { safeJsonParse } from "../utils/safeStorage";
+import { safeJsonParse, getUserId } from "../utils/safeStorage";
 
 // --- Types -------------------------------------------------------------------
 
@@ -135,12 +139,23 @@ export function useQuizStreak(): QuizStreakData {
   const compute = useCallback(() => {
     if (typeof window === "undefined" || !window.localStorage) return;
 
-    // 1. Gather every completedAt timestamp from all quiz_attempts_* keys
+    // Resolve the current user's ID so we only read their own quiz keys.
+    // getQuizAttemptStorageKey writes: quiz_attempts_<uid>_<quizId>
+    // If no user is logged in, fall back to scanning all quiz_attempts_* keys.
+    const userId = getUserId();
+    const userPrefix = userId
+      ? `quiz_attempts_${userId.toLowerCase()}_`
+      : null;
+
+    // 1. Gather every completedAt timestamp from the current user's keys only
     const activeDateSet = new Set<string>();
 
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
       if (!key || !key.startsWith("quiz_attempts_")) continue;
+
+      // Skip keys that belong to a different user
+      if (userPrefix && !key.startsWith(userPrefix)) continue;
 
       const attempts = safeJsonParse<Array<{ completedAt?: string }>>(key, []);
       if (!Array.isArray(attempts)) continue;


### PR DESCRIPTION
Fixes #3464

## Problem
`useQuizStreak` was iterating every `quiz_attempts_*` key in `localStorage` regardless of which user it belonged to. The storage key format is `quiz_attempts_<uid>_<quizId>`, but the hook had no user filter - so on a shared browser (family computer, school lab, etc.) or in testing with multiple sessions, attempt timestamps from different users were all merged into a single streak calculation, producing inflated or incorrect streak counts and heatmap data.

## Solution
- Imported `getUserId()` from `safeStorage.ts` (already used by `saveQuizAttemptLocal` and `getQuizAttemptStorageKey` for the same purpose)
- Derived `userPrefix = quiz_attempts_<uid>_` from the current user's ID
- Added a single guard in the `localStorage` scan loop: skip any key that does not start with `userPrefix`
- Graceful fallback: when no user is logged in (anonymous / unauthenticated), `userPrefix` is `null` and the hook falls back to scanning all `quiz_attempts_*` keys, so the widget still works without a login

## Files Changed
- `useQuizStreak.ts`

## Testing
1. Log in as User A and complete a quiz - streak starts
2. Log out, log in as User B, complete a quiz on a different day
3. Log back in as User A - streak widget should show only User A's activity, not merged with User B's dates
4. When logged out entirely, the streak widget should still display data based on all available keys (anonymous fallback)