### PR TITLE
docs : added description and tags frontmatter to DLX.md

### DIFF
--- a/docs/extra/algorithms/DLX algorithm/DLX.md
+++ b/docs/extra/algorithms/DLX algorithm/DLX.md
@@ -4,7 +4,8 @@ id: dancing-links
 sidebar_position: 20  
 title: "Dancing Links (DLX)"  
 sidebar_label: Dancing Links  
-
+description: "Dancing Links (DLX) is a technique for implementing the Algorithm X using doubly linked lists, widely used for solving exact cover problems such as Sudoku and N-Queens efficiently."
+tags: [algorithms, exact cover, backtracking, Algorithm X, data structures]
 ---
 
 ### Definition


### PR DESCRIPTION
## Summary of What Has Been Done

Added missing `description` and `tags` frontmatter fields to `DLX.md` in the algorithm documentation. The `description` provides a concise summary of the algorithm and its use cases. The `tags` provide SEO-relevant categorization for discoverability.

## Changes Made

- Added `description` frontmatter field with a concise algorithmic description
- Added `tags` frontmatter field with relevant categorization tags
- Ensured frontmatter conforms to the schema enforced by `validate:docs`

## Impact it Made

- Passes the `validate:docs` CI gate on the documentation frontmatter validation
- Improves SEO discoverability of the algorithm documentation page
- Provides consistent frontmatter across all algorithm documentation files in the repository

Fixes #3540

Note: Please assign this PR to the `tmdeveloper007` account.