### PR TITLE
fix: replace jargon labels in ProgressTracker with plain language

### DIFF
--- a/src/components/ProgressTracker/index.tsx
+++ b/src/components/ProgressTracker/index.tsx
@@ -12,7 +12,7 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
   const [isCompleted, setIsCompleted] = useState<boolean>(false);
   const [animate, setAnimate] = useState<boolean>(false);
 
-  // Safely check and read state from localStorage
+      // Safely check and read state from localStorage
   useEffect(() => {
     try {
       const progress = safeJsonParse<{ [key: string]: any }>('algo_progress', {});
@@ -29,7 +29,7 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
         isCompleted: completed,
       });
     } catch (error) {
-      console.error('[Algo Progress] Failed to parse engine storage state:', error);
+      console.error('[Algo Progress] Failed to read progress from localStorage:', error);
     }
   }, [topicId, topicTitle]);
 
@@ -44,7 +44,7 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
     try {
       const progress = safeJsonParse<{ [key: string]: any }>('algo_progress', {});
       
-      // Sync structured telemetry object schema
+      // Save progress to localStorage
       progress[topicId] = nextState;
       progress[`${topicId}_title`] = topicTitle;
       progress[`${topicId}_updatedAt`] = new Date().toISOString();
@@ -61,14 +61,14 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
         isCompleted: nextState,
       });
 
-      // Dispatch unified pipeline context updates across component domains
+      // Notify other components that progress has changed
       window.dispatchEvent(
         new CustomEvent('progressUpdated', {
           detail: { topicId, completed: nextState, title: topicTitle },
         })
       );
     } catch (error) {
-      console.error('[Algo Progress] Failed to write engine storage state:', error);
+      console.error('[Algo Progress] Failed to save progress to localStorage:', error);
     }
   }, [isCompleted, topicId, topicTitle]);
 
@@ -89,7 +89,7 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
         transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
       }}
     >
-      {/* Informational Tracking Metadata Section */}
+      {/* Progress Status */}
       <div style={{ display: 'flex', alignItems: 'center', gap: '12px', flex: 1, minWidth: '260px' }}>
         <div
           style={{
@@ -119,7 +119,7 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
               opacity: 0.5,
             }}
           >
-            Telemetry Integration
+            Track Your Progress
           </span>
           <p
             style={{
@@ -130,15 +130,15 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
             }}
           >
             {isCompleted ? (
-              <span>🎉 Optimization Mastered! Node checkpoint successfully compiled.</span>
+              <span>🎉 Great job! You've completed this topic.</span>
             ) : (
-              <span>Completed working through this block? Sync progress to workspace.</span>
+              <span>Done with this topic? Mark it as complete to track your progress.</span>
             )}
           </p>
         </div>
       </div>
 
-      {/* Modern High-Fidelity Button Interface */}
+      {/* Toggle Button */}
       <button
         type="button"
         onClick={toggleProgress}
@@ -181,12 +181,12 @@ export default function ProgressTracker({ topicId, topicTitle }: Props) {
         {isCompleted ? (
           <>
             <FiCheckCircle size={16} strokeWidth={2.5} />
-            <span>Mastery Verified</span>
+            <span>Completed</span>
           </>
         ) : (
           <>
             <FiCircle size={16} strokeWidth={2.5} />
-            <span>Commit to Profile</span>
+            <span>Mark as Complete</span>
           </>
         )}
       </button>


### PR DESCRIPTION
## Description

Fixes #3507

## Problem
The ProgressTracker component shown at the bottom of every doc page used developer/system jargon that is confusing to learners:

| Before | After |
|---|---|
| Telemetry Integration | Track Your Progress |
| Commit to Profile | Mark as Complete |
| Mastery Verified | Completed |
| Optimization Mastered! Node checkpoint successfully compiled. | 🎉 Great job! You've completed this topic. |
| Completed working through this block? Sync progress to workspace. | Done with this topic? Mark it as complete to track your progress. |

## Changes
- `index.tsx` - replaced all user-facing jargon labels with plain, learner-friendly language
- Also cleaned up internal code comments that used the same jargon (`Sync structured telemetry object schema`, `Dispatch unified pipeline context updates across component domains`, etc.)

## Files Changed
- `index.tsx`

## Testing
1. Open any doc page (e.g. `/docs/basic-data-structures/arrays-dsa`)
2. Scroll to the bottom
3. The progress tracker card should now show "Track Your Progress" as the label, "Done with this topic? Mark it as complete to track your progress." as the description, and "Mark as Complete" as the button text
4. Click the button - it should toggle to show "Completed" and "🎉 Great job! You've completed this topic."