### PR TITLE
refactor(storage): fix inconsistent localStorage usage in WeeklyChallengeSpotlight (#3495)

### DIFF
--- a/src/__tests__/components/WeeklyChallengeSpotlight.test.tsx
+++ b/src/__tests__/components/WeeklyChallengeSpotlight.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WeeklyChallengeSpotlight from '../../components/WeeklyChallengeSpotlight';
+import * as safeStorage from '../../utils/safeStorage';
+
+jest.mock('@docusaurus/Link', () => {
+  return ({ children, to, ...rest }: any) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  );
+});
+
+describe('WeeklyChallengeSpotlight Component', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('renders weekly challenge spotlight details', () => {
+    render(<WeeklyChallengeSpotlight />);
+
+    expect(screen.getByText(/Challenge of the Week/i)).toBeInTheDocument();
+    expect(screen.getByText(/Solve Now/i)).toBeInTheDocument();
+    expect(screen.getByText(/Mark Solved/i)).toBeInTheDocument();
+  });
+
+  it('reads solved state using safeGetItem on mount', () => {
+    const safeGetSpy = jest.spyOn(safeStorage, 'safeGetItem');
+    render(<WeeklyChallengeSpotlight />);
+
+    expect(safeGetSpy).toHaveBeenCalledWith(expect.stringMatching(/^weekly_challenge_solved_/));
+  });
+
+  it('uses safeSetItem when marking challenge as solved', () => {
+    const safeSetSpy = jest.spyOn(safeStorage, 'safeSetItem');
+    render(<WeeklyChallengeSpotlight />);
+
+    const markBtn = screen.getByText(/Mark Solved/i);
+    fireEvent.click(markBtn);
+
+    expect(safeSetSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^weekly_challenge_solved_/),
+      'solved'
+    );
+    expect(screen.getByText(/Solved ✅/i)).toBeInTheDocument();
+  });
+
+  it('uses safeRemoveItem when unmarking solved challenge', () => {
+    const safeRemoveSpy = jest.spyOn(safeStorage, 'safeRemoveItem');
+    render(<WeeklyChallengeSpotlight />);
+
+    const markBtn = screen.getByText(/Mark Solved/i);
+    // Mark as solved
+    fireEvent.click(markBtn);
+    expect(screen.getByText(/Solved ✅/i)).toBeInTheDocument();
+
+    // Unmark
+    fireEvent.click(screen.getByText(/Solved ✅/i));
+    expect(safeRemoveSpy).toHaveBeenCalledWith(
+      expect.stringMatching(/^weekly_challenge_solved_/)
+    );
+    expect(screen.getByText(/Mark Solved/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/utils/safeStorage.test.ts
+++ b/src/__tests__/utils/safeStorage.test.ts
@@ -9,6 +9,9 @@ import {
   getUserId,
   extractQuizIdFromStorageKey,
   getAchievementSnapshot,
+  safeGetItem,
+  safeSetItem,
+  safeRemoveItem,
 } from '../../utils/safeStorage';
 
 describe('safeStorage', () => {
@@ -73,6 +76,77 @@ describe('safeStorage', () => {
       expect(consoleWarnSpy).toHaveBeenCalled();
       expect(localStorage.getItem('corrupt_key')).toBeNull();
 
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('safeGetItem, safeSetItem, safeRemoveItem', () => {
+    test('safeSetItem stores value and safeGetItem retrieves it', () => {
+      safeSetItem('test_raw_key', 'test_value');
+      expect(safeGetItem('test_raw_key')).toBe('test_value');
+    });
+
+    test('safeGetItem returns fallback when key does not exist', () => {
+      expect(safeGetItem('missing_key', 'default')).toBe('default');
+      expect(safeGetItem('missing_key')).toBeNull();
+    });
+
+    test('safeRemoveItem removes value from localStorage', () => {
+      safeSetItem('to_remove', 'value');
+      expect(safeGetItem('to_remove')).toBe('value');
+      safeRemoveItem('to_remove');
+      expect(safeGetItem('to_remove')).toBeNull();
+    });
+
+    test('safeGetItem logs warning and returns fallback when localStorage throws', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const getItemSpy = jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('Storage access error');
+      });
+
+      const result = safeGetItem('error_key', 'fallback_val');
+
+      expect(result).toBe('fallback_val');
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Algo] Error reading localStorage key "error_key":',
+        expect.any(Error)
+      );
+
+      getItemSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
+    test('safeSetItem logs error when localStorage throws (e.g. QuotaExceededError)', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+
+      safeSetItem('quota_key', 'large_value');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        '[Algo] Error setting localStorage key "quota_key":',
+        expect.any(Error)
+      );
+
+      setItemSpy.mockRestore();
+      consoleErrorSpy.mockRestore();
+    });
+
+    test('safeRemoveItem logs warning when localStorage throws', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const removeItemSpy = jest.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+        throw new Error('Remove error');
+      });
+
+      safeRemoveItem('remove_err_key');
+
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Algo] Error removing localStorage key "remove_err_key":',
+        expect.any(Error)
+      );
+
+      removeItemSpy.mockRestore();
       consoleWarnSpy.mockRestore();
     });
   });

--- a/src/components/WeeklyChallengeSpotlight.tsx
+++ b/src/components/WeeklyChallengeSpotlight.tsx
@@ -18,6 +18,7 @@ import {
   FaChevronRight, FaCalendarWeek, FaBolt,
 } from "react-icons/fa";
 import challengeData from "../data/challengeData";
+import { safeGetItem, safeSetItem, safeRemoveItem } from "../utils/safeStorage";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -149,10 +150,9 @@ const WeeklyChallengeSpotlight: React.FC = () => {
     setChallenge(weekly);
     setWeekLabel(`Week ${getISOWeek(now)} · ${now.getUTCFullYear()}`);
 
-    try {
-      const saved = localStorage.getItem(storageKey);
-      setIsSolved(saved === "solved");
-    } catch { /* ignore */ }
+    const saved = safeGetItem(storageKey);
+    setIsSolved(saved === "solved");
+
 
     // Kick off the countdown ticker
     const tick = () => {
@@ -169,15 +169,13 @@ const WeeklyChallengeSpotlight: React.FC = () => {
     const storageKey = weeklyStorageKey(new Date());
     const next = !isSolved;
     setIsSolved(next);
-    try {
-      if (next) {
-        localStorage.setItem(storageKey, "solved");
-        setJustMarked(true);
-        setTimeout(() => setJustMarked(false), 2200);
-      } else {
-        localStorage.removeItem(storageKey);
-      }
-    } catch { /* ignore */ }
+    if (next) {
+      safeSetItem(storageKey, "solved");
+      setJustMarked(true);
+      setTimeout(() => setJustMarked(false), 2200);
+    } else {
+      safeRemoveItem(storageKey);
+    }
   }, [isSolved, challenge]);
 
   if (!mounted || !challenge) return null;

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -515,3 +515,48 @@ export function getAchievementSnapshot(progress: AlgoProgressData = readAlgoProg
   };
 }
 
+/**
+ * Safely reads a raw string item from localStorage (SSG/SSR-safe).
+ */
+export function safeGetItem(key: string, fallback: string | null = null): string | null {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return fallback;
+  }
+  try {
+    const value = window.localStorage.getItem(key);
+    return value !== null ? value : fallback;
+  } catch (err) {
+    console.warn(`[Algo] Error reading localStorage key "${key}":`, err);
+    return fallback;
+  }
+}
+
+/**
+ * Safely writes a raw string item to localStorage (SSG/SSR-safe, handles quota errors).
+ */
+export function safeSetItem(key: string, value: string): void {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (err) {
+    console.error(`[Algo] Error setting localStorage key "${key}":`, err);
+  }
+}
+
+/**
+ * Safely removes an item from localStorage (SSG/SSR-safe).
+ */
+export function safeRemoveItem(key: string): void {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.removeItem(key);
+  } catch (err) {
+    console.warn(`[Algo] Error removing localStorage key "${key}":`, err);
+  }
+}
+
+


### PR DESCRIPTION
## Description

Fixes #3495

Refactors `WeeklyChallengeSpotlight.tsx` to eliminate raw `localStorage` calls and empty `catch { /* ignore */ }` blocks, bringing it in line with the project's safe storage conventions. Added unified helper functions (`safeGetItem`, `safeSetItem`, and `safeRemoveItem`) to `src/utils/safeStorage.ts` to safely handle browser storage operations, SSG/SSR environments, and console error/warning reporting when storage errors occur (such as `QuotaExceededError`).

## Changes Made

- **`src/utils/safeStorage.ts`**:
  - Added `safeGetItem(key, fallback)`: SSG-safe getter with warning logging on read failures.
  - Added `safeSetItem(key, value)`: SSG-safe setter with error logging on write failures.
  - Added `safeRemoveItem(key)`: SSG-safe item removal with warning logging on failures.

- **`src/components/WeeklyChallengeSpotlight.tsx`**:
  - Replaced raw `localStorage.getItem` with `safeGetItem`.
  - Replaced raw `localStorage.setItem` with `safeSetItem`.
  - Replaced raw `localStorage.removeItem` with `safeRemoveItem`.
  - Removed empty `catch` blocks.

- **Unit Tests**:
  - `src/__tests__/utils/safeStorage.test.ts`: Added test cases for `safeGetItem`, `safeSetItem`, `safeRemoveItem`, and exception logging when `localStorage` throws.
  - `src/__tests__/components/WeeklyChallengeSpotlight.test.tsx`: Added component test cases verifying that reading/toggling solved state triggers the safe storage helpers.

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Performed a self-review of the code
- [x] Added unit tests covering new/refactored functionality
- [x] All automated tests pass locally (`npx jest`)
