### PR TITLE
fix: use safe storage for weekly challenges

### DIFF
--- a/src/__tests__/utils/safeStorage.test.ts
+++ b/src/__tests__/utils/safeStorage.test.ts
@@ -1,5 +1,8 @@
 import {
   safeJsonParse,
+  safeGetItem,
+  safeSetItem,
+  safeRemoveItem,
   readAlgoProgress,
   writeAlgoProgress,
   normalizeQuizId,
@@ -73,6 +76,28 @@ describe('safeStorage', () => {
       expect(consoleWarnSpy).toHaveBeenCalled();
       expect(localStorage.getItem('corrupt_key')).toBeNull();
 
+      consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('safe string storage helpers', () => {
+    test('reads, writes, and removes string values', () => {
+      expect(safeSetItem('challenge_key', 'solved')).toBe(true);
+      expect(safeGetItem('challenge_key')).toBe('solved');
+      expect(safeRemoveItem('challenge_key')).toBe(true);
+      expect(safeGetItem('challenge_key')).toBeNull();
+    });
+
+    test('returns a failure result when storage throws', () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const setItemSpy = jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+
+      expect(safeSetItem('challenge_key', 'solved')).toBe(false);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+
+      setItemSpy.mockRestore();
       consoleWarnSpy.mockRestore();
     });
   });

--- a/src/components/WeeklyChallengeSpotlight.tsx
+++ b/src/components/WeeklyChallengeSpotlight.tsx
@@ -18,6 +18,7 @@ import {
   FaChevronRight, FaCalendarWeek, FaBolt,
 } from "react-icons/fa";
 import challengeData from "../data/challengeData";
+import { safeGetItem, safeRemoveItem, safeSetItem } from "../utils/safeStorage";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -149,10 +150,7 @@ const WeeklyChallengeSpotlight: React.FC = () => {
     setChallenge(weekly);
     setWeekLabel(`Week ${getISOWeek(now)} · ${now.getUTCFullYear()}`);
 
-    try {
-      const saved = localStorage.getItem(storageKey);
-      setIsSolved(saved === "solved");
-    } catch { /* ignore */ }
+    setIsSolved(safeGetItem(storageKey) === "solved");
 
     // Kick off the countdown ticker
     const tick = () => {
@@ -169,15 +167,13 @@ const WeeklyChallengeSpotlight: React.FC = () => {
     const storageKey = weeklyStorageKey(new Date());
     const next = !isSolved;
     setIsSolved(next);
-    try {
-      if (next) {
-        localStorage.setItem(storageKey, "solved");
-        setJustMarked(true);
-        setTimeout(() => setJustMarked(false), 2200);
-      } else {
-        localStorage.removeItem(storageKey);
-      }
-    } catch { /* ignore */ }
+    if (next) {
+      safeSetItem(storageKey, "solved");
+      setJustMarked(true);
+      setTimeout(() => setJustMarked(false), 2200);
+    } else {
+      safeRemoveItem(storageKey);
+    }
   }, [isSolved, challenge]);
 
   if (!mounted || !challenge) return null;

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -76,6 +76,41 @@ export function safeJsonParse<T>(key: string, fallback: T): T {
   }
 }
 
+export function safeGetItem(key: string): string | null {
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    console.warn(`[Algo] Failed to read localStorage key ${key}:`, error);
+    return null;
+  }
+}
+
+export function safeSetItem(key: string, value: string): boolean {
+  if (typeof window === 'undefined' || !window.localStorage) return false;
+
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch (error) {
+    console.warn(`[Algo] Failed to write localStorage key ${key}:`, error);
+    return false;
+  }
+}
+
+export function safeRemoveItem(key: string): boolean {
+  if (typeof window === 'undefined' || !window.localStorage) return false;
+
+  try {
+    window.localStorage.removeItem(key);
+    return true;
+  } catch (error) {
+    console.warn(`[Algo] Failed to remove localStorage key ${key}:`, error);
+    return false;
+  }
+}
+
 export function readAlgoProgress(): AlgoProgressData {
   return safeJsonParse<AlgoProgressData>('algo_progress', {});
 }
@@ -514,4 +549,3 @@ export function getAchievementSnapshot(progress: AlgoProgressData = readAlgoProg
     totalQuizzesAttempted: quizStats.attempted,
   };
 }
-


### PR DESCRIPTION
## Summary
- add safe string storage helpers with browser guards and error logging
- use the shared helpers for WeeklyChallengeSpotlight read, write, and remove operations
- add regression coverage for normal persistence and storage failures

Closes #3495

## Validation
- `npx jest src/__tests__/utils/safeStorage.test.ts --runInBand` (22 passed)
- `npx tsc --noEmit`
- `git diff --check`

The full Docusaurus build reached content processing but was blocked by a lazy-clone Git fetch failure for an unrelated blog file (`comparing-sortings.md`).
