### PR TITLE
ci: add workflow to automatically label new issues with gssoc-26

### DIFF
--- a/.github/workflows/auto-label-gssoc.yml
+++ b/.github/workflows/auto-label-gssoc.yml
@@ -1,0 +1,85 @@
+name: "Auto Assign GSSoC Label"
+
+on:
+  issues:
+    types: [opened]
+    
+  workflow_dispatch:
+
+jobs:
+  add-gssoc-label:
+    name: Add gssoc-26 Label to New Issues
+    
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
+    steps:
+      - name: Ensure label and add to issue
+      
+        uses: actions/github-script@v7
+        with:
+        
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            
+            const labelName = 'gssoc-26';
+            const color = 'F9D0C4'; // Clean hex color for GSSoC label
+            
+            const description = 'Official label for all GSSoC 2026 related issues and pull requests.';
+
+            try {
+              // Check if the label exists in the repo
+              
+              await github.rest.issues.getLabel({
+                owner,
+                repo,
+                name: labelName
+              });
+              
+              console.log(`Label "${labelName}" exists.`);
+              
+            } catch (err) {
+            
+              // If label is missing (404), create it automatically
+              
+              if (err.status === 404) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: labelName,
+                    color,
+                    description
+                  });
+                  
+                  console.log(`Successfully created missing label: "${labelName}"`);
+                  
+                } catch (createErr) {
+                  if (createErr.status !== 422) {
+                    throw createErr;
+                  }
+                }
+              } else {
+                throw err;
+              }
+            }
+
+            // Apply the label to the newly opened issue
+            
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [labelName]
+            });
+
+            console.log(`Successfully labeled Issue #${issue_number} with "${labelName}"`);
+
+
+
+
+            

--- a/.github/workflows/auto-label-gssoc.yml
+++ b/.github/workflows/auto-label-gssoc.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   add-gssoc-label:
-    name: Add gssoc-26 Label to New Issues
-    
+    name: Add gssoc-26 Label to New Issues    
     runs-on: ubuntu-latest
 
     permissions:
@@ -17,10 +16,8 @@ jobs:
 
     steps:
       - name: Ensure label and add to issue
-      
         uses: actions/github-script@v7
         with:
-        
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -30,8 +27,7 @@ jobs:
             const description = 'Official label for all GSSoC 2026 related issues and pull requests.';
 
             try {
-              // Check if the label exists in the repo
-              
+              // Check if the label exists in the repo  
               await github.rest.issues.getLabel({
                 owner,
                 repo,
@@ -39,8 +35,7 @@ jobs:
               });
               
               console.log(`Label "${labelName}" exists.`);
-            } catch (err) {
-            
+            } catch (err) { 
               // If label is missing (404), create it automatically
               
               if (err.status === 404) {
@@ -53,8 +48,7 @@ jobs:
                     description
                   });
                   
-                  console.log(`Successfully created missing label: "${labelName}"`);
-                  
+                  console.log(`Successfully created missing label: "${labelName}"`);                
                 } catch (createErr) {
                   if (createErr.status !== 422) {
                     throw createErr;
@@ -66,7 +60,6 @@ jobs:
             }
 
             // Apply the label to the newly opened issue
-            
             await github.rest.issues.addLabels({
               owner,
               repo,

--- a/.github/workflows/auto-label-gssoc.yml
+++ b/.github/workflows/auto-label-gssoc.yml
@@ -24,11 +24,9 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const issue_number = context.payload.issue.number;
-            
+            const issue_number = context.payload.issue.number;            
             const labelName = 'gssoc-26';
             const color = 'F9D0C4'; // Clean hex color for GSSoC label
-            
             const description = 'Official label for all GSSoC 2026 related issues and pull requests.';
 
             try {
@@ -41,7 +39,6 @@ jobs:
               });
               
               console.log(`Label "${labelName}" exists.`);
-              
             } catch (err) {
             
               // If label is missing (404), create it automatically
@@ -78,8 +75,3 @@ jobs:
             });
 
             console.log(`Successfully labeled Issue #${issue_number} with "${labelName}"`);
-
-
-
-
-            


### PR DESCRIPTION
## 📥 Pull Request

### Description
i noticed that @ajay-dhangar adds gssoc 26 label to most of the issues manually. To save time 
This PR adds a GitHub Actions workflow (`.github/workflows/auto-label-gssoc.yml`) that automatically attaches the `gssoc-26` label to every newly opened issue in the repository.

**Key Changes:**
- Triggers on `issues: [opened]` and supports manual execution via `workflow_dispatch`.
- Uses `actions/github-script@v7` to safely check if the `gssoc-26` label exists (and creates it if missing).
- Automatically applies `gssoc-26` to new issues upon creation.
- Saves maintainers manual effort during high-volume issue triaging.

Fixes #3523 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added screeshot that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

### screenshot of work
<img width="1765" height="860" alt="image" src="https://github.com/user-attachments/assets/0cd34590-62a5-4f72-ad9d-b389794863ae" />
