### PR TITLE
fix: wire showOnlyWeak and showOnlyIncomplete filter states in quizzes pages

### DIFF
--- a/src/pages/quizzes/index.tsx
+++ b/src/pages/quizzes/index.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import {
   FaPlayCircle, FaTerminal, FaLayerGroup, FaSearch,
   FaTrophy, FaFire, FaChartBar, FaRedo, FaCheckCircle,
-  FaClock, FaExclamationTriangle, FaStar,
+  FaClock, FaExclamationTriangle, FaStar, FaCircle,
 } from "react-icons/fa";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
@@ -335,8 +335,6 @@ function QuizCard({ quiz, stat, allStats, index }: { quiz: QuizCardConfig; stat?
 const Quizzes: React.FC = () => {
   const [search, setSearch]           = useState("");
   const [activeFilter, setActiveFilter] = useState<typeof FILTER_CATEGORIES[number]>("All");
-  const [showOnlyWeak, setShowOnlyWeak] = useState(false);
-  const [showOnlyIncomplete, setShowOnlyIncomplete] = useState(false);
 
   const filteredQuizzes = useMemo(() => {
     return QUIZZES_CONFIG.filter(quiz => {
@@ -396,6 +394,24 @@ const Quizzes: React.FC = () => {
           {() => {
             const Inner = () => {
               const { stats, globalStats, userId, loaded } = useQuizProgress(QUIZ_IDS, QUESTION_COUNTS);
+              const [showOnlyWeak, setShowOnlyWeak] = useState(false);
+              const [showOnlyIncomplete, setShowOnlyIncomplete] = useState(false);
+
+              const displayedQuizzes = useMemo(() => {
+                return filteredQuizzes.filter(quiz => {
+                  if (showOnlyWeak) {
+                    const isWeak = globalStats.weakTopics.includes(quiz.id);
+                    if (!isWeak) return false;
+                  }
+                  if (showOnlyIncomplete) {
+                    const stat = stats[quiz.id];
+                    const isIncomplete = !stat || stat.totalAttempts === 0 || stat.status === "in-progress";
+                    if (!isIncomplete) return false;
+                  }
+                  return true;
+                });
+              }, [filteredQuizzes, showOnlyWeak, showOnlyIncomplete, stats, globalStats.weakTopics]);
+
               return (
                 <>
                   <div className="max-w-7xl mx-auto px-4 mt-10 mb-2 grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
@@ -421,7 +437,7 @@ const Quizzes: React.FC = () => {
                         />
                       </div>
                       <div className="overflow-x-auto -mx-4 px-4 lg:mx-0 lg:px-0 scrollbar-none">
-                        <div className="flex gap-1.5" role="group">
+                        <div className="flex gap-1.5 flex-wrap" role="group">
                           {FILTER_CATEGORIES.map(cat => (
                             <button
                               key={cat}
@@ -435,6 +451,37 @@ const Quizzes: React.FC = () => {
                               {cat === "All" ? "All Quizzes" : cat}
                             </button>
                           ))}
+
+                          {/* Divider */}
+                          <div className="w-px self-stretch bg-slate-200 dark:bg-slate-800 mx-1" />
+
+                          {/* Show only weak topics */}
+                          <button
+                            onClick={() => setShowOnlyWeak(v => !v)}
+                            className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-bold tracking-wide border transition-all whitespace-nowrap min-h-[36px] cursor-pointer ${
+                              showOnlyWeak
+                                ? "bg-amber-500 border-amber-500 text-white shadow-sm"
+                                : "border-slate-200 bg-white dark:bg-slate-950 dark:border-slate-800 text-slate-500 dark:text-slate-400 hover:border-amber-400 hover:text-amber-600 dark:hover:text-amber-400"
+                            }`}
+                            title="Show only topics where your score is below 70%"
+                          >
+                            <FaExclamationTriangle className="text-[10px]" />
+                            Needs Review
+                          </button>
+
+                          {/* Show only incomplete */}
+                          <button
+                            onClick={() => setShowOnlyIncomplete(v => !v)}
+                            className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-bold tracking-wide border transition-all whitespace-nowrap min-h-[36px] cursor-pointer ${
+                              showOnlyIncomplete
+                                ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+                                : "border-slate-200 bg-white dark:bg-slate-950 dark:border-slate-800 text-slate-500 dark:text-slate-400 hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400"
+                            }`}
+                            title="Show only quizzes you haven't passed yet"
+                          >
+                            <FaCircle className="text-[10px]" />
+                            Not Completed
+                          </button>
                         </div>
                       </div>
                     </div>
@@ -444,7 +491,7 @@ const Quizzes: React.FC = () => {
                   <section className="max-w-7xl mx-auto px-4 mt-6">
                     <motion.div layout className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                       <AnimatePresence mode="popLayout">
-                        {filteredQuizzes.map((quiz, index) => (
+                        {displayedQuizzes.map((quiz, index) => (
                           <QuizCard
                             key={quiz.id}
                             quiz={quiz}
@@ -456,7 +503,7 @@ const Quizzes: React.FC = () => {
                       </AnimatePresence>
                     </motion.div>
 
-                    {filteredQuizzes.length === 0 && (
+                    {displayedQuizzes.length === 0 && (
                       <div className="text-center py-16 px-4 rounded-2xl border border-dashed border-slate-300 dark:border-slate-800 bg-white dark:bg-slate-900/40">
                         <FaLayerGroup className="text-slate-400 mx-auto text-3xl mb-3" />
                         <h4 className="text-base font-bold text-slate-800 dark:text-slate-200 m-0">No Search Parameters Matched</h4>


### PR DESCRIPTION
## Description
Fixes #3508

## Problem
Two filter states were declared in the quizzes page but never connected to anything:

```tsx
const [showOnlyWeak, setShowOnlyWeak] = useState(false);
const [showOnlyIncomplete, setShowOnlyIncomplete] = useState(false);
```

Neither appeared in the `filteredQuizzes` memo nor had any UI toggle, so users had no way to filter by weak or incomplete topics despite the data already being available via `globalStats.weakTopics` and per-quiz stats.

## Solution
- Moved both states into the `Inner` component (inside `BrowserOnly`) where `stats` and `globalStats` are available
- Added a `displayedQuizzes` memo that applies both filters on top of the existing search + category filter
- Added two new toggle buttons in the filter bar:
  - **Needs Review** (amber) - shows only quizzes where the user's best score is below 70%
  - **Not Completed** (blue) - shows only quizzes the user hasn't passed yet (not started or in-progress)
- Switched the cards grid to render `displayedQuizzes` instead of `filteredQuizzes`
- Added `FaCircle` to the `react-icons/fa` import for the new button icon

## Files Changed
- `index.tsx`

## Testing
1. Go to `/quizzes` and attempt a few quizzes with varying scores
2. Click **Needs Review** - only quizzes with a best score below 70% should appear
3. Click **Not Completed** - only quizzes you haven't passed should appear
4. Both toggles can be active simultaneously and stack with the search and category filters
5. Clicking an active toggle again deactivates it and shows all quizzes again