### PR TITLE
Add Keyboard Shortcut to Open Theme Picker (T / Ctrl+Shift+T)

### DIFF
--- a/src/__tests__/components/ThemePickerModal.test.tsx
+++ b/src/__tests__/components/ThemePickerModal.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen, fireEvent } from "../testUtils";
+import ThemePickerModal from "../../components/ThemePickerModal";
+import * as accentUtils from "../../utils/accentTheme";
+import * as codeUtils from "../../utils/codeTheme";
+
+describe("ThemePickerModal", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("does not render when isOpen is false", () => {
+    render(<ThemePickerModal isOpen={false} onClose={jest.fn()} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("renders dialog with accent and code theme options when isOpen is true", () => {
+    render(<ThemePickerModal isOpen={true} onClose={jest.fn()} />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Theme Picker")).toBeInTheDocument();
+
+    expect(screen.getByRole("radio", { name: /high contrast/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /neon/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /midnight/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /solarized/i })).toBeInTheDocument();
+  });
+
+  test("calls applyAccentTheme and storeAccentTheme when an accent option is selected", () => {
+    const applySpy = jest.spyOn(accentUtils, "applyAccentTheme").mockImplementation();
+    const storeSpy = jest.spyOn(accentUtils, "storeAccentTheme").mockImplementation();
+
+    render(<ThemePickerModal isOpen={true} onClose={jest.fn()} />);
+
+    const neonBtn = screen.getByRole("radio", { name: /neon/i });
+    fireEvent.click(neonBtn);
+
+    expect(applySpy).toHaveBeenCalledWith("neon");
+    expect(storeSpy).toHaveBeenCalledWith("neon");
+  });
+
+  test("calls applyCodeTheme and storeCodeTheme when a code theme option is selected", () => {
+    const applySpy = jest.spyOn(codeUtils, "applyCodeTheme").mockImplementation();
+    const storeSpy = jest.spyOn(codeUtils, "storeCodeTheme").mockImplementation();
+
+    render(<ThemePickerModal isOpen={true} onClose={jest.fn()} />);
+
+    const midnightBtn = screen.getByRole("radio", { name: /midnight/i });
+    fireEvent.click(midnightBtn);
+
+    expect(applySpy).toHaveBeenCalledWith("midnight");
+    expect(storeSpy).toHaveBeenCalledWith("midnight");
+  });
+
+  test("calls onClose when close button is clicked", () => {
+    const onClose = jest.fn();
+    render(<ThemePickerModal isOpen={true} onClose={onClose} />);
+
+    const closeBtn = screen.getByRole("button", { name: /close theme picker/i });
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/hooks/useKeyboardShortcuts.test.ts
+++ b/src/__tests__/hooks/useKeyboardShortcuts.test.ts
@@ -1,0 +1,71 @@
+import { renderHook } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import useKeyboardShortcuts from "../../hooks/useKeyboardShortcuts";
+
+// Mock @docusaurus/router
+const mockPush = jest.fn();
+jest.mock("@docusaurus/router", () => ({
+  useHistory: () => ({
+    push: mockPush,
+  }),
+}));
+
+describe("useKeyboardShortcuts hook", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("triggers onOpenThemePicker when bare 't' key is pressed", async () => {
+    const onOpenThemePicker = jest.fn();
+    const user = userEvent.setup();
+
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onOpenHelp: jest.fn(),
+        onCloseHelp: jest.fn(),
+        onOpenThemePicker,
+      })
+    );
+
+    await user.keyboard("t");
+    expect(onOpenThemePicker).toHaveBeenCalledTimes(1);
+  });
+
+  test("triggers onOpenThemePicker when Ctrl+Shift+T key combination is pressed", async () => {
+    const onOpenThemePicker = jest.fn();
+    const user = userEvent.setup();
+
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onOpenHelp: jest.fn(),
+        onCloseHelp: jest.fn(),
+        onOpenThemePicker,
+      })
+    );
+
+    await user.keyboard("{Control>}{Shift>}t{/Shift}{/Control}");
+    expect(onOpenThemePicker).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not trigger bare 't' shortcut when user is typing in an input element", async () => {
+    const onOpenThemePicker = jest.fn();
+    const user = userEvent.setup();
+
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onOpenHelp: jest.fn(),
+        onCloseHelp: jest.fn(),
+        onOpenThemePicker,
+      })
+    );
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    await user.keyboard("t");
+    expect(onOpenThemePicker).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+});

--- a/src/components/KeyboardShortcutsModal.tsx
+++ b/src/components/KeyboardShortcutsModal.tsx
@@ -28,6 +28,7 @@ const SHORTCUTS_DATA: ShortcutItem[] = [
   { action: "Go to Blog", keys: ["g", "b"] },
   { action: "Go to Quizzes", keys: ["g", "q"] },
   { action: "Toggle dark mode", keys: ["⌘", "Shift", "D"] },
+  { action: "Open theme picker", keys: ["T", "or", "⌘", "Shift", "T"] },
   { action: "Next item / Next step", keys: ["j"] },
   { action: "Previous item / Previous step", keys: ["k"] },
   { action: "Collapse/Expand all panes", keys: ["Esc", "Esc"] },

--- a/src/components/Quiz/ShareResultModal.module.css
+++ b/src/components/Quiz/ShareResultModal.module.css
@@ -7,6 +7,7 @@
   justify-content: center;
   padding: 16px;
   background-color: rgba(15, 23, 42, 0.5);
+  -webkit-backdrop-filter: blur(4px);
   backdrop-filter: blur(4px);
 }
 

--- a/src/components/ThemePickerModal/ThemePickerModal.module.css
+++ b/src/components/ThemePickerModal/ThemePickerModal.module.css
@@ -1,0 +1,235 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(15, 23, 42, 0.45);
+  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(4px);
+  padding: 1rem;
+}
+
+.modal {
+  width: 100%;
+  max-width: 460px;
+  max-height: 90vh;
+  background: var(--ifm-background-surface-color);
+  border: 1px solid var(--ifm-toc-border-color);
+  border-radius: 20px;
+  box-shadow:
+    0 20px 60px rgba(0, 0, 0, 0.22),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* ── Header ── */
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem 1rem;
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+  gap: 0.75rem;
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0 0 0.2rem;
+  letter-spacing: -0.01em;
+  color: var(--ifm-font-color-base);
+}
+
+.subtitle {
+  font-size: 0.8rem;
+  color: var(--ifm-color-emphasis-600);
+  margin: 0;
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+.closeButton:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-font-color-base);
+}
+.closeButton:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+/* ── Body ── */
+.body {
+  padding: 1rem 1.25rem;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.section {
+  margin-bottom: 0.25rem;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.sectionIcon {
+  color: var(--ifm-color-primary);
+  flex-shrink: 0;
+}
+
+.sectionTitle {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ifm-color-emphasis-700);
+  margin: 0;
+}
+
+.divider {
+  height: 1px;
+  background: var(--ifm-toc-border-color);
+  margin: 1rem 0;
+}
+
+.optionList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ── Option rows ── */
+.option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  color: var(--ifm-font-color-base);
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.option:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.option[data-active="true"] {
+  background: var(--ifm-color-primary-lightest, rgba(59, 130, 246, 0.08));
+  border-color: var(--ifm-color-primary);
+}
+
+.option:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 1px;
+}
+
+.optionText {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.optionLabel {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.optionDesc {
+  font-size: 0.72rem;
+  color: var(--ifm-color-emphasis-600);
+  margin-top: 1px;
+}
+
+.checkIcon {
+  color: var(--ifm-color-primary);
+  flex-shrink: 0;
+}
+
+/* ── Swatches ── */
+.swatch {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  border: 1.5px solid rgba(0, 0, 0, 0.1);
+}
+
+/* Accent swatches */
+.swatch[data-swatch='default'] {
+  background: linear-gradient(135deg, #3b82f6 50%, #eab308 50%);
+}
+.swatch[data-swatch='high-contrast'] {
+  background: #000;
+  border: 2px solid #ffff00;
+}
+.swatch[data-swatch='neon'] {
+  background: linear-gradient(135deg, #22d3ee, #a855f7);
+  box-shadow: 0 0 8px rgba(34, 211, 238, 0.5);
+}
+
+/* Code theme swatches */
+.swatch[data-code-swatch='default'] {
+  background: linear-gradient(135deg, #64748b 50%, #94a3b8 50%);
+}
+.swatch[data-code-swatch='midnight'] {
+  background: linear-gradient(135deg, #1e293b 50%, #60a5fa 50%);
+}
+.swatch[data-code-swatch='solarized'] {
+  background: linear-gradient(135deg, #fdf6e3 50%, #859900 50%);
+  border-color: rgba(0, 0, 0, 0.2);
+}
+
+/* ── Footer ── */
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding: 0.75rem 1.5rem;
+  border-top: 1px solid var(--ifm-toc-border-color);
+  background: var(--ifm-color-emphasis-0, var(--ifm-background-color));
+}
+
+.kbdHint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 6px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 5px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  font-family: var(--ifm-font-family-monospace);
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-font-color-base);
+}
+
+.footerText {
+  font-size: 0.7rem;
+  color: var(--ifm-color-emphasis-500);
+}

--- a/src/components/ThemePickerModal/index.tsx
+++ b/src/components/ThemePickerModal/index.tsx
@@ -1,0 +1,177 @@
+import React, { useRef, useState, useEffect } from "react";
+import { FiCheck, FiDroplet, FiCode, FiX } from "react-icons/fi";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
+import {
+  ACCENT_THEMES,
+  applyAccentTheme,
+  getStoredAccentTheme,
+  storeAccentTheme,
+  type AccentTheme,
+} from "../../utils/accentTheme";
+import {
+  CODE_THEMES,
+  applyCodeTheme,
+  getStoredCodeTheme,
+  storeCodeTheme,
+  type CodeTheme,
+} from "../../utils/codeTheme";
+import styles from "./ThemePickerModal.module.css";
+
+interface ThemePickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export default function ThemePickerModal({ isOpen, onClose }: ThemePickerModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(modalRef, { isOpen, onClose });
+
+  const [activeAccent, setActiveAccent] = useState<AccentTheme>("default");
+  const [activeCode, setActiveCode] = useState<CodeTheme>("default");
+
+  // Sync with stored values each time the modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setActiveAccent(getStoredAccentTheme());
+      setActiveCode(getStoredCodeTheme());
+    }
+  }, [isOpen]);
+
+  const selectAccent = (theme: AccentTheme) => {
+    setActiveAccent(theme);
+    applyAccentTheme(theme);
+    storeAccentTheme(theme);
+  };
+
+  const selectCode = (theme: CodeTheme) => {
+    setActiveCode(theme);
+    applyCodeTheme(theme);
+    storeCodeTheme(theme);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      onClick={onClose}
+      className={styles.overlay}
+    >
+      <div
+        ref={modalRef}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="theme-picker-modal-title"
+        className={styles.modal}
+      >
+        {/* Header */}
+        <div className={styles.header}>
+          <div>
+            <h2 id="theme-picker-modal-title" className={styles.title}>
+              Theme Picker
+            </h2>
+            <p className={styles.subtitle}>
+              Customize your accent color and code block appearance
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close theme picker"
+            className={styles.closeButton}
+          >
+            <FiX size={18} />
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          {/* Accent Theme Section */}
+          <section aria-labelledby="accent-theme-heading" className={styles.section}>
+            <div className={styles.sectionHeader}>
+              <FiDroplet size={15} className={styles.sectionIcon} />
+              <h3 id="accent-theme-heading" className={styles.sectionTitle}>
+                Accent Color
+              </h3>
+            </div>
+            <div className={styles.optionList} role="group" aria-label="Accent color options">
+              {ACCENT_THEMES.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={activeAccent === option.value}
+                  onClick={() => selectAccent(option.value)}
+                  className={styles.option}
+                  data-active={activeAccent === option.value ? "true" : undefined}
+                >
+                  <span
+                    className={styles.swatch}
+                    data-swatch={option.value}
+                    aria-hidden="true"
+                  />
+                  <span className={styles.optionText}>
+                    <span className={styles.optionLabel}>{option.label}</span>
+                    <span className={styles.optionDesc}>{option.description}</span>
+                  </span>
+                  {activeAccent === option.value && (
+                    <FiCheck size={15} className={styles.checkIcon} />
+                  )}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <div className={styles.divider} aria-hidden="true" />
+
+          {/* Code Theme Section */}
+          <section aria-labelledby="code-theme-heading" className={styles.section}>
+            <div className={styles.sectionHeader}>
+              <FiCode size={15} className={styles.sectionIcon} />
+              <h3 id="code-theme-heading" className={styles.sectionTitle}>
+                Code Block Style
+              </h3>
+            </div>
+            <div className={styles.optionList} role="group" aria-label="Code theme options">
+              {CODE_THEMES.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="radio"
+                  aria-checked={activeCode === option.value}
+                  onClick={() => selectCode(option.value)}
+                  className={styles.option}
+                  data-active={activeCode === option.value ? "true" : undefined}
+                >
+                  <span
+                    className={styles.swatch}
+                    data-code-swatch={option.value}
+                    aria-hidden="true"
+                  />
+                  <span className={styles.optionText}>
+                    <span className={styles.optionLabel}>{option.label}</span>
+                    <span className={styles.optionDesc}>{option.description}</span>
+                  </span>
+                  {activeCode === option.value && (
+                    <FiCheck size={15} className={styles.checkIcon} />
+                  )}
+                </button>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        {/* Footer hint */}
+        <div className={styles.footer}>
+          <kbd className={styles.kbdHint}>T</kbd>
+          <span className={styles.footerText}>or</span>
+          <kbd className={styles.kbdHint}>Ctrl</kbd>
+          <span className={styles.footerText}>+</span>
+          <kbd className={styles.kbdHint}>Shift</kbd>
+          <span className={styles.footerText}>+</span>
+          <kbd className={styles.kbdHint}>T</kbd>
+          <span className={styles.footerText}>to toggle · changes apply instantly &amp; persist</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -5,10 +5,11 @@ import { useHistory } from "@docusaurus/router";
 interface UseKeyboardShortcutsProps {
   onOpenHelp: () => void;
   onCloseHelp: () => void;
-  onOpenChallengeSearch?: () => void; // ← NEW: opens the challenge search modal
+  onOpenChallengeSearch?: () => void; // ← opens the challenge search modal
   onToggleTheme?: () => void;
   onResetLayout?: () => void;
   onCollapseAll?: () => void;
+  onOpenThemePicker?: () => void;     // ← opens the theme picker modal (T / Ctrl+Shift+T)
 }
 
 type SequentialShortcuts = Record<string, string>;
@@ -34,6 +35,7 @@ export default function useKeyboardShortcuts({
   onToggleTheme,
   onResetLayout,
   onCollapseAll,
+  onOpenThemePicker,
 }: UseKeyboardShortcutsProps): void {
   const history = useHistory();
   const keyBuffer = useRef<string[]>([]);
@@ -66,10 +68,17 @@ export default function useKeyboardShortcuts({
       // All remaining shortcuts are suppressed while the user is typing
       if (isTyping) return;
 
-      // ── 2. Ctrl/Cmd + Shift + D  →  Toggle theme ────────────────────────────
+      // ── 2. Ctrl/Cmd + Shift + D  →  Toggle dark/light mode ────────────────────
       if ((metaKey || ctrlKey) && shiftKey && lowerKey === "d" && onToggleTheme) {
         event.preventDefault();
         onToggleTheme();
+        return;
+      }
+
+      // ── 2b. Ctrl/Cmd + Shift + T  →  Open theme picker ───────────────────────
+      if ((metaKey || ctrlKey) && shiftKey && lowerKey === "t" && onOpenThemePicker) {
+        event.preventDefault();
+        onOpenThemePicker();
         return;
       }
 
@@ -117,6 +126,13 @@ export default function useKeyboardShortcuts({
         if (onOpenChallengeSearch) {
           onOpenChallengeSearch();
         }
+        return;
+      }
+
+      // ── 5b. T  →  Open theme picker ─────────────────────────────────────────
+      if (lowerKey === "t" && !shiftKey && !metaKey && !ctrlKey && !altKey && onOpenThemePicker) {
+        event.preventDefault();
+        onOpenThemePicker();
         return;
       }
 
@@ -175,5 +191,6 @@ export default function useKeyboardShortcuts({
     onToggleTheme,
     onResetLayout,
     onCollapseAll,
+    onOpenThemePicker,
   ]);
 }

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -8,6 +8,7 @@
   background: var(--ifm-color-emphasis-100);
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 10px;
+  -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.03);
   overflow-x: auto;

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -5,6 +5,7 @@ import Head from "@docusaurus/Head";
 import KeyboardShortcutsModal from "../components/KeyboardShortcutsModal";
 import KeyboardShortcutsButton from "../components/KeyboardShortcutsButton";
 import ChallengeSearchModal from "../components/ChallengeSearchModal";
+import ThemePickerModal from "../components/ThemePickerModal";
 import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
 import PageProgressIndicator from "../components/PageProgressIndicator";
 import SidebarUpdater from '../components/ProgressTracker/SidebarUpdater';
@@ -37,10 +38,15 @@ export default function Root({ children }) {
   const onCloseSearch = useCallback(() => setShowChallengeSearch(false), []);
   const [showChallengeSearch, setShowChallengeSearch] = useState(false);
  
+  const onOpenThemePicker  = useCallback(() => setShowThemePicker(true), []);
+  const onCloseThemePicker = useCallback(() => setShowThemePicker(false), []);
+  const [showThemePicker, setShowThemePicker] = useState(false);
+ 
   useKeyboardShortcuts({
     onOpenHelp,
     onCloseHelp,
     onOpenChallengeSearch: onOpenSearch,
+    onOpenThemePicker,
   });
  
   return (
@@ -61,6 +67,10 @@ export default function Root({ children }) {
         <ChallengeSearchModal
           isOpen={showChallengeSearch}
           onClose={onCloseSearch}
+        />
+        <ThemePickerModal
+          isOpen={showThemePicker}
+          onClose={onCloseThemePicker}
         />
       </AuthProvider>
     </>


### PR DESCRIPTION
## 📥 Pull Request

### Description
The application already includes a centralized keyboard shortcuts system through KeyboardShortcutsModal and KeyboardShortcutsButton, but there is currently no quick way to access the theme picker using only the keyboard.

This PR adds a dedicated keyboard shortcut to open (or toggle) the existing theme picker, enabling users to switch accent and code themes without navigating through menus. The implementation reuses the current theme picker and keyboard shortcut infrastructure, ensuring a consistent, keyboard-friendly experience.


Fixes #3585 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
