### PR TITLE
docs : added description and tags frontmatter to GaleShapley.md

### DIFF
--- a/docs/extra/algorithms/Gale-Shapley-Algorithm/GaleShapley.md
+++ b/docs/extra/algorithms/Gale-Shapley-Algorithm/GaleShapley.md
@@ -1,8 +1,10 @@
 ---
-id: gale-shapley-algorithm  
-sidebar_position: 15  
-title: Gale-Shapley Algorithm  
-sidebar_label: Gale-Shapley Algorithm  
+id: gale-shapley-algorithm
+sidebar_position: 15
+title: Gale-Shapley Algorithm
+sidebar_label: Gale-Shapley Algorithm
+description: "The Gale-Shapley algorithm, also known as the Deferred Acceptance Algorithm or Stable Marriage Problem algorithm, finds a stable matching between two sets of participants where no pair would both prefer each other over their current partner. It is widely used in real-world scenarios like college admissions, job matching, and organ donation systems."
+tags: [Stable Matching, Deferred Acceptance, Marriage Problem, Greedy, Game Theory]
 ---
 
 ## Overview:


### PR DESCRIPTION
## Summary of What Has Been Done

Added `description` and `tags` frontmatter fields to `docs/extra/algorithms/Gale-Shapley-Algorithm/GaleShapley.md`.

## Changes Made

- Added `description` field summarizing the Gale-Shapley algorithm (Stable Matching / Deferred Acceptance / Stable Marriage Problem)
- Added `tags` field with relevant topic tags: Stable Matching, Deferred Acceptance, Marriage Problem, Greedy, Game Theory

## Impact it Made

- Improves SEO and discoverability of the Gale-Shapley algorithm documentation
- Enables proper content indexing and filtering
- Consistent with documentation standards used in other algorithm docs in this repo

Closes #3622

Note: Please assign this PR to the `tmdeveloper007` account.