### PR TITLE
fix: replace broken arrow character in RelatedProblems card

### DIFF
--- a/src/components/RelatedProblems.tsx
+++ b/src/components/RelatedProblems.tsx
@@ -230,7 +230,7 @@ export default function RelatedProblems(): React.ReactElement | null {
 
               <div className="mt-3 pt-2.5 border-t border-slate-100 dark:border-slate-800/80 flex items-center justify-between text-[11px] font-mono font-bold text-blue-600 dark:text-blue-400 group-hover:translate-x-0.5 transition-transform">
                 <span>Solve Problem</span>
-                <span>?</span>
+                <span>→</span>
               </div>
             </Link>
           );


### PR DESCRIPTION
## Description
Fixes #3509

The "Solve Problem" row at the bottom of each related problem card was displaying a literal `?` character instead of a right-arrow. This was a copy-paste encoding issue in `RelatedProblems.tsx`.

## Change
`<span>?</span>` → `<span>→</span>`

## Files Changed
- `RelatedProblems.tsx`

## Testing
1. Navigate to any DSA problem doc page (e.g. `/docs/dsa-problems/easy/two-sum`)
2. Scroll to "Related Practice Problems"
3. Each card's bottom row should now show "Solve Problem →" instead of "Solve Problem ?"