### PR TITLE
docs : added description and tags frontmatter to GaleShapley.md

### DIFF
--- a/docs/extra/algorithms/Gale-Shapley-Algorithm/GaleShapley.md
+++ b/docs/extra/algorithms/Gale-Shapley-Algorithm/GaleShapley.md
@@ -3,6 +3,8 @@ id: gale-shapley-algorithm
 sidebar_position: 15  
 title: Gale-Shapley Algorithm  
 sidebar_label: Gale-Shapley Algorithm  
+description: "The Gale-Shapley Algorithm, also known as the Deferred Acceptance Algorithm, finds stable matchings between two sets of participants and guarantees that no participant can improve their outcome by deviating from the algorithm's matching."
+tags: [algorithms, stable marriage problem, deferred acceptance, game theory, graph algorithms]
 ---
 
 ## Overview:


### PR DESCRIPTION
## Summary of What Has Been Done

Added missing `description` and `tags` frontmatter fields to `GaleShapley.md` in the algorithm documentation. The `description` provides a concise summary of the algorithm and its use cases. The `tags` provide SEO-relevant categorization for discoverability.

## Changes Made

- Added `description` frontmatter field with a concise algorithmic description
- Added `tags` frontmatter field with relevant categorization tags
- Ensured frontmatter conforms to the schema enforced by `validate:docs`

## Impact it Made

- Passes the `validate:docs` CI gate on the documentation frontmatter validation
- Improves SEO discoverability of the algorithm documentation page
- Provides consistent frontmatter across all algorithm documentation files in the repository

Fixes #3543

Note: Please assign this PR to the `tmdeveloper007` account.