### PR TITLE
Fix: Brittle Global CSS Mutation in Sorting Visualizations

### DIFF
--- a/src/components/DSA/arrays/BubbleSortVisualization/index.tsx
+++ b/src/components/DSA/arrays/BubbleSortVisualization/index.tsx
@@ -30,10 +30,7 @@ const BubbleSortVisualization: React.FC = () => {
     generateArray();
   }, []);
 
-  // Effect to update the CSS transition duration when the delay changes
-  useEffect(() => {
-    updateMoveDuration();
-  }, [delay]);
+
 
   /**
    * Generates a new array of random numbers and updates the state.
@@ -43,28 +40,7 @@ const BubbleSortVisualization: React.FC = () => {
     setArray(newArray);
   };
 
-  /**
-   * Updates the CSS transition duration for the sorting visualization.
-   */
-  const updateMoveDuration = () => {
-    const stylesheets = document.styleSheets;
-    for (let i = 0; i < stylesheets.length; i++) {
-      try {
-        const rules = (stylesheets[i] as any).cssRules || (stylesheets[i] as any).rules;
-        if (!rules) continue;
-        for (let j = 0; j < rules.length; j++) {
-          const rule = rules[j] as CSSStyleRule;
-          if (rule && rule.selectorText === '.v-move') {
-            rule.style.transitionDuration = `${delay}ms`;
-            return;
-          }
-        }
-      } catch (e) {
-        // Cross-origin stylesheet or inaccessible rules — skip
-        continue;
-      }
-    }
-  };
+
 
   /**
    * Performs the Bubble Sort algorithm on the array with visualization.
@@ -109,7 +85,7 @@ const BubbleSortVisualization: React.FC = () => {
           <div
             key={index}
             className={`array-bar ${comparingIndices.includes(index) ? 'comparing' : ''}`}
-            style={{ height: `${value * 3}px` }}
+            style={{ height: `${value * 3}px`, transitionDuration: `${delay}ms` }}
           />
         ))}
       </div>

--- a/src/components/DSA/arrays/HeapSortVisualization/index.tsx
+++ b/src/components/DSA/arrays/HeapSortVisualization/index.tsx
@@ -22,34 +22,14 @@ const HeapSortVisualization: React.FC = () => {
     generateArray();
   }, []);
 
-  // Update transition duration when delay changes
-  useEffect(() => {
-    updateMoveDuration();
-  }, [delay]);
+
 
   const generateArray = () => {
     const newArray = Array.from({ length: 40 }, () => Math.ceil(Math.random() * 90) + 10);
     setArray(newArray);
   };
 
-  const updateMoveDuration = () => {
-    const stylesheets = document.styleSheets;
-    for (let i = 0; i < stylesheets.length; i++) {
-      try {
-        const rules = (stylesheets[i] as any).cssRules || (stylesheets[i] as any).rules;
-        if (!rules) continue;
-        for (let j = 0; j < rules.length; j++) {
-          const rule = rules[j] as CSSStyleRule;
-          if (rule && rule.selectorText === '.v-move') {
-            rule.style.transitionDuration = `${delay}ms`;
-            return;
-          }
-        }
-      } catch (e) {
-        continue;
-      }
-    }
-  };
+
 
   const delayFunction = (ms: number) => {
     if (!isMounted.current) return Promise.reject(new Error("unmounted"));
@@ -165,7 +145,7 @@ const HeapSortVisualization: React.FC = () => {
               index === heapIndex ? 'heap-index' : 
               comparingIndices?.includes(index) ? 'comparing-index' : ''
             }`}
-            style={{ height: `${value * 3}px`, transitionDelay: `${delay / 2}ms` }}
+            style={{ height: `${value * 3}px`, transitionDelay: `${delay / 2}ms`, transitionDuration: `${delay}ms` }}
           />
         ))}
       </div>

--- a/src/components/DSA/arrays/InsertionSortVisualization/index.tsx
+++ b/src/components/DSA/arrays/InsertionSortVisualization/index.tsx
@@ -14,10 +14,7 @@ const InsertionSortVisualization: React.FC = () => {
     generateArray();    
   }, []);
 
-  // Updates the transition duration whenever the delay changes
-  useEffect(() => {
-    updateMoveDuration();
-  }, [delay]);
+
 
   // Function to generate a new array with random values
   const generateArray = () => {
@@ -25,25 +22,7 @@ const InsertionSortVisualization: React.FC = () => {
     setArray(newArray);
   };
 
-  // Function to update the transition duration for CSS animations
-  const updateMoveDuration = () => {
-    const stylesheets = document.styleSheets;
-    for (let i = 0; i < stylesheets.length; i++) {
-      try {
-        const rules = (stylesheets[i] as any).cssRules || (stylesheets[i] as any).rules;
-        if (!rules) continue;
-        for (let j = 0; j < rules.length; j++) {
-          const rule = rules[j] as CSSStyleRule;
-          if (rule && rule.selectorText === '.v-move') {
-            rule.style.transitionDuration = `${delay}ms`;
-            return;
-          }
-        }
-      } catch (e) {
-        continue;
-      }
-    }
-  };
+
 
   // Function to perform insertion sort on the array
   const insertionSort = async () => {
@@ -89,7 +68,7 @@ const InsertionSortVisualization: React.FC = () => {
           <div
             key={index}
             className={`array-bar ${index === currentIndex ? 'current-index' : index === minIndex ? 'min-index' : ''}`}
-            style={{ height: `${value * 3}px`, transitionDelay: `${delay / 2}ms` }}
+            style={{ height: `${value * 3}px`, transitionDelay: `${delay / 2}ms`, transitionDuration: `${delay}ms` }}
            />
         ))}
       </div>      

--- a/src/components/DSA/arrays/QuickSortVisualization/index.tsx
+++ b/src/components/DSA/arrays/QuickSortVisualization/index.tsx
@@ -14,34 +14,14 @@ const QuickSortVisualization: React.FC = () => {
     generateArray();
   }, []);
 
-  // Update transition duration when delay changes
-  useEffect(() => {
-    updateMoveDuration();
-  }, [delay]);
+
 
   const generateArray = () => {
     const newArray = Array.from({ length: 40 }, () => Math.ceil(Math.random() * 90) + 10);
     setArray(newArray);
   };
 
-  const updateMoveDuration = () => {
-    const stylesheets = document.styleSheets;
-    for (let i = 0; i < stylesheets.length; i++) {
-      try {
-        const rules = (stylesheets[i] as any).cssRules || (stylesheets[i] as any).rules;
-        if (!rules) continue;
-        for (let j = 0; j < rules.length; j++) {
-          const rule = rules[j] as CSSStyleRule;
-          if (rule && rule.selectorText === '.v-move') {
-            rule.style.transitionDuration = `${delay}ms`;
-            return;
-          }
-        }
-      } catch (e) {
-        continue;
-      }
-    }
-  };
+
 
   const delayFunction = (ms: number) => {
     return new Promise(resolve => setTimeout(resolve, ms));
@@ -130,7 +110,7 @@ const QuickSortVisualization: React.FC = () => {
               index === pivotIndex ? 'pivot-index' : 
               comparingIndices?.includes(index) ? 'comparing-index' : ''
             }`}
-            style={{ height: `${value * 3}px`, transitionDelay: `${delay / 2}ms` }}
+            style={{ height: `${value * 3}px`, transitionDelay: `${delay / 2}ms`, transitionDuration: `${delay}ms` }}
           />
         ))}
       </div>

--- a/src/components/DSA/arrays/SelectionSortVisualization/index.tsx
+++ b/src/components/DSA/arrays/SelectionSortVisualization/index.tsx
@@ -22,10 +22,7 @@ const SelectionSortVisualization: React.FC = () => {
     generateArray();
   }, []);
 
-  // Effect to update the CSS transition duration when the delay changes
-  useEffect(() => {
-    updateMoveDuration();
-  }, [delay]);
+
 
   /**
    * Generates a new array of random numbers and updates the state.
@@ -35,27 +32,7 @@ const SelectionSortVisualization: React.FC = () => {
     setArray(newArray);
   };
 
-  /**
-   * Updates the CSS transition duration for the sorting visualization.
-   */
-  const updateMoveDuration = () => {
-    const stylesheets = document.styleSheets;
-    for (let i = 0; i < stylesheets.length; i++) {
-      try {
-        const rules = (stylesheets[i] as any).cssRules || (stylesheets[i] as any).rules;
-        if (!rules) continue;
-        for (let j = 0; j < rules.length; j++) {
-          const rule = rules[j] as CSSStyleRule;
-          if (rule && rule.selectorText === '.v-move') {
-            rule.style.transitionDuration = `${delay}ms`;
-            return;
-          }
-        }
-      } catch (e) {
-        continue;
-      }
-    }
-  };
+
 
   /**
    * Performs the Selection Sort algorithm on the array with visualization.
@@ -97,7 +74,7 @@ const SelectionSortVisualization: React.FC = () => {
           <div
             key={index}
             className={`array-bar ${comparingIndices.includes(index) ? 'comparing' : ''}`}
-            style={{ height: `${value * 3}px` }}
+            style={{ height: `${value * 3}px`, transitionDuration: `${delay}ms` }}
           />
         ))}
       </div>

--- a/src/components/DSA/arrays/ShellSortVisualization/index.tsx
+++ b/src/components/DSA/arrays/ShellSortVisualization/index.tsx
@@ -17,33 +17,14 @@ const ShellSortVisualization: React.FC = () => {
     generateArray();
   }, []);
 
-  useEffect(() => {
-    updateMoveDuration();
-  }, [delay]);
+
 
   const generateArray = () => {
     const newArray = Array.from({ length: 30 }, () => Math.ceil(Math.random() * 100));
     setArray(newArray);
   };
 
-  const updateMoveDuration = () => {
-    const stylesheets = document.styleSheets;
-    for (let i = 0; i < stylesheets.length; i++) {
-      try {
-        const rules = (stylesheets[i] as any).cssRules || (stylesheets[i] as any).rules;
-        if (!rules) continue;
-        for (let j = 0; j < rules.length; j++) {
-          const rule = rules[j] as CSSStyleRule;
-          if (rule && rule.selectorText === '.v-move') {
-            rule.style.transitionDuration = `${delay}ms`;
-            return;
-          }
-        }
-      } catch (e) {
-        continue;
-      }
-    }
-  };
+
 
 
   const shellSort = async () => {
@@ -88,7 +69,7 @@ const ShellSortVisualization: React.FC = () => {
           <div
             key={index}
             className={`array-bar ${comparingIndices.includes(index) ? 'comparing' : ''}`}
-            style={{ height: `${value * 3}px` }}
+            style={{ height: `${value * 3}px`, transitionDuration: `${delay}ms` }}
           />
         ))}
       </div>


### PR DESCRIPTION
Fixes #3491. Removed \updateMoveDuration\ which mutated global stylesheets. Passing \delay\ as an inline style for \	ransitionDuration\ instead.