### PR TITLE
fix: use heatmap.activeDays instead of streak.totalActiveDays for weekly active days stat

### DIFF
--- a/src/components/PracticeActivitySummaryCard.tsx
+++ b/src/components/PracticeActivitySummaryCard.tsx
@@ -49,7 +49,7 @@ export default function PracticeActivitySummaryCard() {
           <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/70 p-4 border border-slate-200 dark:border-slate-800">
             <p className="text-[10px] font-bold uppercase tracking-wider opacity-50 m-0">Active days</p>
             <p className="mt-2 text-3xl font-black" style={{ color: "var(--ifm-heading-color)" }}>
-              {streak.totalActiveDays}
+              {heatmap.activeDays}
             </p>
             <p className="text-xs opacity-70 mt-2 m-0">Unique days practiced this week.</p>
           </div>


### PR DESCRIPTION
Fix #3581 

Issue #3581: the middle stat box in PracticeActivitySummaryCard showed streak.totalActiveDays (all-time count of distinct calendar days ever practiced) while the label read 'Unique days practiced this week'.

The component already calls usePracticeActivityHeatmap(7), which computes activeDays as the count of distinct days with at least one attempt within the last 7 days. Replace streak.totalActiveDays with heatmap.activeDays so the displayed value is correctly scoped to the current week and matches the label.

