### PR TITLE
fix: correct Reverse Bits problem ID from display name to slug

### DIFF
--- a/docs/dsa-problems/easy/reverse-bits.md
+++ b/docs/dsa-problems/easy/reverse-bits.md
@@ -1,5 +1,5 @@
 ---
-id: Reverse Bits
+id: reverse-bits
 title: Reverse Bits Solution
 sidebar_label: Reverse Bits
 description: >-

--- a/src/data/companyTracks.ts
+++ b/src/data/companyTracks.ts
@@ -147,7 +147,7 @@ export const COMPANY_TRACKS: CompanyTrack[] = [
       'reverse-linked-list',
       'maximum-depth-of-binary-tree',
       'symmetric-tree',
-      'Reverse Bits',
+      'reverse-bits',
       'plus-one',
       'removing-stars-from-string',
       'valid-parenthesis-string',

--- a/src/data/generated/dsaProblemsIndex.json
+++ b/src/data/generated/dsaProblemsIndex.json
@@ -1137,7 +1137,7 @@
       "url": "/docs/dsa-problems/medium/removing-stars-from-string"
     },
     {
-      "id": "Reverse Bits",
+      "id": "reverse-bits",
       "title": "Reverse Bits Solution",
       "description": "The Reverse Bits problem asks you to reverse the bits of a given 32-bit unsigned integer. Essentially, you need to flip the binary representation of the number so that the least significant bit (LSB) becomes the most significant bit (MSB) and vice versa.",
       "difficulty": "Easy",
@@ -1145,7 +1145,7 @@
       "companies": [
         "Microsoft"
       ],
-      "url": "/docs/dsa-problems/easy/Reverse Bits"
+      "url": "/docs/dsa-problems/easy/reverse-bits"
     },
     {
       "id": "reverse-integer",
@@ -2371,8 +2371,8 @@
       ],
       "url": "/docs/dsa-problems/medium/removing-stars-from-string"
     },
-    "Reverse Bits": {
-      "id": "Reverse Bits",
+    "reverse-bits": {
+      "id": "reverse-bits",
       "title": "Reverse Bits Solution",
       "description": "The Reverse Bits problem asks you to reverse the bits of a given 32-bit unsigned integer. Essentially, you need to flip the binary representation of the number so that the least significant bit (LSB) becomes the most significant bit (MSB) and vice versa.",
       "difficulty": "Easy",
@@ -2380,7 +2380,7 @@
       "companies": [
         "Microsoft"
       ],
-      "url": "/docs/dsa-problems/easy/Reverse Bits"
+      "url": "/docs/dsa-problems/easy/reverse-bits"
     },
     "reverse-integer": {
       "id": "reverse-integer",


### PR DESCRIPTION
Fixes #3577

## Root Cause

The doc frontmatter in `reverse-bits.md` had `id: Reverse Bits` (capitalised, with a space) instead of a proper lowercase slug. The index generation script (`generate-dsa-problems-index.js`) uses `frontMatter.id || baseId`, so it picked up `"Reverse Bits"` instead of the filename-derived `"reverse-bits"`. This gave the problem a broken URL (`/docs/dsa-problems/easy/Reverse Bits` with a space) and a non-standard key in `problemsById`.

The Microsoft company track already referenced `'Reverse Bits'` which technically matched the bad key - but is inconsistent with every other track entry which all use lowercase slugs.

## Changes

- `reverse-bits.md` - fix frontmatter `id` from `Reverse Bits` → `reverse-bits`
- `companyTracks.ts` - update Microsoft track `problemId` from `'Reverse Bits'` → `'reverse-bits'`
- `dsaProblemsIndex.json` - patch both the `problems` array entry and the `problemsById` map key to use `"reverse-bits"` and the corrected URL `/docs/dsa-problems/easy/reverse-bits`

## Testing

1. Go to `/dsa-problems/tracks` and open the Microsoft track
2. The "Reverse Bits" problem should now render as a proper linked card instead of showing "Coming soon to DSA index"
3. The link should navigate to `/docs/dsa-problems/easy/reverse-bits`
