### PR TITLE
docs : added description and tags frontmatter to advanced_encryption_standard.md

### DIFF
--- a/docs/extra/algorithms/Encryption algorithms/advanced_encryption_standard.md
+++ b/docs/extra/algorithms/Encryption algorithms/advanced_encryption_standard.md
@@ -4,7 +4,8 @@ id: advanced-encryption-standard
 sidebar_position: 4  
 title: Advanced Encryption Standard (AES)  
 sidebar_label: Advanced Encryption Standard  
-
+description: "The Advanced Encryption Standard (AES) is a symmetric block cipher that encrypts electronic data using key sizes of 128, 192, and 256 bits, and is widely adopted as the standard for secure data encryption."
+tags: [encryption algorithms, symmetric encryption, block cipher, cryptography, AES]
 ---
 
 ### Definition:


### PR DESCRIPTION
## Summary of What Has Been Done

Added missing `description` and `tags` frontmatter fields to `advanced_encryption_standard.md` in the algorithm documentation. The `description` provides a concise summary of the algorithm and its use cases. The `tags` provide SEO-relevant categorization for discoverability.

## Changes Made

- Added `description` frontmatter field with a concise algorithmic description
- Added `tags` frontmatter field with relevant categorization tags
- Ensured frontmatter conforms to the schema enforced by `validate:docs`

## Impact it Made

- Passes the `validate:docs` CI gate on the documentation frontmatter validation
- Improves SEO discoverability of the algorithm documentation page
- Provides consistent frontmatter across all algorithm documentation files in the repository

Fixes #3542

Note: Please assign this PR to the `tmdeveloper007` account.