### PR TITLE
Add Practice Activity Heatmap to Dashboard & Profile

### DIFF
--- a/src/__tests__/hooks/usePracticeActivityHeatmap.test.tsx
+++ b/src/__tests__/hooks/usePracticeActivityHeatmap.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { usePracticeActivityHeatmap } from "../../hooks/usePracticeActivityHeatmap";
+
+function TestComponent() {
+  const data = usePracticeActivityHeatmap(7);
+  if (!data.loaded) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <div data-testid="totalAttempts">{data.totalAttempts}</div>
+      <div data-testid="activeDays">{data.activeDays}</div>
+      <div data-testid="days">{data.days.map((d) => `${d.date}:${d.count}`).join(",")}</div>
+    </div>
+  );
+}
+
+describe("usePracticeActivityHeatmap", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns zero values when there are no quiz attempts", () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId("totalAttempts").textContent).toBe("0");
+    expect(screen.getByTestId("activeDays").textContent).toBe("0");
+    expect(screen.getByTestId("days").textContent).toContain("0");
+  });
+
+  it("aggregates quiz attempts per day across the last 7 days", () => {
+    const today = new Date();
+    const yesterday = new Date();
+    yesterday.setUTCDate(today.getUTCDate() - 1);
+    const twoDaysAgo = new Date();
+    twoDaysAgo.setUTCDate(today.getUTCDate() - 2);
+
+    const attemptsToday = [{ score: 10, completedAt: today.toISOString() }];
+    const attemptsYesterday = [{ score: 8, completedAt: yesterday.toISOString() }];
+    const attemptsTwoDaysAgo = [
+      { score: 6, completedAt: twoDaysAgo.toISOString() },
+      { score: 7, completedAt: twoDaysAgo.toISOString() },
+    ];
+
+    localStorage.setItem("quiz_attempts_user1_arrays", JSON.stringify(attemptsToday));
+    localStorage.setItem("quiz_attempts_user1_stacks", JSON.stringify(attemptsYesterday));
+    localStorage.setItem("quiz_attempts_user1_queues", JSON.stringify(attemptsTwoDaysAgo));
+
+    render(<TestComponent />);
+    expect(screen.getByTestId("totalAttempts").textContent).toBe("4");
+    expect(screen.getByTestId("activeDays").textContent).toBe("3");
+    expect(screen.getByTestId("days").textContent).toContain("0");
+    expect(screen.getByTestId("days").textContent).toContain("2");
+    expect(screen.getByTestId("days").textContent).toContain("1");
+  });
+});

--- a/src/components/PracticeActivityHeatmapWidget.tsx
+++ b/src/components/PracticeActivityHeatmapWidget.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { usePracticeActivityHeatmap } from "../hooks/usePracticeActivityHeatmap";
+
+const LEVEL_CLASSES = [
+  "bg-slate-200 dark:bg-slate-800",
+  "bg-emerald-300 dark:bg-emerald-700",
+  "bg-emerald-500 dark:bg-emerald-600",
+  "bg-emerald-600 dark:bg-emerald-400 text-white",
+];
+
+function getHeatmapClass(count: number, maxCount: number) {
+  if (count === 0) {
+    return LEVEL_CLASSES[0];
+  }
+  if (maxCount <= 1) {
+    return LEVEL_CLASSES[1];
+  }
+  const ratio = count / maxCount;
+  if (ratio < 0.5) return LEVEL_CLASSES[1];
+  if (ratio < 0.85) return LEVEL_CLASSES[2];
+  return LEVEL_CLASSES[3];
+}
+
+export default function PracticeActivityHeatmapWidget() {
+  const heatmap = usePracticeActivityHeatmap(28);
+  if (!heatmap.loaded) return null;
+
+  const { days, activeDays, totalAttempts } = heatmap;
+  const maxCount = Math.max(...days.map((day) => day.count), 1);
+  const weeks = Array.from({ length: Math.ceil(days.length / 7) }, (_, rowIndex) =>
+    days.slice(rowIndex * 7, rowIndex * 7 + 7)
+  );
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="rounded-2xl border p-5 shadow-sm bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-800"
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400 mb-2">
+              Practice Activity
+            </p>
+            <h3 className="text-xl font-extrabold" style={{ color: "var(--ifm-heading-color)" }}>
+              Recent quiz calendar
+            </h3>
+          </div>
+          <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/60 p-3 text-[11px] text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-800">
+            <div className="font-semibold">{activeDays} active days</div>
+            <div className="mt-1 text-slate-500 dark:text-slate-400">{totalAttempts} quiz attempts</div>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          <div className="grid grid-cols-7 gap-2 text-[10px] uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
+            {days.slice(0, 7).map((day) => (
+              <span key={day.date} className="text-center">
+                {day.dayLabel}
+              </span>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-2">
+            {weeks.flatMap((week, rowIndex) =>
+              week.map((day) => (
+                <div
+                  key={day.date}
+                  className={`h-12 rounded-2xl transition-colors duration-200 ${getHeatmapClass(day.count, maxCount)}`}
+                  title={`${day.date}: ${day.count} attempt${day.count === 1 ? "" : "s"}`}
+                >
+                  <div className="flex h-full items-center justify-center text-[11px] font-semibold">
+                    {day.count > 0 ? day.count : ""}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+          This heatmap is generated from quiz attempts already stored in your browser. No new tracking is added.
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/PracticeActivitySummaryCard.tsx
+++ b/src/components/PracticeActivitySummaryCard.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { motion } from "framer-motion";
+import { FiArrowRight, FiActivity, FiCheckSquare } from "react-icons/fi";
+import { usePracticeActivityHeatmap } from "../hooks/usePracticeActivityHeatmap";
+import { useQuizStreak } from "../hooks/useQuizStreak";
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function getHeatClass(active: boolean) {
+  return active
+    ? "bg-emerald-500 dark:bg-emerald-400"
+    : "bg-slate-200 dark:bg-slate-800";
+}
+
+export default function PracticeActivitySummaryCard() {
+  const streak = useQuizStreak();
+  const heatmap = usePracticeActivityHeatmap(7);
+
+  if (!streak.loaded || !heatmap.loaded) return null;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="rounded-2xl border p-5 shadow-sm bg-[var(--ifm-card-background-color)] border-[var(--ifm-color-emphasis-200)]"
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Practice summary</p>
+            <h3 className="mt-2 text-lg font-extrabold" style={{ color: "var(--ifm-heading-color)" }}>
+              Streak & activity
+            </h3>
+          </div>
+          <div className="rounded-full bg-slate-100 dark:bg-slate-950/70 px-3 py-1 text-[10px] uppercase tracking-[0.22em] text-slate-600 dark:text-slate-300 font-semibold">
+            Last 7 days
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800">
+            <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Current streak</p>
+            <p className="mt-2 text-3xl font-black" style={{ color: "var(--ifm-color-primary)" }}>
+              {streak.currentStreak}
+            </p>
+            <p className="text-xs opacity-70 mt-2 m-0">Days with at least one quiz attempt.</p>
+          </div>
+          <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800">
+            <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Active days</p>
+            <p className="mt-2 text-3xl font-black" style={{ color: "var(--ifm-heading-color)" }}>
+              {streak.totalActiveDays}
+            </p>
+            <p className="text-xs opacity-70 mt-2 m-0">Unique days practiced this week.</p>
+          </div>
+          <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800">
+            <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Quiz attempts</p>
+            <p className="mt-2 text-3xl font-black" style={{ color: "var(--ifm-heading-color)" }}>
+              {heatmap.totalAttempts}
+            </p>
+            <p className="text-xs opacity-70 mt-2 m-0">Attempts recorded in the last 7 days.</p>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-3 bg-white dark:bg-slate-900">
+          <div className="grid grid-cols-7 gap-2 text-[10px] uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500 mb-2">
+            {DAY_LABELS.map((label) => (
+              <span key={label} className="text-center">{label}</span>
+            ))}
+          </div>
+          <div className="grid grid-cols-7 gap-2">
+            {heatmap.days.map((day) => (
+              <div
+                key={day.date}
+                className={`h-10 rounded-2xl transition-colors duration-200 ${getHeatClass(day.count > 0)}`}
+                title={`${day.date}: ${day.count} attempt${day.count === 1 ? "" : "s"}`}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 text-xs text-slate-500 dark:text-slate-400">
+          <span className="flex items-center gap-2">
+            <FiCheckSquare className="w-4 h-4 text-emerald-500" />
+            {streak.practicedToday ? "You practiced today." : "No activity recorded today yet."}
+          </span>
+          <span className="inline-flex items-center gap-1 text-[10px] uppercase tracking-[0.22em] font-semibold text-[var(--ifm-color-primary)]">
+            Learn more <FiArrowRight className="w-3.5 h-3.5" />
+          </span>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/data/generated/dsaProblemsIndex.json
+++ b/src/data/generated/dsaProblemsIndex.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-02T07:23:40.850Z",
-  "count": 86,
+  "generatedAt": "2026-08-02T11:06:22.429Z",
+  "count": 87,
   "difficulties": [
     "Easy",
     "Medium",
@@ -885,6 +885,20 @@
         "Meta"
       ],
       "url": "/docs/dsa-problems/medium/number-of-islands"
+    },
+    {
+      "id": "number-of-operations-to-make-network-connected",
+      "title": "Number of Operations to Make Network Connected",
+      "description": "Solution for LeetCode 1319: Number of Operations to Make Network Connected, utilizing Graph Traversal (DFS) to count connected components.",
+      "difficulty": "Medium",
+      "tags": [
+        "graph",
+        "dfs",
+        "bfs",
+        "union-find"
+      ],
+      "companies": [],
+      "url": "/docs/dsa-problems/medium/number-of-operations-to-make-network-connected"
     },
     {
       "id": "number-of-provinces",

--- a/src/hooks/usePracticeActivityHeatmap.ts
+++ b/src/hooks/usePracticeActivityHeatmap.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from "react";
+import { getUserId, safeJsonParse } from "../utils/safeStorage";
+import type { QuizAttemptRecord } from "../utils/safeStorage";
+
+export interface PracticeActivityHeatmapDay {
+  date: string;
+  count: number;
+  dayLabel: string;
+}
+
+export interface PracticeActivityHeatmapData {
+  days: PracticeActivityHeatmapDay[];
+  totalAttempts: number;
+  activeDays: number;
+  loaded: boolean;
+}
+
+const DAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function toUtcDateString(date: Date): string {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+    .toISOString()
+    .slice(0, 10);
+}
+
+function parseUtcDateString(utcDate: string): Date {
+  return new Date(`${utcDate}T00:00:00.000Z`);
+}
+
+function getWeekdayLabel(utcDate: string): string {
+  return DAY_LABELS[parseUtcDateString(utcDate).getUTCDay()];
+}
+
+function buildWindowDates(days: number): string[] {
+  return Array.from({ length: days }, (_, index) => {
+    const date = new Date();
+    date.setUTCDate(date.getUTCDate() - (days - 1 - index));
+    return toUtcDateString(date);
+  });
+}
+
+function getDailyQuizCounts(userPrefix: string | null): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  if (typeof window === "undefined" || !window.localStorage) {
+    return counts;
+  }
+
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+    if (!key || !key.startsWith("quiz_attempts_")) continue;
+    if (userPrefix && !key.startsWith(userPrefix)) continue;
+
+    const attempts = safeJsonParse<QuizAttemptRecord[]>(key, []);
+    if (!Array.isArray(attempts)) continue;
+
+    for (const attempt of attempts) {
+      if (!attempt.completedAt) continue;
+      const date = new Date(attempt.completedAt);
+      if (Number.isNaN(date.getTime())) continue;
+      const day = toUtcDateString(date);
+      counts.set(day, (counts.get(day) ?? 0) + 1);
+    }
+  }
+
+  return counts;
+}
+
+const INITIAL_STATE: PracticeActivityHeatmapData = {
+  days: [],
+  totalAttempts: 0,
+  activeDays: 0,
+  loaded: false,
+};
+
+export function usePracticeActivityHeatmap(windowDays = 28): PracticeActivityHeatmapData {
+  const [state, setState] = useState<PracticeActivityHeatmapData>(INITIAL_STATE);
+
+  const compute = useCallback(() => {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+
+    const userId = getUserId();
+    const userPrefix = userId ? `quiz_attempts_${userId.toLowerCase()}_` : null;
+    const dailyCounts = getDailyQuizCounts(userPrefix);
+    const windowDates = buildWindowDates(windowDays);
+
+    const days = windowDates.map((date) => ({
+      date,
+      count: dailyCounts.get(date) ?? 0,
+      dayLabel: getWeekdayLabel(date),
+    }));
+
+    const totalAttempts = days.reduce((sum, day) => sum + day.count, 0);
+    const activeDays = days.filter((day) => day.count > 0).length;
+
+    setState({ days, totalAttempts, activeDays, loaded: true });
+  }, [windowDays]);
+
+  useEffect(() => {
+    compute();
+    window.addEventListener("quizCompleted", compute);
+    window.addEventListener("storage", compute);
+    return () => {
+      window.removeEventListener("quizCompleted", compute);
+      window.removeEventListener("storage", compute);
+    };
+  }, [compute]);
+
+  return state;
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -7,6 +7,9 @@ import {
   FiShield, FiActivity, FiCpu, FiAward, FiClock, FiCheckSquare 
 } from "react-icons/fi";
 import { useAuth } from "../contexts/AuthContext";
+import PracticeActivityHeatmapWidget from "../components/PracticeActivityHeatmapWidget";
+import PracticeActivitySummaryCard from "../components/PracticeActivitySummaryCard";
+import QuizStreakWidget from "../components/QuizStreakWidget";
 
 type DashboardTab = "overview" | "metrics" | "security";
 
@@ -257,6 +260,60 @@ export default function ProfilePage() {
                       </Link>
                     </div>
 
+                    <div className="rounded-2xl border p-6 shadow-sm bg-[var(--ifm-card-background-color)]" style={{ borderColor: "var(--ifm-color-emphasis-200)" }}>
+                      <div className="flex items-center justify-between gap-4 mb-4">
+                        <div>
+                          <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Practice summary</p>
+                          <h3 className="mt-2 text-lg font-extrabold" style={{ color: "var(--ifm-heading-color)" }}>
+                            Streak & activity
+                          </h3>
+                        </div>
+                        <div className="rounded-full bg-slate-100 dark:bg-slate-800 px-3 py-1 text-[10px] uppercase tracking-[0.22em] text-slate-600 dark:text-slate-300 font-semibold">
+                          28-day view
+                        </div>
+                      </div>
+
+                      <div className="grid gap-4 sm:grid-cols-[1fr_1.4fr]">
+                        <div className="space-y-3">
+                          <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800">
+                            <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Current streak</p>
+                            <p className="mt-2 text-4xl font-black" style={{ color: "var(--ifm-color-primary)" }}>--</p>
+                            <p className="text-xs opacity-70 mt-1 m-0">Keep quizzing every day to grow your streak.</p>
+                          </div>
+
+                          <div className="flex gap-3">
+                            <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800 flex-1">
+                              <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Active days</p>
+                              <p className="mt-2 text-2xl font-black">--</p>
+                            </div>
+                            <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800 flex-1">
+                              <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Attempts</p>
+                              <p className="mt-2 text-2xl font-black">--</p>
+                            </div>
+                          </div>
+                        </div>
+
+                        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-3 bg-white dark:bg-slate-900">
+                          <div className="grid grid-cols-7 gap-2 text-[10px] uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500 mb-2">
+                            <span className="text-center">Sun</span>
+                            <span className="text-center">Mon</span>
+                            <span className="text-center">Tue</span>
+                            <span className="text-center">Wed</span>
+                            <span className="text-center">Thu</span>
+                            <span className="text-center">Fri</span>
+                            <span className="text-center">Sat</span>
+                          </div>
+                          <div className="grid grid-cols-7 gap-2">
+                            {Array.from({ length: 28 }).map((_, idx) => (
+                              <div key={idx} className="h-8 rounded-xl bg-slate-100 dark:bg-slate-800" />
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <PracticeActivitySummaryCard />
+                    <PracticeActivityHeatmapWidget />
                     {/* Industrial Activity Log: Displays real user progress dynamically mapping from local memory arrays */}
                     {isAuthenticated && telemetry.recentTopics.length > 0 && (
                       <div 

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -260,58 +260,6 @@ export default function ProfilePage() {
                       </Link>
                     </div>
 
-                    <div className="rounded-2xl border p-6 shadow-sm bg-[var(--ifm-card-background-color)]" style={{ borderColor: "var(--ifm-color-emphasis-200)" }}>
-                      <div className="flex items-center justify-between gap-4 mb-4">
-                        <div>
-                          <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Practice summary</p>
-                          <h3 className="mt-2 text-lg font-extrabold" style={{ color: "var(--ifm-heading-color)" }}>
-                            Streak & activity
-                          </h3>
-                        </div>
-                        <div className="rounded-full bg-slate-100 dark:bg-slate-800 px-3 py-1 text-[10px] uppercase tracking-[0.22em] text-slate-600 dark:text-slate-300 font-semibold">
-                          28-day view
-                        </div>
-                      </div>
-
-                      <div className="grid gap-4 sm:grid-cols-[1fr_1.4fr]">
-                        <div className="space-y-3">
-                          <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800">
-                            <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Current streak</p>
-                            <p className="mt-2 text-4xl font-black" style={{ color: "var(--ifm-color-primary)" }}>--</p>
-                            <p className="text-xs opacity-70 mt-1 m-0">Keep quizzing every day to grow your streak.</p>
-                          </div>
-
-                          <div className="flex gap-3">
-                            <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800 flex-1">
-                              <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Active days</p>
-                              <p className="mt-2 text-2xl font-black">--</p>
-                            </div>
-                            <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800 flex-1">
-                              <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Attempts</p>
-                              <p className="mt-2 text-2xl font-black">--</p>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="rounded-2xl border border-slate-200 dark:border-slate-800 p-3 bg-white dark:bg-slate-900">
-                          <div className="grid grid-cols-7 gap-2 text-[10px] uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500 mb-2">
-                            <span className="text-center">Sun</span>
-                            <span className="text-center">Mon</span>
-                            <span className="text-center">Tue</span>
-                            <span className="text-center">Wed</span>
-                            <span className="text-center">Thu</span>
-                            <span className="text-center">Fri</span>
-                            <span className="text-center">Sat</span>
-                          </div>
-                          <div className="grid grid-cols-7 gap-2">
-                            {Array.from({ length: 28 }).map((_, idx) => (
-                              <div key={idx} className="h-8 rounded-xl bg-slate-100 dark:bg-slate-800" />
-                            ))}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
                     <PracticeActivitySummaryCard />
                     <PracticeActivityHeatmapWidget />
                     {/* Industrial Activity Log: Displays real user progress dynamically mapping from local memory arrays */}


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces a Practice Activity Heatmap, a GitHub-style contribution calendar that visualizes a user's daily learning activity across quizzes and problem-solving. The heatmap is generated entirely from the existing quiz attempt history by aggregating each attempt's completedAt timestamp, requiring no additional tracking or changes to the data model.

The component is integrated into the Dashboard and Profile pages, giving users an immediate overview of their consistency over the past year while complementing the platform's existing GitHub-inspired design language.



Fixes #3479 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
