### PR TITLE
fix: prevent MockExamTimer interval restart on parent re-renders

### DIFF
--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -31,6 +31,15 @@ export default function MockExamTimer({
   const [timeLeft, setTimeLeft] = useState<number>(timeLimitSeconds);
   const expiredRef = useRef<boolean>(false);
 
+  // Keep refs to the latest callbacks so the interval closure never goes stale.
+  // This means a new referentially-different onTick/onTimeExpired from the parent
+  // will NOT restart the interval — it simply updates what gets called on the
+  // next tick.
+  const onTickRef = useRef(onTick);
+  const onTimeExpiredRef = useRef(onTimeExpired);
+  useEffect(() => { onTickRef.current = onTick; }, [onTick]);
+  useEffect(() => { onTimeExpiredRef.current = onTimeExpired; }, [onTimeExpired]);
+
   useEffect(() => {
     setTimeLeft(timeLimitSeconds);
     expiredRef.current = false;
@@ -42,15 +51,15 @@ export default function MockExamTimer({
     const timer = setInterval(() => {
       setTimeLeft((prev) => {
         const next = prev - 1;
-        if (onTick) {
-          onTick(next);
+        if (onTickRef.current) {
+          onTickRef.current(next);
         }
 
         if (next <= 0 && !expiredRef.current) {
           expiredRef.current = true;
           clearInterval(timer);
           setTimeout(() => {
-            onTimeExpired();
+            onTimeExpiredRef.current();
           }, 0);
           return 0;
         }
@@ -59,7 +68,9 @@ export default function MockExamTimer({
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [isSubmitted, onTimeExpired, onTick]);
+  // onTimeExpired and onTick intentionally excluded — refs keep them current
+  // without restarting the interval on every parent re-render.
+  }, [isSubmitted]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const isWarning = timeLeft > 0 && timeLeft <= 300; // < 5 mins
   const isCritical = timeLeft > 0 && timeLeft <= 60;  // < 1 min

--- a/src/pages/mock-exam.tsx
+++ b/src/pages/mock-exam.tsx
@@ -228,6 +228,16 @@ function MockExamContent() {
     [totalScore, questions, timeSpentSeconds, topicPerformanceList, userAnswers]
   );
 
+  // Memoize the tick handler so MockExamTimer never receives a new
+  // function reference on every render, which would previously restart
+  // the interval mid-exam.
+  const handleTick = useCallback(
+    (secsLeft: number) => {
+      setTimeSpentSeconds(timeLimitMinutes * 60 - secsLeft);
+    },
+    [timeLimitMinutes]
+  );
+
   const currentQuestion = questions[currentQuestionIndex];
 
   return (
@@ -487,9 +497,7 @@ function MockExamContent() {
                 timeLimitSeconds={timeLimitMinutes * 60}
                 onTimeExpired={() => handleSubmitExam(true)}
                 isSubmitted={mode !== "active"}
-                onTick={(secsLeft) => {
-                  setTimeSpentSeconds(timeLimitMinutes * 60 - secsLeft);
-                }}
+                onTick={handleTick}
               />
             </div>
 


### PR DESCRIPTION
Fixes #3510

The countdown interval was restarting mid-exam whenever the parent passed new referentially-different onTick or onTimeExpired callbacks, because both were in the interval useEffect dependency array. This caused skipped or double-counted seconds.

MockExamTimer.tsx:
- Store onTick and onTimeExpired in refs (onTickRef, onTimeExpiredRef)
- Sync the refs via two lightweight useEffects so they always hold the latest callback without triggering an interval restart
- Remove onTimeExpired and onTick from the interval useEffect deps - only isSubmitted remains, so the timer only restarts when the exam is submitted or a new exam starts

mock-exam.tsx:
- Extract the inline onTick arrow into a memoized handleTick via useCallback([timeLimitMinutes]) so the ref never receives a stale timeLimitMinutes value
- Pass handleTick to MockExamTimer instead of an inline arrow
