### PR TITLE
Export Quiz History as CSV/JSON from Weak Topics Dashboard

### DIFF
--- a/src/__tests__/components/WeakTopicsChart.test.tsx
+++ b/src/__tests__/components/WeakTopicsChart.test.tsx
@@ -1,8 +1,14 @@
 import React from "react";
-import { render, screen } from "../testUtils";
+import { render, screen, fireEvent } from "../testUtils";
 import WeakTopicsChart from "../../components/WeakTopicsChart";
 import type { WeakTopicEntry } from "../../utils/weakTopics";
 import type { QuizStat } from "../../hooks/useQuizProgress";
+import * as exportUtils from "../../utils/exportQuizData";
+
+jest.mock("../../utils/exportQuizData", () => ({
+  ...jest.requireActual("../../utils/exportQuizData"),
+  downloadQuizData: jest.fn(),
+}));
 
 function makeStat(quizId: string, overrides: Partial<QuizStat> = {}): QuizStat {
   return {
@@ -33,6 +39,10 @@ const entries: WeakTopicEntry[] = [
 ];
 
 describe("WeakTopicsChart", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   test("renders an empty state when there are no entries", () => {
     render(<WeakTopicsChart entries={[]} />);
     expect(screen.getByText(/no quiz history yet/i)).toBeInTheDocument();
@@ -56,5 +66,40 @@ describe("WeakTopicsChart", () => {
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute("href", "/quizzes/graph");
     expect(links[1]).toHaveAttribute("href", "/quizzes/binary-search-tree");
+  });
+
+  test('renders "Download my data" button and calls downloadQuizData on click', () => {
+    render(<WeakTopicsChart entries={entries} />);
+
+    const downloadBtn = screen.getByRole("button", { name: /download my data/i });
+    expect(downloadBtn).toBeInTheDocument();
+
+    fireEvent.click(downloadBtn);
+
+    expect(exportUtils.downloadQuizData).toHaveBeenCalledWith(
+      {
+        graphs: entries[0].stat,
+        bst: entries[1].stat,
+      },
+      "csv"
+    );
+  });
+
+  test("allows selecting JSON format and downloading JSON quiz data", () => {
+    render(<WeakTopicsChart entries={entries} />);
+
+    const formatSelect = screen.getByRole("combobox", { name: /export format/i });
+    fireEvent.change(formatSelect, { target: { value: "json" } });
+
+    const downloadBtn = screen.getByRole("button", { name: /download my data/i });
+    fireEvent.click(downloadBtn);
+
+    expect(exportUtils.downloadQuizData).toHaveBeenCalledWith(
+      {
+        graphs: entries[0].stat,
+        bst: entries[1].stat,
+      },
+      "json"
+    );
   });
 });

--- a/src/__tests__/utils/exportQuizData.test.ts
+++ b/src/__tests__/utils/exportQuizData.test.ts
@@ -1,0 +1,121 @@
+import {
+  serializeQuizStatsToCsv,
+  serializeQuizStatsToJson,
+  downloadQuizData,
+} from "../../utils/exportQuizData";
+import type { QuizStat } from "../../hooks/useQuizProgress";
+
+const mockStats: Record<string, QuizStat> = {
+  arrays: {
+    quizId: "arrays",
+    bestScore: 8,
+    bestPercent: 80,
+    latestScore: 8,
+    latestPercent: 80,
+    latestAttemptAt: "2026-08-01T10:00:00.000Z",
+    totalAttempts: 2,
+    totalQuestions: 10,
+    averagePercent: 75,
+    status: "passed",
+    attempts: [
+      { score: 7, totalQuestions: 10, timeSpent: 45, completedAt: "2026-07-30T09:00:00.000Z" },
+      { score: 8, totalQuestions: 10, timeSpent: 30, completedAt: "2026-08-01T10:00:00.000Z" },
+    ],
+  },
+  graphs: {
+    quizId: "graphs",
+    bestScore: 3,
+    bestPercent: 25,
+    latestScore: 3,
+    latestPercent: 25,
+    latestAttemptAt: "2026-08-02T12:00:00.000Z",
+    totalAttempts: 1,
+    totalQuestions: 12,
+    averagePercent: 25,
+    status: "in-progress",
+    attempts: [
+      { score: 3, totalQuestions: 12, timeSpent: 120, completedAt: "2026-08-02T12:00:00.000Z" },
+    ],
+  },
+};
+
+describe("exportQuizData utility", () => {
+  describe("serializeQuizStatsToCsv", () => {
+    test("serializes quiz stats into a formatted CSV string with headers", () => {
+      const csv = serializeQuizStatsToCsv(mockStats);
+
+      const lines = csv.split("\n");
+      expect(lines[0]).toBe(
+        "Quiz ID,Best Score,Best Percent (%),Average Percent (%),Total Attempts,Total Questions,Status,Latest Attempt Date,Attempts History"
+      );
+
+      // Check arrays row
+      expect(lines[1]).toContain("arrays,8,80,75,2,10,passed,2026-08-01T10:00:00.000Z");
+      expect(lines[1]).toContain("Score: 7/10");
+      expect(lines[1]).toContain("Score: 8/10");
+
+      // Check graphs row
+      expect(lines[2]).toContain("graphs,3,25,25,1,12,in-progress,2026-08-02T12:00:00.000Z");
+    });
+  });
+
+  describe("serializeQuizStatsToJson", () => {
+    test("serializes quiz stats into valid formatted JSON", () => {
+      const json = serializeQuizStatsToJson(mockStats);
+      const parsed = JSON.parse(json);
+
+      expect(parsed).toEqual(mockStats);
+    });
+  });
+
+  describe("downloadQuizData", () => {
+    let originalCreateObjectURL: typeof URL.createObjectURL;
+    let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+
+    beforeEach(() => {
+      originalCreateObjectURL = URL.createObjectURL;
+      originalRevokeObjectURL = URL.revokeObjectURL;
+      URL.createObjectURL = jest.fn(() => "blob:mock-url");
+      URL.revokeObjectURL = jest.fn();
+    });
+
+    afterEach(() => {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+      // Restore all spies (including createElement) so each test starts clean
+      jest.restoreAllMocks();
+    });
+
+    test("creates Blob and triggers element click for CSV download", () => {
+      const appendSpy = jest.spyOn(document.body, "appendChild");
+      const removeSpy = jest.spyOn(document.body, "removeChild");
+
+      const realAnchor = document.createElement("a");
+      const clickSpy = jest.spyOn(realAnchor, "click").mockImplementation(() => {});
+      const setAttributeSpy = jest.spyOn(realAnchor, "setAttribute");
+      jest.spyOn(document, "createElement").mockReturnValue(realAnchor);
+
+      downloadQuizData(mockStats, "csv", "test_history.csv");
+
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(setAttributeSpy).toHaveBeenCalledWith("download", "test_history.csv");
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(appendSpy).toHaveBeenCalledWith(realAnchor);
+      expect(removeSpy).toHaveBeenCalledWith(realAnchor);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    });
+
+    test("creates Blob and triggers element click for JSON download", () => {
+      const realAnchor = document.createElement("a");
+      const clickSpy = jest.spyOn(realAnchor, "click").mockImplementation(() => {});
+      const setAttributeSpy = jest.spyOn(realAnchor, "setAttribute");
+      jest.spyOn(document, "createElement").mockReturnValue(realAnchor);
+
+      downloadQuizData(mockStats, "json", "test_history.json");
+
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(setAttributeSpy).toHaveBeenCalledWith("download", "test_history.json");
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/WeakTopicsChart.tsx
+++ b/src/components/WeakTopicsChart.tsx
@@ -1,11 +1,15 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import Link from "@docusaurus/Link";
-import { FiArrowRight } from "react-icons/fi";
+import { FiArrowRight, FiDownload } from "react-icons/fi";
 import type { WeakTopicEntry } from "../utils/weakTopics";
+import type { QuizStat } from "../hooks/useQuizProgress";
+import { downloadQuizData } from "../utils/exportQuizData";
 
-interface WeakTopicsChartProps {
+export interface WeakTopicsChartProps {
   entries: WeakTopicEntry[];
+  stats?: Record<string, QuizStat>;
+  showExport?: boolean;
 }
 
 function barColor(bestPercent: number, hasAttempts: boolean): string {
@@ -15,7 +19,28 @@ function barColor(bestPercent: number, hasAttempts: boolean): string {
   return "bg-blue-500";
 }
 
-export default function WeakTopicsChart({ entries }: WeakTopicsChartProps) {
+export default function WeakTopicsChart({
+  entries,
+  stats,
+  showExport = true,
+}: WeakTopicsChartProps) {
+  const [exportFormat, setExportFormat] = useState<"csv" | "json">("csv");
+
+  const exportDataMap = useMemo(() => {
+    if (stats && Object.keys(stats).length > 0) {
+      return stats;
+    }
+    const map: Record<string, QuizStat> = {};
+    entries.forEach((entry) => {
+      map[entry.quiz.id] = entry.stat;
+    });
+    return map;
+  }, [stats, entries]);
+
+  const handleDownload = (format: "csv" | "json" = exportFormat) => {
+    downloadQuizData(exportDataMap, format);
+  };
+
   if (entries.length === 0) {
     return (
       <div className="text-center py-12 border border-dashed border-slate-200 dark:border-slate-800 rounded-2xl">
@@ -28,6 +53,34 @@ export default function WeakTopicsChart({ entries }: WeakTopicsChartProps) {
 
   return (
     <div className="space-y-4">
+      {showExport && (
+        <div className="flex flex-wrap items-center justify-between gap-3 pb-3 border-b border-slate-100 dark:border-slate-800">
+          <span className="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+            Recommended Practice Topics
+          </span>
+          <div className="flex items-center gap-2">
+            <select
+              value={exportFormat}
+              onChange={(e) => setExportFormat(e.target.value as "csv" | "json")}
+              aria-label="Export format"
+              className="text-xs py-1.5 px-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-700 font-medium focus:outline-none"
+            >
+              <option value="csv">CSV (.csv)</option>
+              <option value="json">JSON (.json)</option>
+            </select>
+            <button
+              type="button"
+              onClick={() => handleDownload()}
+              aria-label="Download my data"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs shadow-sm transition-all"
+            >
+              <FiDownload size={14} />
+              Download my data
+            </button>
+          </div>
+        </div>
+      )}
+
       {entries.map((entry, index) => {
         const hasAttempts = entry.stat.totalAttempts > 0;
         const pct = hasAttempts ? entry.stat.bestPercent : 0;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,0 +1,108 @@
+import React, { useMemo } from "react";
+import Layout from "@theme/Layout";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import { motion } from "framer-motion";
+import { FaChartBar, FaExclamationTriangle } from "react-icons/fa";
+import { FiDownload } from "react-icons/fi";
+import { useQuizProgress } from "../hooks/useQuizProgress";
+import { QUIZZES_CONFIG, QUESTION_COUNTS, QUIZ_IDS } from "../data/quizzesConfig";
+import { rankWeakTopics } from "../utils/weakTopics";
+import WeakTopicsChart from "../components/WeakTopicsChart";
+import QuizStreakWidget from "../components/QuizStreakWidget";
+import { downloadQuizData } from "../utils/exportQuizData";
+
+function DashboardContent() {
+  const { stats, globalStats, userId, loaded } = useQuizProgress(QUIZ_IDS, QUESTION_COUNTS);
+
+  const weakTopicEntries = useMemo(() => {
+    return rankWeakTopics(stats, QUIZZES_CONFIG);
+  }, [stats]);
+
+  if (!loaded) {
+    return (
+      <div className="py-16 text-center text-slate-400 font-mono text-sm">
+        Loading quiz history & weak topics dashboard...
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 py-8 space-y-8">
+      {/* Header Banner */}
+      <motion.div
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-slate-900 dark:bg-slate-950 text-white rounded-3xl p-6 sm:p-8 shadow-xl border border-slate-800 flex flex-col md:flex-row md:items-center justify-between gap-6"
+      >
+        <div className="space-y-2 max-w-2xl">
+          <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-amber-500/10 text-amber-400 border border-amber-500/20 text-xs font-bold uppercase tracking-widest">
+            <FaExclamationTriangle size={12} />
+            Weak Topics Dashboard
+          </div>
+          <h1 className="text-2xl sm:text-3xl font-black tracking-tight text-white m-0">
+            Target Your Weak Spots & Track Progress
+          </h1>
+          <p className="text-slate-400 text-sm m-0 leading-relaxed">
+            Review the topics where your quiz scores are lowest, practice tailored questions, or export your serialized stats to track interview prep progress in your own spreadsheet.
+          </p>
+        </div>
+
+        <div className="shrink-0 flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+          <button
+            type="button"
+            onClick={() => downloadQuizData(stats, "csv")}
+            aria-label="Download my data"
+            className="inline-flex items-center justify-center gap-2 px-5 py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-bold text-sm shadow-lg hover:shadow-xl transition-all cursor-pointer border-0"
+          >
+            <FiDownload size={16} />
+            Download my data (CSV)
+          </button>
+          <button
+            type="button"
+            onClick={() => downloadQuizData(stats, "json")}
+            aria-label="Download JSON data"
+            className="inline-flex items-center justify-center gap-2 px-4 py-3 rounded-2xl bg-slate-800 hover:bg-slate-700 text-slate-200 font-bold text-sm border border-slate-700 transition-all cursor-pointer"
+          >
+            Export JSON
+          </button>
+        </div>
+      </motion.div>
+
+      {/* Main Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 items-start">
+        {/* Left 2 Columns: Weak Topics Chart */}
+        <div className="lg:col-span-2 space-y-6">
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-3xl p-6 shadow-sm">
+            <div className="flex items-center justify-between pb-4 mb-4 border-b border-slate-100 dark:border-slate-800">
+              <div className="flex items-center gap-2.5">
+                <FaExclamationTriangle className="text-amber-500 text-sm" />
+                <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 m-0">
+                  Weak Topics Analysis
+                </h2>
+              </div>
+            </div>
+            <WeakTopicsChart entries={weakTopicEntries} stats={stats} showExport={true} />
+          </div>
+        </div>
+
+        {/* Right Column: Quiz Streak Widget */}
+        <div className="lg:col-span-1 space-y-6">
+          <QuizStreakWidget />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function WeakTopicsDashboardPage() {
+  return (
+    <Layout
+      title="Weak Topics Dashboard"
+      description="Track quiz progress, target weak data structure topics, and download history for interview prep spreadsheets."
+    >
+      <BrowserOnly fallback={<div className="py-16 text-center text-slate-400 font-mono">Loading dashboard...</div>}>
+        {() => <DashboardContent />}
+      </BrowserOnly>
+    </Layout>
+  );
+}

--- a/src/pages/quizzes/index.tsx
+++ b/src/pages/quizzes/index.tsx
@@ -12,6 +12,8 @@ import BrowserOnly from "@docusaurus/BrowserOnly";
 import { useQuizProgress, QuizStat, GlobalQuizStats } from "../../hooks/useQuizProgress";
 import QuizStreakWidget from "../../components/QuizStreakWidget";
 import { QUIZZES_CONFIG, QUESTION_COUNTS, QUIZ_IDS, type QuizCardConfig } from "../../data/quizzesConfig";
+import { downloadQuizData } from "../../utils/exportQuizData";
+import { FiDownload } from "react-icons/fi";
 
 const FILTER_CATEGORIES = ["All", "Linear", "Non-Linear", "Balanced Tree", "Disk Storage"] as const;
 
@@ -60,9 +62,10 @@ interface ProgressDashboardProps {
   globalStats: GlobalQuizStats;
   userId: string | null;
   loaded: boolean;
+  stats?: Record<string, QuizStat>;
 }
 
-function ProgressDashboard({ globalStats, userId, loaded }: ProgressDashboardProps) {
+function ProgressDashboard({ globalStats, userId, loaded, stats }: ProgressDashboardProps) {
   if (!loaded) return null;
 
   const progressPct = globalStats.totalQuizzes > 0
@@ -91,11 +94,24 @@ function ProgressDashboard({ globalStats, userId, loaded }: ProgressDashboardPro
               </span>
             )}
           </div>
-          {!userId && (
-            <span className="text-[10px] font-mono text-slate-400 dark:text-slate-500 italic">
-              Take a quiz to see your scores here
-            </span>
-          )}
+          <div className="flex items-center gap-3">
+            {stats && Object.keys(stats).length > 0 && (
+              <button
+                type="button"
+                onClick={() => downloadQuizData(stats, "csv")}
+                aria-label="Download my data"
+                className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs shadow-sm transition-all"
+              >
+                <FiDownload size={13} />
+                Download my data
+              </button>
+            )}
+            {!userId && (
+              <span className="text-[10px] font-mono text-slate-400 dark:text-slate-500 italic hidden sm:inline">
+                Take a quiz to see your scores here
+              </span>
+            )}
+          </div>
         </div>
 
         <div className="p-5 sm:p-6">
@@ -416,7 +432,7 @@ const Quizzes: React.FC = () => {
                 <>
                   <div className="max-w-7xl mx-auto px-4 mt-10 mb-2 grid grid-cols-1 lg:grid-cols-3 gap-6 items-start">
                     <div className="lg:col-span-2">
-                      <ProgressDashboard globalStats={globalStats} userId={userId} loaded={loaded} />
+                      <ProgressDashboard globalStats={globalStats} userId={userId} loaded={loaded} stats={stats} />
                     </div>
                     <div className="lg:col-span-1">
                       <QuizStreakWidget />

--- a/src/utils/exportQuizData.ts
+++ b/src/utils/exportQuizData.ts
@@ -1,0 +1,104 @@
+import type { QuizStat } from "../hooks/useQuizProgress";
+
+/**
+ * Escapes a single string field for CSV compliance RFC 4180.
+ */
+function escapeCsvField(val: string | number | null | undefined): string {
+  if (val === null || val === undefined) return "";
+  const str = String(val);
+  if (str.includes(",") || str.includes('"') || str.includes("\n") || str.includes("\r")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Serializes a record of QuizStat objects into a CSV string.
+ */
+export function serializeQuizStatsToCsv(stats: Record<string, QuizStat>): string {
+  const headers = [
+    "Quiz ID",
+    "Best Score",
+    "Best Percent (%)",
+    "Average Percent (%)",
+    "Total Attempts",
+    "Total Questions",
+    "Status",
+    "Latest Attempt Date",
+    "Attempts History",
+  ];
+
+  const rows = Object.values(stats).map((stat) => {
+    const attemptsHistoryStr = stat.attempts
+      .map((att) => {
+        const date = att.completedAt ? att.completedAt : "N/A";
+        const total = att.totalQuestions ?? stat.totalQuestions;
+        return `${date} (Score: ${att.score}/${total}, Time: ${att.timeSpent}s)`;
+      })
+      .join("; ");
+
+    return [
+      stat.quizId,
+      stat.bestScore,
+      stat.bestPercent,
+      stat.averagePercent,
+      stat.totalAttempts,
+      stat.totalQuestions,
+      stat.status,
+      stat.latestAttemptAt ?? "",
+      attemptsHistoryStr,
+    ]
+      .map(escapeCsvField)
+      .join(",");
+  });
+
+  return [headers.join(","), ...rows].join("\n");
+}
+
+/**
+ * Serializes a record of QuizStat objects into a JSON string.
+ */
+export function serializeQuizStatsToJson(stats: Record<string, QuizStat>): string {
+  return JSON.stringify(stats, null, 2);
+}
+
+/**
+ * Triggers a browser file download using Blob and a dynamic <a download> element.
+ * Safe for SSG / client environments.
+ */
+export function downloadBlob(content: string, filename: string, mimeType: string): void {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return;
+  }
+
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Helper to serialize quiz stats and trigger client-side download in CSV or JSON format.
+ */
+export function downloadQuizData(
+  stats: Record<string, QuizStat>,
+  format: "csv" | "json" = "csv",
+  filename?: string
+): void {
+  const dateStr = new Date().toISOString().split("T")[0];
+
+  if (format === "csv") {
+    const csvData = serializeQuizStatsToCsv(stats);
+    const fname = filename ?? `quiz_history_${dateStr}.csv`;
+    downloadBlob(csvData, fname, "text/csv;charset=utf-8;");
+  } else {
+    const jsonData = serializeQuizStatsToJson(stats);
+    const fname = filename ?? `quiz_history_${dateStr}.json`;
+    downloadBlob(jsonData, fname, "application/json;charset=utf-8;");
+  }
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description

The upcoming Weak Topics Dashboard aggregates a user's quiz performance using the same data exposed by useQuizProgress, but there is currently no way to export that data for external analysis.

Add a "Download my data" action that exports the computed quiz statistics as either JSON or CSV, entirely on the client using a Blob and <a download>—no backend or API changes required.

This allows users to keep a long-term record of their interview preparation progress in spreadsheets, Notion, or other analytics tools.

Fixes #3503 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
