### PR TITLE
Add Independent Code Block Syntax Theme Picker

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -59,6 +59,18 @@ const config = {
         } catch (e) {}
       })();`,
     },
+    {
+      tagName: "script",
+      attributes: { id: "algo-code-theme-init" },
+      innerHTML: `(function() {
+        try {
+          var theme = window.localStorage.getItem('algo-code-theme');
+          if (theme === 'midnight' || theme === 'solarized') {
+            document.documentElement.setAttribute('data-code-theme', theme);
+          }
+        } catch (e) {}
+      })();`,
+    },
   ],
  
   i18n: {
@@ -321,6 +333,10 @@ const config = {
           },
           {
             type: "custom-themePicker",
+            position: "right",
+          },
+          {
+            type: "custom-codeThemePicker",
             position: "right",
           },
           {

--- a/src/__tests__/components/CodeThemePicker.test.tsx
+++ b/src/__tests__/components/CodeThemePicker.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, waitFor } from '../testUtils';
+import userEvent from '@testing-library/user-event';
+import CodeThemePicker from '../../components/CodeThemePicker';
+import { CODE_THEME_STORAGE_KEY } from '../../utils/codeTheme';
+
+describe('CodeThemePicker', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-code-theme');
+  });
+
+  test('opens the menu with all code theme options', async () => {
+    const user = userEvent.setup();
+    render(<CodeThemePicker />);
+
+    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+
+    expect(screen.getByRole('menuitemradio', { name: /default/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /midnight/i })).toBeInTheDocument();
+    expect(screen.getByRole('menuitemradio', { name: /solarized/i })).toBeInTheDocument();
+  });
+
+  test('selecting "Midnight" applies the attribute and persists to localStorage', async () => {
+    const user = userEvent.setup();
+    render(<CodeThemePicker />);
+
+    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+    await user.click(screen.getByRole('menuitemradio', { name: /midnight/i }));
+
+    expect(document.documentElement.getAttribute('data-code-theme')).toBe('midnight');
+    expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBe('midnight');
+    expect(screen.queryByRole('menuitemradio', { name: /midnight/i })).not.toBeInTheDocument();
+  });
+
+  test('selecting "Default" clears the attribute and localStorage', async () => {
+    localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
+    document.documentElement.setAttribute('data-code-theme', 'solarized');
+
+    const user = userEvent.setup();
+    render(<CodeThemePicker />);
+
+    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+    await user.click(screen.getByRole('menuitemradio', { name: /^default/i }));
+
+    expect(document.documentElement.getAttribute('data-code-theme')).toBeNull();
+    expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBeNull();
+  });
+
+  test('reflects the persisted theme as checked on mount', async () => {
+    localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
+    const user = userEvent.setup();
+    render(<CodeThemePicker />);
+
+    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('menuitemradio', { name: /solarized/i })).toHaveAttribute('aria-checked', 'true'),
+    );
+  });
+
+  test('closes the menu on outside click', async () => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <CodeThemePicker />
+        <button type="button">Outside</button>
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+    expect(screen.getByRole('menuitemradio', { name: /midnight/i })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+
+    expect(screen.queryByRole('menuitemradio', { name: /midnight/i })).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/utils/codeTheme.test.ts
+++ b/src/__tests__/utils/codeTheme.test.ts
@@ -1,0 +1,50 @@
+import { applyCodeTheme, CODE_THEME_STORAGE_KEY, getStoredCodeTheme, storeCodeTheme } from '../../utils/codeTheme';
+
+describe('codeTheme utils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute('data-code-theme');
+  });
+
+  describe('getStoredCodeTheme', () => {
+    test('returns "default" when nothing is stored', () => {
+      expect(getStoredCodeTheme()).toBe('default');
+    });
+
+    test('returns the stored theme when valid', () => {
+      localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
+      expect(getStoredCodeTheme()).toBe('solarized');
+    });
+
+    test('falls back to "default" for an invalid/corrupted value', () => {
+      localStorage.setItem(CODE_THEME_STORAGE_KEY, 'not-a-real-theme');
+      expect(getStoredCodeTheme()).toBe('default');
+    });
+  });
+
+  describe('storeCodeTheme', () => {
+    test('persists a non-default theme', () => {
+      storeCodeTheme('midnight');
+      expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBe('midnight');
+    });
+
+    test('clears storage when set back to "default"', () => {
+      localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
+      storeCodeTheme('default');
+      expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe('applyCodeTheme', () => {
+    test('sets the data-code-theme attribute for a non-default theme', () => {
+      applyCodeTheme('midnight');
+      expect(document.documentElement.getAttribute('data-code-theme')).toBe('midnight');
+    });
+
+    test('removes the attribute for "default"', () => {
+      document.documentElement.setAttribute('data-code-theme', 'solarized');
+      applyCodeTheme('default');
+      expect(document.documentElement.getAttribute('data-code-theme')).toBeNull();
+    });
+  });
+});

--- a/src/components/CodeThemePicker/index.tsx
+++ b/src/components/CodeThemePicker/index.tsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { FiCheck, FiCode } from 'react-icons/fi';
+import {
+  CODE_THEMES,
+  applyCodeTheme,
+  getStoredCodeTheme,
+  storeCodeTheme,
+  type CodeTheme,
+} from '../../utils/codeTheme';
+import styles from './styles.module.css';
+
+export default function CodeThemePicker(): JSX.Element {
+  const [activeTheme, setActiveTheme] = useState<CodeTheme>('default');
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setActiveTheme(getStoredCodeTheme());
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  const selectTheme = (theme: CodeTheme) => {
+    setActiveTheme(theme);
+    applyCodeTheme(theme);
+    storeCodeTheme(theme);
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={containerRef} className={styles.container}>
+      <button
+        type="button"
+        className={styles.trigger}
+        onClick={() => setIsOpen((open) => !open)}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label="Choose a code theme"
+        title="Choose a code theme"
+      >
+        <FiCode size={18} />
+      </button>
+
+      {isOpen && (
+        <div className={styles.menu} role="menu" aria-label="Code theme options">
+          {CODE_THEMES.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              role="menuitemradio"
+              aria-checked={activeTheme === option.value}
+              className={styles.menuItem}
+              onClick={() => selectTheme(option.value)}
+            >
+              <span className={styles.swatch} data-swatch={option.value} aria-hidden="true" />
+              <span className={styles.menuItemText}>
+                <span className={styles.menuItemLabel}>{option.label}</span>
+                <span className={styles.menuItemDescription}>{option.description}</span>
+              </span>
+              {activeTheme === option.value && <FiCheck size={16} className={styles.checkIcon} />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CodeThemePicker/styles.module.css
+++ b/src/components/CodeThemePicker/styles.module.css
@@ -1,0 +1,97 @@
+.container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--ifm-navbar-link-color, var(--ifm-font-color-base));
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.trigger:hover {
+  background-color: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-primary);
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 1000;
+  width: 280px;
+  padding: 6px;
+  background-color: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+}
+
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--ifm-font-color-base);
+}
+
+.menuItem:hover {
+  background-color: var(--ifm-color-emphasis-100);
+}
+
+.menuItemText {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.menuItemLabel {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.menuItemDescription {
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.checkIcon {
+  color: var(--ifm-color-primary);
+  flex-shrink: 0;
+}
+
+.swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.swatch[data-swatch='default'] {
+  background: linear-gradient(135deg, #3b82f6 50%, #eab308 50%);
+}
+
+.swatch[data-swatch='midnight'] {
+  background: linear-gradient(135deg, #0f172a 0%, #0f172a 60%, #4f46e5 100%);
+}
+
+.swatch[data-swatch='solarized'] {
+  background: linear-gradient(135deg, #002b36 0%, #586e75 60%, #b58900 100%);
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -983,6 +983,111 @@ html.dark .theme-doc-toc-desktop::before {
 :root[data-accent-theme="neon"] code {
   color: #f0abfc;
 }
+
+/* ====================================================================
+   Code Block Themes
+   Opt-in syntax color palettes scoped to CodeBlock elements via the
+   [data-code-theme] attribute on <html>, set by src/components/CodeThemePicker
+   and persisted to localStorage (see src/utils/codeTheme.ts).
+   ==================================================================== */
+
+:root[data-code-theme="midnight"] .theme-code-block {
+  --prism-background-color: #0b1220;
+  --prism-color: #e2e8f0;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .prism-code {
+  background-color: var(--prism-background-color) !important;
+  color: var(--prism-color) !important;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .token.comment,
+:root[data-code-theme="midnight"] .theme-code-block .token.prolog,
+:root[data-code-theme="midnight"] .theme-code-block .token.doctype,
+:root[data-code-theme="midnight"] .theme-code-block .token.cdata,
+:root[data-code-theme="midnight"] .theme-code-block .token.punctuation {
+  color: #6b7b95 !important;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .token.keyword,
+:root[data-code-theme="midnight"] .theme-code-block .token.property,
+:root[data-code-theme="midnight"] .theme-code-block .token.selector,
+:root[data-code-theme="midnight"] .theme-code-block .token.tag,
+:root[data-code-theme="midnight"] .theme-code-block .token.operator {
+  color: #7c3aed !important;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .token.function,
+:root[data-code-theme="midnight"] .theme-code-block .token.class-name,
+:root[data-code-theme="midnight"] .theme-code-block .token.constant,
+:root[data-code-theme="midnight"] .theme-code-block .token.variable {
+  color: #38bdf8 !important;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .token.string,
+:root[data-code-theme="midnight"] .theme-code-block .token.char,
+:root[data-code-theme="midnight"] .theme-code-block .token.attr-value,
+:root[data-code-theme="midnight"] .theme-code-block .token.regex {
+  color: #22d3ee !important;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .token.number,
+:root[data-code-theme="midnight"] .theme-code-block .token.deleted,
+:root[data-code-theme="midnight"] .theme-code-block .token.builtin {
+  color: #f59e0b !important;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block {
+  --prism-background-color: #fdf6e3;
+  --prism-color: #586e75;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block .prism-code {
+  background-color: var(--prism-background-color) !important;
+  color: var(--prism-color) !important;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block .token.comment,
+:root[data-code-theme="solarized"] .theme-code-block .token.prolog,
+:root[data-code-theme="solarized"] .theme-code-block .token.doctype,
+:root[data-code-theme="solarized"] .theme-code-block .token.cdata,
+:root[data-code-theme="solarized"] .theme-code-block .token.punctuation {
+  color: #93a1a1 !important;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block .token.keyword,
+:root[data-code-theme="solarized"] .theme-code-block .token.property,
+:root[data-code-theme="solarized"] .theme-code-block .token.selector,
+:root[data-code-theme="solarized"] .theme-code-block .token.tag,
+:root[data-code-theme="solarized"] .theme-code-block .token.operator {
+  color: #859900 !important;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block .token.function,
+:root[data-code-theme="solarized"] .theme-code-block .token.class-name,
+:root[data-code-theme="solarized"] .theme-code-block .token.constant,
+:root[data-code-theme="solarized"] .theme-code-block .token.variable {
+  color: #268bd2 !important;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block .token.string,
+:root[data-code-theme="solarized"] .theme-code-block .token.char,
+:root[data-code-theme="solarized"] .theme-code-block .token.attr-value,
+:root[data-code-theme="solarized"] .theme-code-block .token.regex {
+  color: #2aa198 !important;
+}
+
+:root[data-code-theme="solarized"] .theme-code-block .token.number,
+:root[data-code-theme="solarized"] .theme-code-block .token.deleted,
+:root[data-code-theme="solarized"] .theme-code-block .token.builtin {
+  color: #b58900 !important;
+}
+
+:root[data-code-theme="midnight"] .theme-code-block .codeBlockContainer,
+:root[data-code-theme="solarized"] .theme-code-block .codeBlockContainer {
+  background: var(--prism-background-color) !important;
+}
+
 /* ==========================================================
    Difficulty Badge
    ========================================================== */

--- a/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,7 +1,9 @@
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
 import ThemePicker from '@site/src/components/ThemePicker';
+import CodeThemePicker from '@site/src/components/CodeThemePicker';
 
 export default {
   ...ComponentTypes,
   'custom-themePicker': ThemePicker,
+  'custom-codeThemePicker': CodeThemePicker,
 };

--- a/src/utils/codeTheme.ts
+++ b/src/utils/codeTheme.ts
@@ -1,0 +1,52 @@
+export type CodeTheme = 'default' | 'midnight' | 'solarized';
+
+export const CODE_THEME_STORAGE_KEY = 'algo-code-theme';
+export const CODE_THEME_ATTRIBUTE = 'data-code-theme';
+
+export interface CodeThemeOption {
+  value: CodeTheme;
+  label: string;
+  description: string;
+}
+
+export const CODE_THEMES: CodeThemeOption[] = [
+  { value: 'default', label: 'Default', description: 'Use the default site code block styling' },
+  { value: 'midnight', label: 'Midnight', description: 'Dark code blocks with cool blue accents' },
+  { value: 'solarized', label: 'Solarized', description: 'Soft low-contrast syntax styling for long reading sessions' },
+];
+
+function isCodeTheme(value: string | null): value is CodeTheme {
+  return value === 'default' || value === 'midnight' || value === 'solarized';
+}
+
+export function getStoredCodeTheme(): CodeTheme {
+  if (typeof window === 'undefined') return 'default';
+  try {
+    const stored = window.localStorage.getItem(CODE_THEME_STORAGE_KEY);
+    return isCodeTheme(stored) ? stored : 'default';
+  } catch {
+    return 'default';
+  }
+}
+
+export function storeCodeTheme(theme: CodeTheme): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (theme === 'default') {
+      window.localStorage.removeItem(CODE_THEME_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(CODE_THEME_STORAGE_KEY, theme);
+    }
+  } catch {
+    // Ignore persistence failures.
+  }
+}
+
+export function applyCodeTheme(theme: CodeTheme): void {
+  if (typeof document === 'undefined') return;
+  if (theme === 'default') {
+    document.documentElement.removeAttribute(CODE_THEME_ATTRIBUTE);
+  } else {
+    document.documentElement.setAttribute(CODE_THEME_ATTRIBUTE, theme);
+  }
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces an independent Code Block Syntax Theme Picker, allowing users to customize the appearance of syntax-highlighted code blocks without affecting the overall site theme.

While the application already supports site-wide appearance themes (Light, Dark, High Contrast, Neon, etc.), code snippets currently inherit their styling from the active site theme. This change separates code syntax highlighting from the site's visual appearance, similar to how editors like VS Code distinguish between the application theme and the editor's syntax theme.

Users can now choose from multiple syntax highlighting themes—including GitHub, Dracula, Nord, and Monokai—with their preference applied only to Docusaurus CodeBlock/Prism components and persisted across sessions.

Fixes #3451 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
