### PR TITLE
fix: replace inline styles with Tailwind classes in RecentlyViewedAlgorithms

### DIFF
--- a/src/components/RecentlyViewedAlgorithms/index.jsx
+++ b/src/components/RecentlyViewedAlgorithms/index.jsx
@@ -1,38 +1,51 @@
 import React, { useEffect, useState } from "react";
 import Link from "@docusaurus/Link";
+import { FiClock, FiArrowRight } from "react-icons/fi";
 import {
   getRecentAlgorithms,
 } from "../../utils/recentAlgorithms";
 
 export default function RecentlyViewedAlgorithms() {
   const [algorithms, setAlgorithms] = useState([]);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    setMounted(true);
     setAlgorithms(getRecentAlgorithms());
   }, []);
 
-  if (algorithms.length === 0) {
+  // Wait for client hydration — component reads localStorage which is unavailable during SSR
+  if (!mounted || algorithms.length === 0) {
     return null;
   }
 
   return (
-    <div
-      style={{
-        marginTop: "2rem",
-        padding: "1rem",
-        border: "1px solid #ddd",
-        borderRadius: "8px",
-      }}
-    >
-      <h2>Recently Viewed Algorithms</h2>
+    <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-2">
+        <FiClock className="h-4 w-4 text-blue-500 dark:text-blue-400" aria-hidden="true" />
+        <h2 className="m-0 text-lg font-bold text-slate-900 dark:text-white">
+          Recently Viewed Algorithms
+        </h2>
+      </div>
 
-      <ul>
+      {/* Algorithm list */}
+      <ul className="m-0 list-none space-y-2 p-0">
         {algorithms.map((algo) => (
-          <li key={algo.path}>
-            <Link to={algo.path}>{algo.title}</Link>
+          <li key={algo.path} className="m-0 p-0">
+            <Link
+              to={algo.path}
+              className="group flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-slate-50/50 px-4 py-3 text-sm font-semibold text-slate-700 no-underline transition-all hover:border-blue-200 hover:bg-blue-50/50 hover:text-blue-600 dark:border-slate-800 dark:bg-slate-800/50 dark:text-slate-300 dark:hover:border-blue-800 dark:hover:bg-blue-900/20 dark:hover:text-blue-400"
+            >
+              <span className="flex-1">{algo.title}</span>
+              <FiArrowRight
+                className="h-3.5 w-3.5 shrink-0 text-slate-400 transition-transform group-hover:translate-x-0.5 group-hover:text-blue-500 dark:text-slate-600 dark:group-hover:text-blue-400"
+                aria-hidden="true"
+              />
+            </Link>
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
Fix #3580 

Issue #3580 reported that RecentlyViewedAlgorithms used hardcoded inline
styles (border: '1px solid #ddd', borderRadius: '8px') and a plain <ul>/<li>
list, which did not respond to dark mode and ignored all Tailwind/CSS variable patterns used by every other component in the codebase.

Changes:
- Remove all inline style props
- Replace container <div> with <section> using the same card pattern as DailyChallengeWidget and QuizStreakWidget: rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm
- Style <h2> heading and add FiClock icon in a flex header row to match widget header conventions
- Replace bare <ul>/<li> with a list-none space-y-2 list; each item is a full-width styled <Link> row with proper light and dark hover states
- Add FiArrowRight chevron with group-hover slide transition
- Add mounted guard to prevent SSR/hydration mismatch (localStorage is unavailable server-side)


