### PR TITLE
Add Spaced Repetition Review Mode for Weak Topics

### DIFF
--- a/src/__tests__/pages/dashboard.test.tsx
+++ b/src/__tests__/pages/dashboard.test.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DashboardPage from "../../pages/dashboard";
+
+// Mock Docusaurus Layout and Link
+jest.mock("@theme/Layout", () => {
+  return function MockLayout({ children }: { children: React.ReactNode }) {
+    return <div data-testid="docusaurus-layout">{children}</div>;
+  };
+});
+
+jest.mock("@docusaurus/Link", () => {
+  return function MockLink({ to, children, className, onClick }: any) {
+    return (
+      <a href={to} className={className} onClick={onClick}>
+        {children}
+      </a>
+    );
+  };
+});
+
+jest.mock("@docusaurus/BrowserOnly", () => {
+  return function MockBrowserOnly({ children }: { children: () => React.ReactNode }) {
+    return <>{children()}</>;
+  };
+});
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("renders learning dashboard with overview metrics and spaced repetition review section", () => {
+    render(<DashboardPage />);
+
+    expect(screen.getByText(/DSA Learning Dashboard/i)).toBeInTheDocument();
+    expect(screen.getByText(/Weak Topics Analysis/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Spaced Repetition Review/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Start Spaced Review/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/pages/quizzes/review.test.tsx
+++ b/src/__tests__/pages/quizzes/review.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import SpacedRepetitionReviewPage from "../../../pages/quizzes/review";
+
+jest.mock("@theme/Layout", () => {
+  return function MockLayout({ children }: { children: React.ReactNode }) {
+    return <div data-testid="docusaurus-layout">{children}</div>;
+  };
+});
+
+jest.mock("@docusaurus/Link", () => {
+  return function MockLink({ to, children, className, onClick }: any) {
+    return (
+      <a href={to} className={className} onClick={onClick}>
+        {children}
+      </a>
+    );
+  };
+});
+
+jest.mock("@docusaurus/BrowserOnly", () => {
+  return function MockBrowserOnly({ children }: { children: () => React.ReactNode }) {
+    return <>{children()}</>;
+  };
+});
+
+describe("SpacedRepetitionReviewPage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("renders spaced repetition review quiz page header and questions", () => {
+    render(<SpacedRepetitionReviewPage />);
+
+    expect(screen.getByText(/Review Weak Topics/i)).toBeInTheDocument();
+    expect(screen.getByText(/Spaced Repetition/i)).toBeInTheDocument();
+    expect(screen.getByText(/Submit Answer/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/utils/spacedRepetition.test.ts
+++ b/src/__tests__/utils/spacedRepetition.test.ts
@@ -1,0 +1,165 @@
+import {
+  calculateNextReview,
+  getSpacedRepetitionQueue,
+  saveSpacedRepetitionQueue,
+  recordQuestionReview,
+  getDueItems,
+  getQuestionsForReviewSession,
+  STORAGE_PREFIX,
+} from "../../utils/spacedRepetition";
+import type { QuizStat } from "../../hooks/useQuizProgress";
+
+describe("spacedRepetition", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("calculateNextReview", () => {
+    test("calculates interval for first correct attempt", () => {
+      const now = new Date("2026-08-01T12:00:00Z");
+      const result = calculateNextReview({}, true, now);
+      expect(result.repetitions).toBe(1);
+      expect(result.intervalDays).toBe(1);
+      expect(result.easeFactor).toBe(2.5);
+      expect(result.nextReviewDate).toBe(new Date("2026-08-02T12:00:00Z").toISOString());
+    });
+
+    test("calculates interval for second correct attempt", () => {
+      const now = new Date("2026-08-01T12:00:00Z");
+      const result = calculateNextReview({ repetitions: 1, intervalDays: 1, easeFactor: 2.5 }, true, now);
+      expect(result.repetitions).toBe(2);
+      expect(result.intervalDays).toBe(3);
+      expect(result.nextReviewDate).toBe(new Date("2026-08-04T12:00:00Z").toISOString());
+    });
+
+    test("calculates interval for third correct attempt using ease factor", () => {
+      const now = new Date("2026-08-01T12:00:00Z");
+      const result = calculateNextReview({ repetitions: 2, intervalDays: 3, easeFactor: 2.5 }, true, now);
+      expect(result.repetitions).toBe(3);
+      expect(result.intervalDays).toBe(8); // Math.round(3 * 2.5) = 8
+    });
+
+    test("resets interval and reduces ease factor on incorrect attempt", () => {
+      const now = new Date("2026-08-01T12:00:00Z");
+      const result = calculateNextReview({ repetitions: 3, intervalDays: 8, easeFactor: 2.5 }, false, now);
+      expect(result.repetitions).toBe(0);
+      expect(result.intervalDays).toBe(1);
+      expect(result.easeFactor).toBe(2.3);
+    });
+
+    test("ease factor does not drop below minimum bound of 1.3", () => {
+      const now = new Date("2026-08-01T12:00:00Z");
+      const result = calculateNextReview({ repetitions: 0, intervalDays: 1, easeFactor: 1.3 }, false, now);
+      expect(result.easeFactor).toBe(1.3);
+    });
+  });
+
+  describe("queue storage and recording", () => {
+    test("reads and writes queue to localStorage", () => {
+      const mockQueue = {
+        arrays_1: {
+          uniqueId: "arrays_1",
+          topicId: "arrays",
+          questionId: 1,
+          nextReviewDate: new Date().toISOString(),
+          intervalDays: 1,
+          easeFactor: 2.5,
+          repetitions: 0,
+          missedCount: 1,
+        },
+      };
+      saveSpacedRepetitionQueue(mockQueue, "user123");
+      const loaded = getSpacedRepetitionQueue("user123");
+      expect(loaded).toEqual(mockQueue);
+    });
+
+    test("records question review and updates queue", () => {
+      const item = recordQuestionReview("arrays_1", "arrays", 1, true, "user123");
+      expect(item.uniqueId).toBe("arrays_1");
+      expect(item.repetitions).toBe(1);
+
+      const queue = getSpacedRepetitionQueue("user123");
+      expect(queue["arrays_1"]).toBeDefined();
+    });
+
+    test("filters due items correctly", () => {
+      const past = new Date("2026-01-01T00:00:00Z").toISOString();
+      const future = new Date("2026-12-31T00:00:00Z").toISOString();
+      const queue = {
+        arrays_1: {
+          uniqueId: "arrays_1",
+          topicId: "arrays",
+          questionId: 1,
+          nextReviewDate: past,
+          intervalDays: 1,
+          easeFactor: 2.5,
+          repetitions: 0,
+          missedCount: 1,
+        },
+        arrays_2: {
+          uniqueId: "arrays_2",
+          topicId: "arrays",
+          questionId: 2,
+          nextReviewDate: future,
+          intervalDays: 5,
+          easeFactor: 2.5,
+          repetitions: 2,
+          missedCount: 1,
+        },
+      };
+
+      const due = getDueItems(queue, new Date("2026-08-01T00:00:00Z"));
+      expect(due.length).toBe(1);
+      expect(due[0].uniqueId).toBe("arrays_1");
+    });
+  });
+
+  describe("getQuestionsForReviewSession", () => {
+    test("returns questions from due items when present", () => {
+      const past = new Date("2026-01-01T00:00:00Z").toISOString();
+      saveSpacedRepetitionQueue(
+        {
+          arrays_1: {
+            uniqueId: "arrays_1",
+            topicId: "arrays",
+            questionId: 1,
+            nextReviewDate: past,
+            intervalDays: 1,
+            easeFactor: 2.5,
+            repetitions: 0,
+            missedCount: 1,
+          },
+        },
+        "testUser"
+      );
+
+      const mockStats: Record<string, QuizStat> = {};
+      const session = getQuestionsForReviewSession(mockStats, "testUser");
+      expect(session.source).toBe("due");
+      expect(session.questions.length).toBeGreaterThan(0);
+      expect(session.questions[0].uniqueId).toBe("arrays_1");
+    });
+
+    test("falls back to weak topics questions when no items are due", () => {
+      const mockStats: Record<string, QuizStat> = {
+        arrays: {
+          quizId: "arrays",
+          attempts: [],
+          bestScore: 2,
+          bestPercent: 20,
+          latestScore: 2,
+          latestPercent: 20,
+          latestAttemptAt: new Date().toISOString(),
+          totalAttempts: 1,
+          totalQuestions: 10,
+          averagePercent: 20,
+          status: "in-progress",
+        },
+      };
+
+      const session = getQuestionsForReviewSession(mockStats, "testUser");
+      expect(session.questions.length).toBeGreaterThan(0);
+      expect(["due", "weak-topics", "all"]).toContain(session.source);
+    });
+  });
+});

--- a/src/components/WeakTopicsChart.tsx
+++ b/src/components/WeakTopicsChart.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import { motion } from "framer-motion";
 import Link from "@docusaurus/Link";
-import { FiArrowRight } from "react-icons/fi";
+import { FiArrowRight, FiRepeat } from "react-icons/fi";
 import type { WeakTopicEntry } from "../utils/weakTopics";
 
 interface WeakTopicsChartProps {
   entries: WeakTopicEntry[];
+  onStartReview?: () => void;
+  dueCount?: number;
 }
 
 function barColor(bestPercent: number, hasAttempts: boolean): string {
@@ -15,7 +17,7 @@ function barColor(bestPercent: number, hasAttempts: boolean): string {
   return "bg-blue-500";
 }
 
-export default function WeakTopicsChart({ entries }: WeakTopicsChartProps) {
+export default function WeakTopicsChart({ entries, onStartReview, dueCount }: WeakTopicsChartProps) {
   if (entries.length === 0) {
     return (
       <div className="text-center py-12 border border-dashed border-slate-200 dark:border-slate-800 rounded-2xl">
@@ -28,6 +30,32 @@ export default function WeakTopicsChart({ entries }: WeakTopicsChartProps) {
 
   return (
     <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between p-3.5 rounded-xl bg-indigo-50 dark:bg-indigo-950/40 border border-indigo-200 dark:border-indigo-800/40 gap-3">
+        <div className="flex items-center gap-2">
+          <FiRepeat className="text-indigo-600 dark:text-indigo-400 text-base" />
+          <div className="flex flex-col">
+            <span className="text-xs font-bold text-indigo-900 dark:text-indigo-200 flex items-center gap-2">
+              Spaced Repetition Review Mode
+              {dueCount !== undefined && dueCount > 0 && (
+                <span className="px-2 py-0.5 text-[10px] font-mono font-black rounded-full bg-amber-500 text-white">
+                  {dueCount} questions due
+                </span>
+              )}
+            </span>
+            <span className="text-[11px] text-indigo-700 dark:text-indigo-300">
+              Resurface missed questions on an adaptive schedule to boost long-term retention.
+            </span>
+          </div>
+        </div>
+        <Link
+          to="/quizzes/review"
+          onClick={onStartReview}
+          className="inline-flex items-center justify-center gap-1.5 text-xs font-bold px-3.5 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white no-underline transition-colors shadow-sm shrink-0"
+        >
+          Review weak topics
+          <FiArrowRight size={14} />
+        </Link>
+      </div>
       {entries.map((entry, index) => {
         const hasAttempts = entry.stat.totalAttempts > 0;
         const pct = hasAttempts ? entry.stat.bestPercent : 0;

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,0 +1,230 @@
+import React, { useMemo } from "react";
+import Layout from "@theme/Layout";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import Link from "@docusaurus/Link";
+import { motion } from "framer-motion";
+import {
+  FaChartBar,
+  FaCheckCircle,
+  FaAward,
+  FaExclamationTriangle,
+  FaBook,
+  FaChevronRight,
+  FaFire,
+  FaHistory,
+} from "react-icons/fa";
+import { FiRepeat, FiArrowRight } from "react-icons/fi";
+
+import WeakTopicsChart from "../components/WeakTopicsChart";
+import { useQuizProgress } from "../hooks/useQuizProgress";
+import { QUIZZES_CONFIG, QUESTION_COUNTS, QUIZ_IDS } from "../data/quizzesConfig";
+import { rankWeakTopics } from "../utils/weakTopics";
+import {
+  getSpacedRepetitionQueue,
+  getDueItems,
+  syncMissedQuestionsFromHistory,
+} from "../utils/spacedRepetition";
+
+function DashboardContent() {
+  const { stats, globalStats, userId, loaded } = useQuizProgress(QUIZ_IDS, QUESTION_COUNTS);
+
+  const weakEntries = useMemo(() => {
+    return rankWeakTopics(stats, QUIZZES_CONFIG);
+  }, [stats]);
+
+  const queue = useMemo(() => {
+    const synced = syncMissedQuestionsFromHistory(stats, userId);
+    return synced;
+  }, [stats, userId]);
+
+  const dueItems = useMemo(() => {
+    return getDueItems(queue);
+  }, [queue]);
+
+  if (!loaded) {
+    return (
+      <div className="max-w-6xl mx-auto px-4 py-16 text-center">
+        <div className="animate-spin text-blue-600 dark:text-blue-400 text-3xl mb-4 inline-block">
+          <FiRepeat />
+        </div>
+        <p className="text-slate-500 font-semibold">Loading your learning dashboard...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8 sm:py-12 space-y-8">
+      {/* Header Banner */}
+      <div className="p-8 rounded-3xl bg-gradient-to-br from-indigo-900 via-slate-900 to-blue-900 text-white shadow-xl relative overflow-hidden">
+        <div className="absolute top-0 right-0 w-96 h-96 bg-blue-500/10 rounded-full blur-3xl -mr-20 -mt-20 pointer-events-none" />
+        <div className="relative z-10 flex flex-col md:flex-row md:items-center justify-between gap-6">
+          <div className="space-y-2">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-indigo-500/20 border border-indigo-400/30 text-indigo-200 text-xs font-bold">
+              <FaChartBar size={12} />
+              DSA Learning Dashboard
+            </div>
+            <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-white m-0">
+              Welcome Back, Learner
+            </h1>
+            <p className="text-indigo-200 text-sm max-w-xl m-0">
+              Track your performance, resurface weak concepts with spaced repetition, and master algorithms.
+            </p>
+          </div>
+
+          <Link
+            to="/quizzes/review"
+            className="inline-flex items-center justify-center gap-2 px-6 py-3.5 rounded-2xl bg-indigo-500 hover:bg-indigo-600 text-white font-bold no-underline transition-all transform hover:-translate-y-0.5 shadow-lg shrink-0"
+          >
+            <FiRepeat className="text-lg" />
+            Start Spaced Review ({dueItems.length} Due)
+          </Link>
+        </div>
+      </div>
+
+      {/* Global Stat Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="p-5 rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm flex flex-col justify-between">
+          <div className="flex items-center justify-between text-slate-400 mb-2">
+            <span className="text-xs font-bold uppercase tracking-wider">Attempted</span>
+            <FaBook className="text-blue-500" />
+          </div>
+          <div className="text-3xl font-black font-mono text-slate-900 dark:text-slate-100">
+            {globalStats.totalCompleted} <span className="text-sm font-semibold text-slate-400">/ {globalStats.totalQuizzes}</span>
+          </div>
+          <div className="text-[11px] text-slate-500 mt-1">Quizzes tried at least once</div>
+        </div>
+
+        <div className="p-5 rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm flex flex-col justify-between">
+          <div className="flex items-center justify-between text-slate-400 mb-2">
+            <span className="text-xs font-bold uppercase tracking-wider">Mastered</span>
+            <FaAward className="text-amber-500" />
+          </div>
+          <div className="text-3xl font-black font-mono text-amber-500">
+            {globalStats.totalMastered}
+          </div>
+          <div className="text-[11px] text-slate-500 mt-1">Quizzes with ≥ 90% score</div>
+        </div>
+
+        <div className="p-5 rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm flex flex-col justify-between">
+          <div className="flex items-center justify-between text-slate-400 mb-2">
+            <span className="text-xs font-bold uppercase tracking-wider">Average Score</span>
+            <FaChartBar className="text-emerald-500" />
+          </div>
+          <div className="text-3xl font-black font-mono text-emerald-500">
+            {globalStats.overallAvgPercent}%
+          </div>
+          <div className="text-[11px] text-slate-500 mt-1">Across all attempted topics</div>
+        </div>
+
+        <div className="p-5 rounded-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm flex flex-col justify-between">
+          <div className="flex items-center justify-between text-slate-400 mb-2">
+            <span className="text-xs font-bold uppercase tracking-wider">Review Queue</span>
+            <FiRepeat className="text-indigo-500" />
+          </div>
+          <div className="text-3xl font-black font-mono text-indigo-600 dark:text-indigo-400">
+            {dueItems.length}
+          </div>
+          <div className="text-[11px] text-slate-500 mt-1">Questions due for spaced review</div>
+        </div>
+      </div>
+
+      {/* Main Grid: Spaced Repetition + Weak Topics */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        {/* Left Column: Weak Topics Chart */}
+        <div className="lg:col-span-2 space-y-6">
+          <div className="p-6 sm:p-8 rounded-3xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm space-y-6">
+            <div className="flex items-center justify-between border-b border-slate-100 dark:border-slate-800 pb-4">
+              <div>
+                <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 m-0 flex items-center gap-2">
+                  <FaExclamationTriangle className="text-amber-500 text-sm" />
+                  Weak Topics Analysis
+                </h2>
+                <p className="text-xs text-slate-500 m-0 mt-0.5">
+                  Topics needing practice based on low scores and error history.
+                </p>
+              </div>
+              <Link
+                to="/quizzes"
+                className="text-xs font-bold text-blue-600 dark:text-blue-400 hover:underline no-underline"
+              >
+                All Quizzes →
+              </Link>
+            </div>
+
+            <WeakTopicsChart entries={weakEntries} dueCount={dueItems.length} />
+          </div>
+        </div>
+
+        {/* Right Column: Spaced Repetition Widget & Quick Actions */}
+        <div className="space-y-6">
+          <div className="p-6 rounded-3xl bg-indigo-50/60 dark:bg-indigo-950/30 border border-indigo-200 dark:border-indigo-800/40 shadow-sm space-y-4">
+            <div className="flex items-center gap-2">
+              <div className="p-2 rounded-xl bg-indigo-600 text-white">
+                <FiRepeat size={18} />
+              </div>
+              <div>
+                <h3 className="text-sm font-bold text-indigo-950 dark:text-indigo-100 m-0">
+                  Spaced Repetition Review
+                </h3>
+                <p className="text-xs text-indigo-700 dark:text-indigo-300 m-0">
+                  Scientific memory scheduling
+                </p>
+              </div>
+            </div>
+
+            <p className="text-xs text-slate-600 dark:text-slate-300 leading-relaxed m-0">
+              Resurface missed questions at expanding intervals (1d, 3d, 7d, 14d) to convert short-term errors into long-term recall.
+            </p>
+
+            <div className="p-3.5 rounded-2xl bg-white dark:bg-slate-900 border border-indigo-100 dark:border-indigo-900/50 flex items-center justify-between text-xs font-bold">
+              <span className="text-slate-600 dark:text-slate-400">Questions Due Now:</span>
+              <span className="font-mono text-sm font-black text-indigo-600 dark:text-indigo-400">
+                {dueItems.length}
+              </span>
+            </div>
+
+            <Link
+              to="/quizzes/review"
+              className="w-full inline-flex items-center justify-center gap-2 py-3 px-4 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold no-underline transition-colors shadow-sm"
+            >
+              Start Review Session
+              <FiArrowRight size={14} />
+            </Link>
+          </div>
+
+          <div className="p-6 rounded-3xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-sm space-y-4">
+            <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 flex items-center gap-2">
+              <FaHistory className="text-blue-500" />
+              Quick Practice Shortcuts
+            </h3>
+            <div className="space-y-2">
+              {QUIZZES_CONFIG.slice(0, 4).map((quiz) => (
+                <Link
+                  key={quiz.id}
+                  to={quiz.path}
+                  className="flex items-center justify-between p-3 rounded-xl bg-slate-50 dark:bg-slate-800/40 hover:bg-slate-100 dark:hover:bg-slate-800 border border-slate-100 dark:border-slate-800 text-xs font-bold text-slate-700 dark:text-slate-200 no-underline transition-colors"
+                >
+                  <span>{quiz.title.replace("Quiz on ", "")}</span>
+                  <FaChevronRight className="text-slate-400" size={10} />
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <Layout
+      title="Learning Dashboard — Weak Topics & Spaced Repetition | Algo"
+      description="Track your DSA quiz progress, identify weak topics, and master algorithms with scheduled spaced repetition."
+    >
+      <BrowserOnly fallback={<div className="p-8 text-center">Loading dashboard...</div>}>
+        {() => <DashboardContent />}
+      </BrowserOnly>
+    </Layout>
+  );
+}

--- a/src/pages/quizzes/review.tsx
+++ b/src/pages/quizzes/review.tsx
@@ -1,0 +1,424 @@
+import React, { useState, useEffect, useMemo } from "react";
+import Layout from "@theme/Layout";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import Link from "@docusaurus/Link";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+  FaClock,
+  FaCheckCircle,
+  FaTimesCircle,
+  FaRedoAlt,
+  FaChevronRight,
+  FaAward,
+  FaBookOpen,
+  FaArrowLeft,
+  FaLightbulb,
+} from "react-icons/fa";
+import { FiRepeat } from "react-icons/fi";
+import { useQuizProgress } from "../../hooks/useQuizProgress";
+import { QUIZZES_CONFIG, QUESTION_COUNTS, QUIZ_IDS } from "../../data/quizzesConfig";
+import {
+  getQuestionsForReviewSession,
+  recordQuestionReview,
+  getDueItems,
+  getSpacedRepetitionQueue,
+  type SpacedRepetitionItem,
+} from "../../utils/spacedRepetition";
+import type { MockExamQuestion } from "../../utils/mockExamData";
+
+function SpacedRepetitionReviewContent() {
+  const { stats, userId, loaded } = useQuizProgress(QUIZ_IDS, QUESTION_COUNTS);
+  const [questions, setQuestions] = useState<MockExamQuestion[]>([]);
+  const [sourceType, setSourceType] = useState<"due" | "weak-topics" | "all">("due");
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [lastReviewItem, setLastReviewItem] = useState<SpacedRepetitionItem | null>(null);
+  const [results, setResults] = useState<{ question: MockExamQuestion; isCorrect: boolean; selected: string }[]>([]);
+  const [isFinished, setIsFinished] = useState(false);
+
+  useEffect(() => {
+    if (loaded) {
+      const session = getQuestionsForReviewSession(stats, userId, 10);
+      setQuestions(session.questions);
+      setSourceType(session.source);
+    }
+  }, [loaded, stats, userId]);
+
+  const currentQuestion = questions[currentIndex];
+  const queue = useMemo(() => getSpacedRepetitionQueue(userId), [userId, results]);
+  const dueCount = useMemo(() => getDueItems(queue).length, [queue]);
+
+  const handleSelectOption = (option: string) => {
+    if (isSubmitted) return;
+    setSelectedOption(option);
+  };
+
+  const handleSubmitAnswer = () => {
+    if (!currentQuestion || !selectedOption || isSubmitted) return;
+    const isCorrect = selectedOption === currentQuestion.answer;
+
+    const updatedItem = recordQuestionReview(
+      currentQuestion.uniqueId,
+      currentQuestion.topicId,
+      currentQuestion.id,
+      isCorrect,
+      userId
+    );
+
+    setLastReviewItem(updatedItem);
+    setIsSubmitted(true);
+    setResults((prev) => [...prev, { question: currentQuestion, isCorrect, selected: selectedOption }]);
+  };
+
+  const handleNextQuestion = () => {
+    if (currentIndex < questions.length - 1) {
+      setCurrentIndex((prev) => prev + 1);
+      setSelectedOption(null);
+      setIsSubmitted(false);
+      setLastReviewItem(null);
+    } else {
+      setIsFinished(true);
+    }
+  };
+
+  const handleRestartSession = () => {
+    const session = getQuestionsForReviewSession(stats, userId, 10);
+    setQuestions(session.questions);
+    setSourceType(session.source);
+    setCurrentIndex(0);
+    setSelectedOption(null);
+    setIsSubmitted(false);
+    setLastReviewItem(null);
+    setResults([]);
+    setIsFinished(false);
+  };
+
+  if (!loaded) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-16 text-center">
+        <div className="animate-spin text-indigo-600 dark:text-indigo-400 text-3xl mb-4 inline-block">
+          <FiRepeat />
+        </div>
+        <p className="text-slate-500 font-semibold">Loading your Spaced Repetition queue...</p>
+      </div>
+    );
+  }
+
+  if (questions.length === 0) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-16 text-center space-y-6">
+        <div className="w-16 h-16 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 rounded-full flex items-center justify-center mx-auto text-2xl">
+          <FaCheckCircle />
+        </div>
+        <h2 className="text-2xl font-bold text-slate-800 dark:text-slate-100">All Caught Up!</h2>
+        <p className="text-slate-600 dark:text-slate-400 max-w-md mx-auto">
+          No questions are currently due for review, and no weak topics were identified. Take a new quiz to start tracking your knowledge retention!
+        </p>
+        <Link
+          to="/quizzes"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold no-underline transition-colors shadow-md"
+        >
+          Explore All Quizzes
+          <FaChevronRight size={14} />
+        </Link>
+      </div>
+    );
+  }
+
+  if (isFinished) {
+    const correctCount = results.filter((r) => r.isCorrect).length;
+    const accuracy = Math.round((correctCount / results.length) * 100);
+
+    return (
+      <div className="max-w-3xl mx-auto px-4 py-12 space-y-8">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="p-8 rounded-3xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 text-center shadow-xl space-y-6"
+        >
+          <div className="w-20 h-20 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 rounded-full flex items-center justify-center mx-auto text-3xl shadow-inner">
+            <FaAward />
+          </div>
+
+          <div>
+            <h1 className="text-3xl font-black text-slate-900 dark:text-slate-100 m-0">
+              Review Session Complete!
+            </h1>
+            <p className="text-sm font-semibold text-slate-500 dark:text-slate-400 mt-2">
+              Spaced repetition queue updated based on your performance.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-4 max-w-md mx-auto">
+            <div className="p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/50 text-center">
+              <div className="text-2xl font-black font-mono text-indigo-600 dark:text-indigo-400">
+                {results.length}
+              </div>
+              <div className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mt-1">
+                Questions
+              </div>
+            </div>
+            <div className="p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/50 text-center">
+              <div className="text-2xl font-black font-mono text-emerald-500">
+                {correctCount}
+              </div>
+              <div className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mt-1">
+                Correct
+              </div>
+            </div>
+            <div className="p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/50 text-center">
+              <div className="text-2xl font-black font-mono text-blue-500">
+                {accuracy}%
+              </div>
+              <div className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mt-1">
+                Accuracy
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 pt-4">
+            <button
+              onClick={handleRestartSession}
+              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold border-0 cursor-pointer shadow-md transition-colors"
+            >
+              <FaRedoAlt size={14} />
+              Review Another Batch
+            </button>
+            <Link
+              to="/dashboard"
+              className="w-full sm:w-auto inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 font-bold no-underline transition-colors hover:bg-slate-200 dark:hover:bg-slate-700"
+            >
+              <FaArrowLeft size={14} />
+              Back to Dashboard
+            </Link>
+          </div>
+        </motion.div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+      {/* Header bar */}
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 pb-4 border-b border-slate-200 dark:border-slate-800">
+        <div className="flex items-center gap-3">
+          <Link
+            to="/dashboard"
+            className="p-2 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-700 no-underline transition-colors"
+            title="Return to dashboard"
+          >
+            <FaArrowLeft size={14} />
+          </Link>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="text-xs font-bold px-2.5 py-0.5 rounded-full bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-800/40">
+                Spaced Repetition
+              </span>
+              <span className="text-xs font-semibold text-slate-400">
+                {sourceType === "due"
+                  ? "Scheduled Reviews"
+                  : sourceType === "weak-topics"
+                  ? "Weak Topics Focus"
+                  : "Mixed Practice"}
+              </span>
+            </div>
+            <h1 className="text-xl font-black text-slate-900 dark:text-slate-100 m-0 mt-1">
+              Review Weak Topics
+            </h1>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <div className="text-right">
+            <div className="text-xs font-mono font-bold text-indigo-600 dark:text-indigo-400">
+              Question {currentIndex + 1} of {questions.length}
+            </div>
+            <div className="text-[11px] font-semibold text-slate-400">
+              {dueCount > 0 ? `${dueCount} total items due` : "All due items reviewed"}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full h-2 bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-indigo-600 transition-all duration-300"
+          style={{ width: `${((currentIndex + 1) / questions.length) * 100}%` }}
+        />
+      </div>
+
+      {/* Question Card */}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={currentQuestion.uniqueId}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2 }}
+          className="p-6 sm:p-8 rounded-3xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 shadow-lg space-y-6"
+        >
+          {/* Topic & Difficulty */}
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+              {currentQuestion.topicTitle}
+            </span>
+            {currentQuestion.difficulty && (
+              <span
+                className={`text-[10px] font-bold px-2.5 py-0.5 rounded-md ${
+                  currentQuestion.difficulty === "Easy"
+                    ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300"
+                    : currentQuestion.difficulty === "Medium"
+                    ? "bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+                    : "bg-rose-100 text-rose-700 dark:bg-rose-950 dark:text-rose-300"
+                }`}
+              >
+                {currentQuestion.difficulty}
+              </span>
+            )}
+          </div>
+
+          {/* Question text */}
+          <h2 className="text-lg sm:text-xl font-bold text-slate-800 dark:text-slate-100 leading-snug m-0">
+            {currentQuestion.question}
+          </h2>
+
+          {/* Code snippet if any */}
+          {currentQuestion.codeSnippet && (
+            <div className="p-4 rounded-xl bg-slate-900 text-slate-100 font-mono text-xs overflow-x-auto border border-slate-800">
+              <pre className="m-0 whitespace-pre-wrap">{currentQuestion.codeSnippet}</pre>
+            </div>
+          )}
+
+          {/* Options */}
+          <div className="space-y-3 pt-2">
+            {currentQuestion.options.map((opt, idx) => {
+              const isSelected = selectedOption === opt;
+              const isCorrectAnswer = opt === currentQuestion.answer;
+
+              let styleClasses =
+                "p-4 rounded-2xl border text-sm font-semibold transition-all duration-200 flex items-center justify-between cursor-pointer ";
+
+              if (!isSubmitted) {
+                styleClasses += isSelected
+                  ? "border-indigo-500 bg-indigo-50 dark:bg-indigo-950/40 text-indigo-900 dark:text-indigo-200 shadow-sm"
+                  : "border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-800/40 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800";
+              } else {
+                if (isCorrectAnswer) {
+                  styleClasses +=
+                    "border-emerald-500 bg-emerald-50 dark:bg-emerald-950/40 text-emerald-900 dark:text-emerald-200 font-bold";
+                } else if (isSelected && !isCorrectAnswer) {
+                  styleClasses +=
+                    "border-rose-500 bg-rose-50 dark:bg-rose-950/40 text-rose-900 dark:text-rose-200";
+                } else {
+                  styleClasses +=
+                    "border-slate-200 dark:border-slate-800 opacity-50 text-slate-500 dark:text-slate-400";
+                }
+              }
+
+              return (
+                <div
+                  key={idx}
+                  onClick={() => handleSelectOption(opt)}
+                  className={styleClasses}
+                >
+                  <span className="flex-1">{opt}</span>
+                  {isSubmitted && (
+                    <span className="shrink-0 ml-2">
+                      {isCorrectAnswer ? (
+                        <FaCheckCircle className="text-emerald-500 text-lg" />
+                      ) : isSelected ? (
+                        <FaTimesCircle className="text-rose-500 text-lg" />
+                      ) : null}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Feedback & Spaced Interval Banner */}
+          {isSubmitted && lastReviewItem && (
+            <motion.div
+              initial={{ opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: "auto" }}
+              className="space-y-4 pt-4 border-t border-slate-200 dark:border-slate-800"
+            >
+              <div
+                className={`p-4 rounded-2xl border flex items-start gap-3 ${
+                  selectedOption === currentQuestion.answer
+                    ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800/40 text-emerald-900 dark:text-emerald-200"
+                    : "bg-rose-50 dark:bg-rose-950/30 border-rose-200 dark:border-rose-800/40 text-rose-900 dark:text-rose-200"
+                }`}
+              >
+                <div className="mt-0.5">
+                  {selectedOption === currentQuestion.answer ? (
+                    <FaCheckCircle className="text-emerald-500 text-lg" />
+                  ) : (
+                    <FaTimesCircle className="text-rose-500 text-lg" />
+                  )}
+                </div>
+                <div className="space-y-1">
+                  <div className="font-bold text-sm">
+                    {selectedOption === currentQuestion.answer
+                      ? "Spot on! Mastery reinforced."
+                      : "Incorrect attempt."}
+                  </div>
+                  <div className="text-xs leading-relaxed opacity-90">
+                    {currentQuestion.explanation}
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between p-3 rounded-xl bg-slate-100 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/50 text-xs font-semibold">
+                <span className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                  <FaClock className="text-indigo-500" />
+                  Spaced Repetition Schedule:
+                </span>
+                <span className="font-mono font-bold text-indigo-600 dark:text-indigo-400">
+                  Next review in {lastReviewItem.intervalDays}{" "}
+                  {lastReviewItem.intervalDays === 1 ? "day" : "days"}
+                </span>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex items-center justify-end gap-3 pt-4">
+            {!isSubmitted ? (
+              <button
+                onClick={handleSubmitAnswer}
+                disabled={!selectedOption}
+                className="px-6 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 text-white font-bold border-0 cursor-pointer shadow-md transition-colors"
+              >
+                Submit Answer
+              </button>
+            ) : (
+              <button
+                onClick={handleNextQuestion}
+                className="inline-flex items-center gap-2 px-6 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-bold border-0 cursor-pointer shadow-md transition-colors"
+              >
+                {currentIndex < questions.length - 1 ? "Next Question" : "Finish Review"}
+                <FaChevronRight size={14} />
+              </button>
+            )}
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  );
+}
+
+export default function SpacedRepetitionReviewPage() {
+  return (
+    <Layout
+      title="Review Weak Topics — Spaced Repetition | Algo"
+      description="Adaptive spaced repetition review mode to master weak topics and resurface missed quiz questions on a scientific memory schedule."
+    >
+      <BrowserOnly fallback={<div className="p-8 text-center">Loading review session...</div>}>
+        {() => <SpacedRepetitionReviewContent />}
+      </BrowserOnly>
+    </Layout>
+  );
+}

--- a/src/utils/spacedRepetition.ts
+++ b/src/utils/spacedRepetition.ts
@@ -1,0 +1,237 @@
+import { safeJsonParse } from "./safeStorage";
+import { getAllMockExamQuestions, type MockExamQuestion } from "./mockExamData";
+import { rankWeakTopics } from "./weakTopics";
+import type { QuizStat } from "../hooks/useQuizProgress";
+import { QUIZZES_CONFIG } from "../data/quizzesConfig";
+
+export interface SpacedRepetitionItem {
+  uniqueId: string; // e.g. "arrays_1"
+  topicId: string;  // e.g. "arrays"
+  questionId: number;
+  nextReviewDate: string; // ISO date string
+  intervalDays: number;
+  easeFactor: number;
+  repetitions: number;
+  lastReviewedAt?: string;
+  missedCount: number;
+}
+
+export const STORAGE_PREFIX = "quiz_spaced_repetition";
+
+export function getSpacedRepetitionStorageKey(userId?: string | null): string {
+  if (userId) {
+    return `${STORAGE_PREFIX}_${userId}`;
+  }
+  return `${STORAGE_PREFIX}_default`;
+}
+
+/**
+ * Reads the spaced repetition queue for a given user from localStorage.
+ */
+export function getSpacedRepetitionQueue(userId?: string | null): Record<string, SpacedRepetitionItem> {
+  if (typeof window === "undefined") return {};
+  const key = getSpacedRepetitionStorageKey(userId);
+  return safeJsonParse<Record<string, SpacedRepetitionItem>>(key, {});
+}
+
+/**
+ * Saves the spaced repetition queue to localStorage.
+ */
+export function saveSpacedRepetitionQueue(
+  queue: Record<string, SpacedRepetitionItem>,
+  userId?: string | null
+): void {
+  if (typeof window === "undefined") return;
+  const key = getSpacedRepetitionStorageKey(userId);
+  try {
+    localStorage.setItem(key, JSON.stringify(queue));
+  } catch (err) {
+    console.warn("[SpacedRepetition] Failed to save queue to localStorage:", err);
+  }
+}
+
+/**
+ * Calculates the next review date and interval based on SM-2 algorithm derivative.
+ */
+export function calculateNextReview(
+  item: Partial<SpacedRepetitionItem>,
+  wasCorrect: boolean,
+  now: Date = new Date()
+): { intervalDays: number; easeFactor: number; repetitions: number; nextReviewDate: string } {
+  let easeFactor = item.easeFactor ?? 2.5;
+  let repetitions = item.repetitions ?? 0;
+  let intervalDays = item.intervalDays ?? 1;
+
+  if (wasCorrect) {
+    repetitions += 1;
+    if (repetitions === 1) {
+      intervalDays = 1;
+    } else if (repetitions === 2) {
+      intervalDays = 3;
+    } else {
+      intervalDays = Math.round(intervalDays * easeFactor);
+    }
+  } else {
+    repetitions = 0;
+    intervalDays = 1;
+    easeFactor = Math.max(1.3, easeFactor - 0.2);
+  }
+
+  const nextReviewMs = now.getTime() + intervalDays * 24 * 60 * 60 * 1000;
+  const nextReviewDate = new Date(nextReviewMs).toISOString();
+
+  return {
+    intervalDays,
+    easeFactor,
+    repetitions,
+    nextReviewDate,
+  };
+}
+
+/**
+ * Records a question review result, updating or creating the item in the queue.
+ */
+export function recordQuestionReview(
+  uniqueId: string,
+  topicId: string,
+  questionId: number,
+  wasCorrect: boolean,
+  userId?: string | null
+): SpacedRepetitionItem {
+  const queue = getSpacedRepetitionQueue(userId);
+  const existing = queue[uniqueId] || {
+    uniqueId,
+    topicId,
+    questionId,
+    nextReviewDate: new Date().toISOString(),
+    intervalDays: 1,
+    easeFactor: 2.5,
+    repetitions: 0,
+    missedCount: 0,
+  };
+
+  const now = new Date();
+  const next = calculateNextReview(existing, wasCorrect, now);
+
+  const updated: SpacedRepetitionItem = {
+    ...existing,
+    ...next,
+    lastReviewedAt: now.toISOString(),
+    missedCount: wasCorrect ? existing.missedCount : existing.missedCount + 1,
+  };
+
+  queue[uniqueId] = updated;
+  saveSpacedRepetitionQueue(queue, userId);
+  return updated;
+}
+
+/**
+ * Scans quiz attempts stored in localStorage for missed questions and adds them to the review queue.
+ */
+export function syncMissedQuestionsFromHistory(
+  stats: Record<string, QuizStat>,
+  userId?: string | null
+): Record<string, SpacedRepetitionItem> {
+  const queue = getSpacedRepetitionQueue(userId);
+  let updated = false;
+
+  Object.values(stats).forEach((stat) => {
+    stat.attempts.forEach((attempt) => {
+      const missed = (attempt as any).missedQuestionIds || [];
+      missed.forEach((qId: number) => {
+        const uniqueId = `${stat.quizId}_${qId}`;
+        if (!queue[uniqueId]) {
+          queue[uniqueId] = {
+            uniqueId,
+            topicId: stat.quizId,
+            questionId: qId,
+            nextReviewDate: new Date().toISOString(),
+            intervalDays: 1,
+            easeFactor: 2.5,
+            repetitions: 0,
+            missedCount: 1,
+          };
+          updated = true;
+        }
+      });
+    });
+  });
+
+  if (updated) {
+    saveSpacedRepetitionQueue(queue, userId);
+  }
+
+  return queue;
+}
+
+/**
+ * Filters queue items that are due for review as of `now`.
+ */
+export function getDueItems(
+  queue: Record<string, SpacedRepetitionItem>,
+  now: Date = new Date()
+): SpacedRepetitionItem[] {
+  const nowMs = now.getTime();
+  return Object.values(queue)
+    .filter((item) => new Date(item.nextReviewDate).getTime() <= nowMs)
+    .sort((a, b) => new Date(a.nextReviewDate).getTime() - new Date(b.nextReviewDate).getTime());
+}
+
+/**
+ * Prepares a set of questions for a review session.
+ * 1. Checks due items in queue.
+ * 2. If due items exist, maps them to MockExamQuestion objects.
+ * 3. If no items are due (or queue is empty), falls back to selecting questions from weak topics.
+ */
+export function getQuestionsForReviewSession(
+  stats: Record<string, QuizStat>,
+  userId?: string | null,
+  limit: number = 10
+): { questions: MockExamQuestion[]; source: "due" | "weak-topics" | "all" } {
+  const queue = syncMissedQuestionsFromHistory(stats, userId);
+  const dueItems = getDueItems(queue);
+  const allQuestions = getAllMockExamQuestions();
+  const questionMap = new Map<string, MockExamQuestion>();
+  allQuestions.forEach((q) => questionMap.set(q.uniqueId, q));
+
+  if (dueItems.length > 0) {
+    const questions: MockExamQuestion[] = [];
+    dueItems.forEach((item) => {
+      const q = questionMap.get(item.uniqueId);
+      if (q) questions.push(q);
+    });
+    if (questions.length > 0) {
+      return {
+        questions: questions.slice(0, limit),
+        source: "due",
+      };
+    }
+  }
+
+  // Fallback: Pick questions from weak topics (lowest scores or unattempted)
+  const weakTopicEntries = rankWeakTopics(stats, QUIZZES_CONFIG);
+  const weakTopicIds = weakTopicEntries.map((e) => e.quiz.id);
+
+  const fallbackQuestions: MockExamQuestion[] = [];
+  allQuestions.forEach((q) => {
+    if (weakTopicIds.includes(q.topicId)) {
+      fallbackQuestions.push(q);
+    }
+  });
+
+  if (fallbackQuestions.length > 0) {
+    // Shuffle slightly so review session varies
+    const shuffled = [...fallbackQuestions].sort(() => Math.random() - 0.5);
+    return {
+      questions: shuffled.slice(0, limit),
+      source: "weak-topics",
+    };
+  }
+
+  // If no weak topics recorded, return random sample of all questions
+  const shuffledAll = [...allQuestions].sort(() => Math.random() - 0.5);
+  return {
+    questions: shuffledAll.slice(0, limit),
+    source: "all",
+  };
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description

The dashboard already includes a Weak Topics view powered by WeakTopicsChart, helping users identify areas where they struggle. However, it stops at analytics and doesn't provide a structured way to revisit those concepts.

This PR introduces a "Review Weak Topics" mode that applies a lightweight spaced repetition strategy to automatically resurface previously missed or low-scoring quiz questions on a review schedule. Rather than manually searching for questions, users receive focused review sessions based on their quiz history, encouraging long-term retention and more effective interview preparation.

Fixes #3586 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
