### PR TITLE
feat(ui): apply accent theme CSS variables to Tailwind-based leaderboard and quiz pages

### DIFF
--- a/src/pages/leaderboard/index.tsx
+++ b/src/pages/leaderboard/index.tsx
@@ -55,7 +55,7 @@ function getTier(xp: number, rank: number): Pick<ChallengePlayer, "tier" | "acce
   if (rank === 2)  return { tier: "GRANDMASTER",  accentColor: "from-purple-500 via-fuchsia-500 to-pink-500",  textColor: "text-purple-500 dark:text-purple-400" };
   if (rank === 3)  return { tier: "MASTER",        accentColor: "from-emerald-500 to-teal-400",                textColor: "text-emerald-500 dark:text-emerald-400" };
   if (xp >= 8000)  return { tier: "DIAMOND",       accentColor: "from-blue-500 to-indigo-500",                 textColor: "text-blue-500 dark:text-blue-400" };
-  if (xp >= 4000)  return { tier: "PLATINUM",      accentColor: "from-cyan-500 to-blue-500",                   textColor: "text-cyan-600 dark:text-cyan-400" };
+  if (xp >= 4000)  return { tier: "PLATINUM",      accentColor: "from-primary to-blue-500",                   textColor: "text-primary-dark dark:text-primary-light" };
   if (xp >= 1500)  return { tier: "GOLD",          accentColor: "from-yellow-500 to-amber-400",                textColor: "text-yellow-600 dark:text-yellow-400" };
   return              { tier: "SILVER",        accentColor: "from-slate-400 to-slate-500",                textColor: "text-slate-500 dark:text-slate-400" };
 }
@@ -143,7 +143,7 @@ function TabButton({ active, onClick, children }: { active: boolean; onClick: ()
       onClick={onClick}
       className={`flex items-center gap-2 px-5 py-2.5 rounded-xl font-mono text-xs font-black uppercase tracking-widest border transition-all duration-200 cursor-pointer ${
         active
-          ? "bg-slate-900 dark:bg-cyan-500 text-white dark:text-black border-slate-900 dark:border-cyan-500 shadow-md"
+          ? "bg-primary text-white border-primary shadow-md"
           : "bg-white dark:bg-neutral-900 text-slate-500 dark:text-neutral-400 border-slate-200 dark:border-neutral-800 hover:border-slate-400 dark:hover:border-neutral-600"
       }`}
     >
@@ -217,11 +217,11 @@ function ChallengeRow({ player, maxXp, isMe }: { player: ChallengePlayer; maxXp:
       animate={{ opacity: 1, x: 0 }}
       exit={{ opacity: 0, scale: 0.99 }}
       layout
-      className={`p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4 hover:bg-slate-50/70 dark:hover:bg-neutral-900/30 border-l-2 transition-all duration-150 relative group ${isMe ? "border-l-cyan-500 bg-cyan-50/30 dark:bg-cyan-500/5" : "border-l-transparent hover:border-l-cyan-500"}`}
+      className={`p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4 hover:bg-slate-50/70 dark:hover:bg-neutral-900/30 border-l-2 transition-all duration-150 relative group ${isMe ? "border-l-primary bg-cyan-50/30 dark:bg-primary/5" : "border-l-transparent hover:border-l-primary"}`}
     >
       {/* identity */}
       <div className="flex items-center gap-4 flex-1 min-w-0">
-        <div className="w-8 font-mono text-xs font-black text-slate-300 dark:text-neutral-700 group-hover:text-slate-900 dark:group-hover:text-cyan-400 transition-colors shrink-0">
+        <div className="w-8 font-mono text-xs font-black text-slate-300 dark:text-neutral-700 group-hover:text-slate-900 dark:group-hover:text-primary-light transition-colors shrink-0">
           #{String(player.rank).padStart(2, "0")}
         </div>
 
@@ -232,10 +232,10 @@ function ChallengeRow({ player, maxXp, isMe }: { player: ChallengePlayer; maxXp:
 
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <a href={player.profileUrl} target="_blank" rel="noopener noreferrer" className="text-sm font-bold tracking-wide text-slate-800 dark:text-neutral-100 hover:text-blue-600 dark:hover:text-cyan-400 transition-colors no-underline">
+            <a href={player.profileUrl} target="_blank" rel="noopener noreferrer" className="text-sm font-bold tracking-wide text-slate-800 dark:text-neutral-100 hover:text-blue-600 dark:hover:text-primary-light transition-colors no-underline">
               {player.username}
             </a>
-            {isMe && <span className="text-[8px] font-black tracking-widest px-1.5 py-0.5 rounded bg-cyan-500 text-white uppercase">YOU</span>}
+            {isMe && <span className="text-[8px] font-black tracking-widest px-1.5 py-0.5 rounded bg-primary text-white uppercase">YOU</span>}
             <span className={`text-[8px] font-black tracking-widest px-1.5 py-0.5 rounded bg-gradient-to-r ${player.accentColor} text-white uppercase`}>{player.tier}</span>
           </div>
 
@@ -378,7 +378,7 @@ const Leaderboard: React.FC = () => {
           const mapped: LeaderNode[] = response.data.map((user, idx) => {
             const rank = idx + 1;
             const score = user.contributions * 150;
-            let tier = "PLATINUM", accent = "from-cyan-500 to-blue-500", text = "text-cyan-600 dark:text-cyan-400";
+            let tier = "PLATINUM", accent = "from-primary to-blue-500", text = "text-primary-dark dark:text-primary-light";
             if (rank === 1) { tier = "APEX LEGEND"; accent = "from-amber-400 via-orange-500 to-yellow-500"; text = "text-amber-600 dark:text-amber-400"; }
             else if (rank === 2) { tier = "GRANDMASTER"; accent = "from-purple-500 via-fuchsia-500 to-pink-500"; text = "text-purple-600 dark:text-purple-400"; }
             else if (rank === 3) { tier = "MASTER"; accent = "from-emerald-500 to-teal-400"; text = "text-emerald-600 dark:text-emerald-400"; }
@@ -449,7 +449,7 @@ const Leaderboard: React.FC = () => {
           // Shown during SSG/SSR - a lightweight static shell with no client APIs
           <main className="min-h-screen bg-slate-50 dark:bg-black flex items-center justify-center">
             <div className="text-center space-y-4">
-              <div className="w-8 h-8 border-2 border-cyan-500 border-t-transparent rounded-full animate-spin mx-auto" />
+              <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin mx-auto" />
               <p className="text-xs font-mono font-bold tracking-widest text-slate-400 uppercase">
                 Loading Arena Rankings…
               </p>
@@ -458,11 +458,11 @@ const Leaderboard: React.FC = () => {
         }
       >
         {() => (
-      <main className="min-h-screen bg-slate-50 dark:bg-black text-slate-900 dark:text-white font-mono relative overflow-hidden pb-32 transition-colors duration-300 selection:bg-cyan-500 selection:text-black">
+      <main className="min-h-screen bg-slate-50 dark:bg-black text-slate-900 dark:text-white font-mono relative overflow-hidden pb-32 transition-colors duration-300 selection:bg-primary selection:text-black">
 
         {/* Background mesh */}
         <div className="absolute inset-0 bg-[linear-gradient(to_right,#e2e8f0_1px,transparent_1px),linear-gradient(to_bottom,#e2e8f0_1px,transparent_1px)] dark:bg-[linear-gradient(to_right,#1f293722_1px,transparent_1px),linear-gradient(to_bottom,#1f293722_1px,transparent_1px)] bg-[size:32px_32px] pointer-events-none opacity-70 dark:opacity-100" />
-        <div className="absolute top-0 left-1/4 w-[500px] h-[500px] bg-blue-500/5 dark:bg-cyan-500/10 rounded-full filter blur-[120px] pointer-events-none" />
+        <div className="absolute top-0 left-1/4 w-[500px] h-[500px] bg-blue-500/5 dark:bg-primary/10 rounded-full filter blur-[120px] pointer-events-none" />
         <div className="absolute top-1/3 right-1/4 w-[600px] h-[600px] bg-purple-500/5 rounded-full filter blur-[160px] pointer-events-none" />
 
         {/* ── Header ── */}
@@ -470,7 +470,7 @@ const Leaderboard: React.FC = () => {
           <div className="inline-flex items-center gap-3 px-4 py-1.5 rounded-full bg-white dark:bg-neutral-900 border border-slate-200 dark:border-neutral-800 text-xs font-semibold tracking-widest mb-6 uppercase text-slate-500 dark:text-neutral-400 shadow-sm">
             {activeTab === "github" ? (
               dataSource === "live" ? (
-                <span className="flex items-center gap-2"><span className="w-2 h-2 rounded-full bg-cyan-500 shadow-[0_0_8px_#22d3ee] animate-pulse" /><span className="text-cyan-600 dark:text-cyan-400 font-bold">GITHUB_CORE // CONNECTED</span></span>
+                <span className="flex items-center gap-2"><span className="w-2 h-2 rounded-full bg-primary shadow-[0_0_8px_#22d3ee] animate-pulse" /><span className="text-primary-dark dark:text-primary-light font-bold">GITHUB_CORE // CONNECTED</span></span>
               ) : dataSource === "cache" ? (
                 <span className="flex items-center gap-2"><span className="w-2 h-2 rounded-full bg-amber-500 shadow-[0_0_8px_#f59e0b] animate-pulse" /><span className="text-amber-600 dark:text-amber-400 font-bold">LOCAL_CACHE // {formattedAge || "LOADED"}</span></span>
               ) : (
@@ -483,7 +483,7 @@ const Leaderboard: React.FC = () => {
 
           <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tighter uppercase mb-4 text-slate-900 dark:text-white">
             ARENA{" "}
-            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-cyan-500 dark:from-cyan-400 dark:to-teal-300 drop-shadow-[0_0_15px_rgba(34,211,238,0.2)]">
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-primary dark:from-primary-light dark:to-teal-300 drop-shadow-[0_0_15px_rgba(34,211,238,0.2)]">
               RANKINGS
             </span>
           </h1>
@@ -549,24 +549,24 @@ const Leaderboard: React.FC = () => {
               <section className="relative z-10 max-w-7xl mx-auto px-6">
                 <div className="bg-white dark:bg-neutral-950 border border-slate-200 dark:border-neutral-800 rounded-2xl overflow-hidden shadow-md dark:shadow-[0_20px_50px_rgba(0,0,0,0.8)] transition-colors duration-300">
                   <div className="p-5 border-b border-slate-200 dark:border-neutral-800 bg-slate-50/50 dark:bg-neutral-900/30 flex flex-col md:flex-row items-center justify-between gap-4">
-                    <div className="flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-blue-500 dark:bg-cyan-400 animate-pulse" /><h2 className="text-xs font-black tracking-widest uppercase text-slate-400 dark:text-neutral-500 m-0">GITHUB_ROSTER_STREAM</h2></div>
+                    <div className="flex items-center gap-2"><span className="w-1.5 h-1.5 rounded-full bg-blue-500 dark:bg-primary-light animate-pulse" /><h2 className="text-xs font-black tracking-widest uppercase text-slate-400 dark:text-neutral-500 m-0">GITHUB_ROSTER_STREAM</h2></div>
                     <div className="w-full md:max-w-sm relative flex items-center">
                       <span className="absolute left-3.5 text-slate-400 text-xs font-bold">⚡</span>
-                      <input type="text" placeholder="SEARCH CONTRIBUTOR ID..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="w-full bg-white dark:bg-black border border-slate-200 dark:border-neutral-800 text-xs tracking-widest font-mono pl-9 pr-4 py-2.5 rounded-xl text-slate-900 dark:text-white focus:outline-none focus:border-blue-500 dark:focus:border-cyan-500 transition-all uppercase placeholder:text-slate-400 dark:placeholder:text-neutral-600" />
+                      <input type="text" placeholder="SEARCH CONTRIBUTOR ID..." value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="w-full bg-white dark:bg-black border border-slate-200 dark:border-neutral-800 text-xs tracking-widest font-mono pl-9 pr-4 py-2.5 rounded-xl text-slate-900 dark:text-white focus:outline-none focus:border-blue-500 dark:focus:border-primary transition-all uppercase placeholder:text-slate-400 dark:placeholder:text-neutral-600" />
                     </div>
                   </div>
-                  {ghLoading && <div className="py-24 text-center text-xs tracking-widest font-bold text-slate-400 dark:text-neutral-500"><div className="w-6 h-6 border-2 border-blue-500 dark:border-cyan-500 border-t-transparent rounded-full animate-spin mx-auto mb-4" />COMPILING MATRIX REALTIME RANK PLACEMENTS...</div>}
+                  {ghLoading && <div className="py-24 text-center text-xs tracking-widest font-bold text-slate-400 dark:text-neutral-500"><div className="w-6 h-6 border-2 border-blue-500 dark:border-primary border-t-transparent rounded-full animate-spin mx-auto mb-4" />COMPILING MATRIX REALTIME RANK PLACEMENTS...</div>}
                   {!ghLoading && (
                     <motion.div layout className="divide-y divide-slate-100 dark:divide-neutral-900 bg-white dark:bg-black transition-colors duration-300">
                       <AnimatePresence mode="popLayout">
                         {ghRoster.map((leader) => (
-                          <motion.div key={leader.username} initial={{ opacity: 0, x: -8 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, scale: 0.99 }} layout className="p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-6 hover:bg-slate-50/50 dark:hover:bg-neutral-900/20 border-l-2 border-l-transparent hover:border-l-blue-500 dark:hover:border-l-cyan-500 transition-all duration-150 relative group">
+                          <motion.div key={leader.username} initial={{ opacity: 0, x: -8 }} animate={{ opacity: 1, x: 0 }} exit={{ opacity: 0, scale: 0.99 }} layout className="p-4 sm:p-5 flex flex-col sm:flex-row sm:items-center justify-between gap-4 sm:gap-6 hover:bg-slate-50/50 dark:hover:bg-neutral-900/20 border-l-2 border-l-transparent hover:border-l-blue-500 dark:hover:border-l-primary transition-all duration-150 relative group">
                             <div className="flex items-center gap-4 flex-1 min-w-0">
-                              <div className="w-8 font-mono text-xs font-black text-slate-300 dark:text-neutral-700 group-hover:text-slate-900 dark:group-hover:text-cyan-400 transition-colors">#{String(leader.rank).padStart(2, "0")}</div>
+                              <div className="w-8 font-mono text-xs font-black text-slate-300 dark:text-neutral-700 group-hover:text-slate-900 dark:group-hover:text-primary-light transition-colors">#{String(leader.rank).padStart(2, "0")}</div>
                               <div className="relative shrink-0"><img src={leader.avatarUrl} alt="" className="w-10 h-10 rounded-xl object-cover bg-slate-100 dark:bg-neutral-900 p-0.5 border border-slate-200 dark:border-neutral-800" /><div className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-emerald-500 border-2 border-white dark:border-black" /></div>
                               <div className="min-w-0 flex-1">
                                 <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-                                  <a href={leader.profileUrl} target="_blank" rel="noopener noreferrer" className="text-sm font-bold tracking-wide text-slate-800 dark:text-neutral-100 hover:text-blue-600 dark:hover:text-cyan-400 transition-colors no-underline">{leader.username}</a>
+                                  <a href={leader.profileUrl} target="_blank" rel="noopener noreferrer" className="text-sm font-bold tracking-wide text-slate-800 dark:text-neutral-100 hover:text-blue-600 dark:hover:text-primary-light transition-colors no-underline">{leader.username}</a>
                                   <span className={`text-[8px] font-black tracking-widest px-1.5 py-0.5 rounded bg-gradient-to-r ${leader.accentColor} text-white uppercase`}>{leader.tier}</span>
                                 </div>
                                 <div className="w-full max-w-sm h-1 bg-slate-100 dark:bg-neutral-900 rounded-full mt-2 overflow-hidden hidden sm:block">
@@ -598,10 +598,10 @@ const Leaderboard: React.FC = () => {
               {/* "Your rank" banner if local progress found */}
               {myEntry && (
                 <div className="relative z-10 max-w-6xl mx-auto px-6 mb-6">
-                  <div className="flex flex-wrap items-center gap-4 p-4 bg-cyan-50 dark:bg-cyan-500/10 border border-cyan-200 dark:border-cyan-500/30 rounded-2xl">
-                    <img src={myEntry.avatarUrl} alt="" className="w-10 h-10 rounded-xl object-cover border border-cyan-300 dark:border-cyan-600" onError={(e) => { (e.currentTarget as HTMLImageElement).src = `https://api.dicebear.com/7.x/identicon/svg?seed=${myEntry.username}`; }} />
+                  <div className="flex flex-wrap items-center gap-4 p-4 bg-cyan-50 dark:bg-primary/10 border border-cyan-200 dark:border-primary/30 rounded-2xl">
+                    <img src={myEntry.avatarUrl} alt="" className="w-10 h-10 rounded-xl object-cover border border-primary-lightest dark:border-primary-dark" onError={(e) => { (e.currentTarget as HTMLImageElement).src = `https://api.dicebear.com/7.x/identicon/svg?seed=${myEntry.username}`; }} />
                     <div>
-                      <div className="text-[9px] font-black tracking-widest text-cyan-600 dark:text-cyan-400 uppercase mb-0.5">Your Current Rank</div>
+                      <div className="text-[9px] font-black tracking-widest text-primary-dark dark:text-primary-light uppercase mb-0.5">Your Current Rank</div>
                       <div className="text-sm font-black text-slate-800 dark:text-white">#{myEntry.rank} · {myEntry.username} · {myEntry.xp.toLocaleString()} XP · {myEntry.solved} solved</div>
                     </div>
                     <span className={`ml-auto text-[9px] font-black tracking-widest px-2.5 py-1 rounded-lg bg-gradient-to-r ${myEntry.accentColor} text-white uppercase`}>{myEntry.tier}</span>
@@ -644,7 +644,7 @@ const Leaderboard: React.FC = () => {
                       ))}
                       <span className="text-[9px] font-black tracking-widest text-slate-400 dark:text-neutral-600 uppercase ml-2">Filter:</span>
                       {(["All", "Easy", "Medium", "Hard"] as const).map((d) => (
-                        <button key={d} onClick={() => setFilterDiff(d)} className={`px-3 py-1 rounded-lg text-[9px] font-black tracking-widest uppercase border transition-all cursor-pointer ${filterDiff === d ? d === "Easy" ? "bg-emerald-500 text-white border-emerald-500" : d === "Medium" ? "bg-amber-500 text-white border-amber-500" : d === "Hard" ? "bg-red-500 text-white border-red-500" : "bg-slate-800 text-white border-slate-800 dark:bg-cyan-500 dark:border-cyan-500 dark:text-black" : "bg-white dark:bg-neutral-900 text-slate-500 dark:text-neutral-500 border-slate-200 dark:border-neutral-800 hover:border-slate-400 dark:hover:border-neutral-600"}`}>
+                        <button key={d} onClick={() => setFilterDiff(d)} className={`px-3 py-1 rounded-lg text-[9px] font-black tracking-widest uppercase border transition-all cursor-pointer ${filterDiff === d ? d === "Easy" ? "bg-emerald-500 text-white border-emerald-500" : d === "Medium" ? "bg-amber-500 text-white border-amber-500" : d === "Hard" ? "bg-red-500 text-white border-red-500" : "bg-slate-800 text-white border-slate-800 dark:bg-primary dark:border-primary dark:text-black" : "bg-white dark:bg-neutral-900 text-slate-500 dark:text-neutral-500 border-slate-200 dark:border-neutral-800 hover:border-slate-400 dark:hover:border-neutral-600"}`}>
                           {d}
                         </button>
                       ))}

--- a/src/pages/quizzes/arrays.tsx
+++ b/src/pages/quizzes/arrays.tsx
@@ -243,7 +243,7 @@ const ArrayQuiz: React.FC = () => {
             className="bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-800/80 shadow-md rounded-2xl p-8 max-w-md w-full text-center relative overflow-hidden"
           >
             <div className="absolute inset-0 bg-gradient-to-br from-indigo-500/5 via-transparent to-transparent pointer-events-none" />
-            <div className="w-14 h-14 bg-blue-500/10 text-blue-500 rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-blue-500/20">
+            <div className="w-14 h-14 bg-primary/10 text-primary rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-primary/20">
               <FaAward />
             </div>
             <h2 className="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-2">Arrays Quiz Arena</h2>
@@ -320,7 +320,7 @@ const ArrayQuiz: React.FC = () => {
                       <span className="text-[10px] font-mono tracking-wider text-slate-400 uppercase font-black flex items-center gap-1 justify-end">
                         <FaClock /> Runtime Elapse
                       </span>
-                      <div className="text-base font-mono font-bold text-blue-600 dark:text-blue-400">
+                      <div className="text-base font-mono font-bold text-primary-dark dark:text-primary-light">
                         {formatTime(timeSpent)}
                       </div>
                     </div>
@@ -335,7 +335,7 @@ const ArrayQuiz: React.FC = () => {
                           idx === currentQuestion 
                             ? "bg-[var(--ifm-color-primary)]" 
                             : userAnswers[idx] 
-                              ? "bg-blue-500/40 dark:bg-blue-400/20" 
+                              ? "bg-primary/40 dark:bg-primary-light/20" 
                               : "bg-transparent"
                         }`}
                       />

--- a/src/pages/quizzes/b-tree.tsx
+++ b/src/pages/quizzes/b-tree.tsx
@@ -278,8 +278,8 @@ const BTreeQuiz: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             className="bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-800/80 shadow-md rounded-2xl p-8 max-w-md w-full text-center relative overflow-hidden"
           >
-            <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-transparent to-transparent pointer-events-none" />
-            <div className="w-14 h-14 bg-blue-500/10 text-blue-500 rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-blue-500/20">
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-transparent pointer-events-none" />
+            <div className="w-14 h-14 bg-primary/10 text-primary rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-primary/20">
               <FaDatabase />
             </div>
             <h2 className="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-2">B-Tree Matrix Core</h2>
@@ -295,12 +295,12 @@ const BTreeQuiz: React.FC = () => {
                 value={usernameInput}
                 onChange={(e) => setUsernameInput(e.target.value)}
                 maxLength={24}
-                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 text-sm font-semibold transition-all"
+                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-primary text-sm font-semibold transition-all"
                 required
               />
               <button
                 type="submit"
-                className="w-full py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-sm"
+                className="w-full py-3 bg-primary-dark hover:bg-primary text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-sm"
               >
                 Access Evaluation Stack
               </button>
@@ -357,7 +357,7 @@ const BTreeQuiz: React.FC = () => {
                       <span className="text-[10px] font-mono tracking-wider text-slate-400 uppercase font-black flex items-center gap-1 justify-end">
                         <FaClock /> Engine Runtime
                       </span>
-                      <div className="text-base font-mono font-bold text-blue-600 dark:text-blue-400">
+                      <div className="text-base font-mono font-bold text-primary-dark dark:text-primary-light">
                         {formatDuration(timeSpent)}
                       </div>
                     </div>
@@ -403,7 +403,7 @@ const BTreeQuiz: React.FC = () => {
                           onClick={() => handleAnswer(option)} role="radio" aria-checked={isSelected}
                           className={`w-full text-left p-4 rounded-xl border border-solid transition-all text-xs md:text-sm font-semibold tracking-wide cursor-pointer flex items-center justify-between min-h-[54px] ${
                             isSelected
-                              ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+                              ? "bg-primary-dark border-primary-dark text-white shadow-sm"
                               : "bg-slate-50 dark:bg-slate-950 border-slate-200/80 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
                           }`}
                         >
@@ -445,7 +445,7 @@ const BTreeQuiz: React.FC = () => {
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(59,130,246,0.04),transparent_50%)]" />
                     <h3 className="text-xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-4">Tree Balancing Audit</h3>
                     
-                    <div className="inline-flex items-baseline gap-1 text-5xl font-black text-blue-600 dark:text-blue-500 font-mono">
+                    <div className="inline-flex items-baseline gap-1 text-5xl font-black text-primary-dark dark:text-primary font-mono">
                       {score}
                       <span className="text-xl text-slate-400 font-sans font-normal">/ {QUESTIONS.length}</span>
                     </div>
@@ -528,7 +528,7 @@ const BTreeQuiz: React.FC = () => {
                           </div>
                         </div>
                         <div className="text-right space-y-1">
-                          <div className="font-mono font-black text-sm text-blue-600 dark:text-blue-400">
+                          <div className="font-mono font-black text-sm text-primary-dark dark:text-primary-light">
                             {att.score} <span className="text-[10px] text-slate-400 font-sans font-normal">/ {totalCount}</span>
                           </div>
                           <div className="text-[10px] text-slate-400 font-mono">

--- a/src/pages/quizzes/binary-search-tree.tsx
+++ b/src/pages/quizzes/binary-search-tree.tsx
@@ -248,7 +248,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             className="bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-800 shadow-md rounded-2xl p-8 max-w-md w-full text-center relative overflow-hidden"
           >
-            <div className="w-14 h-14 bg-blue-500/10 text-blue-500 rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-blue-500/20">
+            <div className="w-14 h-14 bg-primary/10 text-primary rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-primary/20">
               <FaNetworkWired />
             </div>
             <h2 className="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-2">BST Arena Gate</h2>
@@ -264,12 +264,12 @@ const BinarySearchTreeQuiz: React.FC = () => {
                 value={usernameInput}
                 onChange={(e) => setUsernameInput(e.target.value)}
                 maxLength={24}
-                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 text-sm font-semibold transition-all"
+                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-primary text-sm font-semibold transition-all"
                 required
               />
               <button
                 type="submit"
-                className="w-full py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-xs"
+                className="w-full py-3 bg-primary-dark hover:bg-primary text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-xs"
               >
                 Initialize Diagnostic Interface
               </button>
@@ -326,7 +326,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
                       <span className="text-[10px] font-mono tracking-wider text-slate-400 uppercase font-black flex items-center gap-1 justify-end">
                         <FaClock /> Runtime Trace
                       </span>
-                      <div className="text-base font-mono font-bold text-blue-600 dark:text-blue-400">
+                      <div className="text-base font-mono font-bold text-primary-dark dark:text-primary-light">
                         {formatDuration(timeSpent)}
                       </div>
                     </div>
@@ -372,7 +372,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
                           onClick={() => handleAnswer(option)} role="radio" aria-checked={isSelected}
                           className={`w-full text-left p-4 rounded-xl border border-solid transition-all text-xs md:text-sm font-semibold tracking-wide cursor-pointer flex items-center justify-between min-h-[54px] ${
                             isSelected
-                              ? "bg-blue-600 border-blue-600 text-white shadow-xs"
+                              ? "bg-primary-dark border-primary-dark text-white shadow-xs"
                               : "bg-slate-50 dark:bg-slate-950 border-slate-200/80 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
                           }`}
                         >
@@ -414,7 +414,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(59,130,246,0.03),transparent_50%)]" />
                     <h3 className="text-xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-4">Tree Structure Compliance</h3>
                     
-                    <div className="inline-flex items-baseline gap-1 text-5xl font-mono font-black text-blue-600 dark:text-blue-500">
+                    <div className="inline-flex items-baseline gap-1 text-5xl font-mono font-black text-primary-dark dark:text-primary">
                       {score}
                       <span className="text-xl text-slate-400 font-sans font-normal">/ {QUESTIONS.length}</span>
                     </div>
@@ -495,7 +495,7 @@ const BinarySearchTreeQuiz: React.FC = () => {
                           </div>
                         </div>
                         <div className="text-right space-y-1">
-                          <div className="font-mono font-black text-sm text-blue-600 dark:text-blue-400">
+                          <div className="font-mono font-black text-sm text-primary-dark dark:text-primary-light">
                             {att.score} <span className="text-[10px] text-slate-400 font-sans font-normal">/ {totalCount}</span>
                           </div>
                           <div className="text-[10px] text-slate-400 font-mono">

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -240,7 +240,7 @@ const BinaryTreeQuiz: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             className="bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-800 shadow-md rounded-2xl p-8 max-w-md w-full text-center"
           >
-            <div className="w-14 h-14 bg-blue-500/10 text-blue-500 rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-blue-500/20">
+            <div className="w-14 h-14 bg-primary/10 text-primary rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-primary/20">
               <FaCodeBranch />
             </div>
             <h2 className="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-2">Tree Space Initialize</h2>
@@ -256,12 +256,12 @@ const BinaryTreeQuiz: React.FC = () => {
                 value={usernameInput}
                 onChange={(e) => setUsernameInput(e.target.value)}
                 maxLength={24}
-                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 text-sm font-semibold transition-all"
+                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-primary text-sm font-semibold transition-all"
                 required
               />
               <button
                 type="submit"
-                className="w-full py-3 bg-blue-600 hover:bg-blue-500 text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-xs"
+                className="w-full py-3 bg-primary-dark hover:bg-primary text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-xs"
               >
                 Mount Evaluation Suite
               </button>
@@ -320,7 +320,7 @@ const BinaryTreeQuiz: React.FC = () => {
                       <span className="text-[10px] font-mono tracking-wider text-slate-400 uppercase font-black flex items-center gap-1 justify-end">
                         <FaClock /> Thread Runtime
                       </span>
-                      <div className="text-base font-mono font-bold text-blue-600 dark:text-blue-400">
+                      <div className="text-base font-mono font-bold text-primary-dark dark:text-primary-light">
                         {formatDuration(timeSpent)}
                       </div>
                     </div>
@@ -366,7 +366,7 @@ const BinaryTreeQuiz: React.FC = () => {
                           onClick={() => handleAnswer(option)} role="radio" aria-checked={isSelected}
                           className={`w-full text-left p-4 rounded-xl border border-solid transition-all text-xs md:text-sm font-semibold tracking-wide cursor-pointer flex items-center justify-between min-h-[54px] ${
                             isSelected
-                              ? "bg-blue-600 border-blue-600 text-white shadow-xs"
+                              ? "bg-primary-dark border-primary-dark text-white shadow-xs"
                               : "bg-slate-50 dark:bg-slate-950 border-slate-200/80 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
                           }`}
                         >
@@ -408,7 +408,7 @@ const BinaryTreeQuiz: React.FC = () => {
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(59,130,246,0.03),transparent_50%)]" />
                     <h3 className="text-xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-4">Compilation Results</h3>
                     
-                    <div className="inline-flex items-baseline gap-1 text-5xl font-mono font-black text-blue-600 dark:text-blue-500">
+                    <div className="inline-flex items-baseline gap-1 text-5xl font-mono font-black text-primary-dark dark:text-primary">
                       {score}
                       <span className="text-xl text-slate-400 font-sans font-normal">/ {QUESTIONS.length}</span>
                     </div>
@@ -489,7 +489,7 @@ const BinaryTreeQuiz: React.FC = () => {
                           </div>
                         </div>
                         <div className="text-right space-y-1">
-                          <div className="font-mono font-black text-sm text-blue-600 dark:text-blue-400">
+                          <div className="font-mono font-black text-sm text-primary-dark dark:text-primary-light">
                             {att.score} <span className="text-[10px] text-slate-400 font-sans font-normal">/ {totalCount}</span>
                           </div>
                           <div className="text-[10px] text-slate-400 font-mono">

--- a/src/pages/quizzes/dependency-graph.tsx
+++ b/src/pages/quizzes/dependency-graph.tsx
@@ -7,7 +7,7 @@ import { QUIZZES_CONFIG, type QuizCardConfig } from "../../data/quizzesConfig";
 
 const CATEGORY_ORDER = ["Linear", "Non-Linear", "Balanced Tree", "Disk Storage"] as const;
 const CATEGORY_STYLES: Record<string, string> = {
-  Linear: "bg-blue-500/10 text-blue-600 border-blue-500/20",
+  Linear: "bg-primary/10 text-primary-dark border-primary/20",
   "Non-Linear": "bg-purple-500/10 text-purple-600 border-purple-500/20",
   "Balanced Tree": "bg-amber-500/10 text-amber-800 border-amber-500/20",
   "Disk Storage": "bg-rose-500/10 text-rose-700 border-rose-500/20",
@@ -106,7 +106,7 @@ const DependencyGraphPage: React.FC = () => {
               <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-6">
                 <div className="space-y-4">
                   <div className="inline-flex items-center gap-2 text-sm uppercase font-semibold tracking-[0.22em] text-slate-500 dark:text-slate-400">
-                    <FaProjectDiagram className="text-base text-blue-600 dark:text-blue-400" />
+                    <FaProjectDiagram className="text-base text-primary-dark dark:text-primary-light" />
                     Topic Dependency Map
                   </div>
                   <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-slate-900 dark:text-white">
@@ -127,7 +127,7 @@ const DependencyGraphPage: React.FC = () => {
                   </Link>
                   <a
                     href="#graph"
-                    className="inline-flex items-center gap-2 rounded-2xl bg-blue-600 hover:bg-blue-700 text-white px-4 py-3 text-sm font-semibold transition"
+                    className="inline-flex items-center gap-2 rounded-2xl bg-primary-dark hover:bg-primary-darker text-white px-4 py-3 text-sm font-semibold transition"
                   >
                     <FaBook className="text-sm" /> Jump to graph
                   </a>

--- a/src/pages/quizzes/index.tsx
+++ b/src/pages/quizzes/index.tsx
@@ -20,7 +20,7 @@ const FILTER_CATEGORIES = ["All", "Linear", "Non-Linear", "Balanced Tree", "Disk
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const CATEGORY_STYLES: Record<string, string> = {
-  Linear:        "bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20",
+  Linear:        "bg-primary/10 text-primary-dark dark:text-primary-light border-primary/20",
   "Non-Linear":  "bg-purple-500/10 text-purple-600 dark:text-purple-400 border-purple-500/20",
   "Balanced Tree":"bg-amber-500/10 text-amber-800 dark:text-amber-400 border-amber-500/20",
   "Disk Storage":"bg-rose-500/10 text-rose-800 dark:text-rose-400 border-rose-500/20",
@@ -28,14 +28,14 @@ const CATEGORY_STYLES: Record<string, string> = {
 
 function scoreColor(pct: number): string {
   if (pct >= 90) return "text-emerald-600 dark:text-emerald-400";
-  if (pct >= 70) return "text-blue-600 dark:text-blue-400";
+  if (pct >= 70) return "text-primary-dark dark:text-primary-light";
   if (pct >= 50) return "text-amber-600 dark:text-amber-400";
   return "text-red-500 dark:text-red-400";
 }
 
 function scoreBg(pct: number): string {
   if (pct >= 90) return "bg-emerald-500";
-  if (pct >= 70) return "bg-blue-500";
+  if (pct >= 70) return "bg-primary";
   if (pct >= 50) return "bg-amber-500";
   return "bg-red-500";
 }
@@ -84,7 +84,7 @@ function ProgressDashboard({ globalStats, userId, loaded, stats }: ProgressDashb
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-slate-100 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/60">
           <div className="flex items-center gap-2.5">
-            <FaChartBar className="text-blue-500 text-sm" />
+            <FaChartBar className="text-primary text-sm" />
             <span className="text-xs font-black tracking-widest text-slate-500 dark:text-slate-400 uppercase">
               Your Progress Dashboard
             </span>
@@ -100,7 +100,7 @@ function ProgressDashboard({ globalStats, userId, loaded, stats }: ProgressDashb
                 type="button"
                 onClick={() => downloadQuizData(stats, "csv")}
                 aria-label="Download my data"
-                className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-bold text-xs shadow-sm transition-all"
+                className="inline-flex items-center gap-1.5 px-3 py-1 rounded-lg bg-primary-dark hover:bg-primary-darker text-white font-bold text-xs shadow-sm transition-all"
               >
                 <FiDownload size={13} />
                 Download my data
@@ -130,7 +130,7 @@ function ProgressDashboard({ globalStats, userId, loaded, stats }: ProgressDashb
                 initial={{ width: 0 }}
                 animate={{ width: `${progressPct}%` }}
                 transition={{ duration: 0.7, ease: "easeOut" }}
-                className="h-full bg-gradient-to-r from-blue-500 to-indigo-500 rounded-full"
+                className="h-full bg-gradient-to-r from-primary to-indigo-500 rounded-full"
               />
             </div>
             <div className="text-right mt-1 text-[10px] font-mono text-slate-400">{progressPct}%</div>
@@ -154,11 +154,11 @@ function ProgressDashboard({ globalStats, userId, loaded, stats }: ProgressDashb
                 color: "text-emerald-600 dark:text-emerald-400",
               },
               {
-                icon: <FaFire className="text-blue-500" />,
+                icon: <FaFire className="text-primary" />,
                 label: "Attempted",
                 value: globalStats.totalCompleted,
                 sub: "started",
-                color: "text-blue-600 dark:text-blue-400",
+                color: "text-primary-dark dark:text-primary-light",
               },
               {
                 icon: <FaChartBar className="text-purple-500" />,
@@ -373,7 +373,7 @@ const Quizzes: React.FC = () => {
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_-20%,rgba(99,102,241,0.06),transparent_50%)]" />
           <div className="max-w-4xl mx-auto text-center relative z-10 space-y-4">
             <motion.div
-              className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-blue-500/10 text-blue-600 dark:text-blue-400 text-xs font-mono font-bold tracking-wider uppercase border border-blue-500/20"
+              className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-primary/10 text-primary-dark dark:text-primary-light text-xs font-mono font-bold tracking-wider uppercase border border-primary/20"
               initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }}
             >
               <FaTerminal className="text-xs" /> diagnostic_assessment_terminal
@@ -396,7 +396,7 @@ const Quizzes: React.FC = () => {
             >
               <Link
                 to="/mock-exam"
-                className="inline-flex items-center gap-2.5 px-6 py-3 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white font-bold text-sm shadow-md hover:shadow-lg transition-all no-underline"
+                className="inline-flex items-center gap-2.5 px-6 py-3 rounded-2xl bg-gradient-to-r from-primary-dark to-indigo-600 hover:from-primary-darker hover:to-indigo-700 text-white font-bold text-sm shadow-md hover:shadow-lg transition-all no-underline"
               >
                 <FaPlayCircle size={16} />
                 Try Timed Mock Exam Mode
@@ -498,8 +498,8 @@ const Quizzes: React.FC = () => {
                             onClick={() => setShowOnlyIncomplete(v => !v)}
                             className={`inline-flex items-center gap-1.5 px-4 py-2 rounded-xl text-xs font-bold tracking-wide border transition-all whitespace-nowrap min-h-[36px] cursor-pointer ${
                               showOnlyIncomplete
-                                ? "bg-blue-600 border-blue-600 text-white shadow-sm"
-                                : "border-slate-200 bg-white dark:bg-slate-950 dark:border-slate-800 text-slate-500 dark:text-slate-400 hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400"
+                                ? "bg-primary-dark border-primary-dark text-white shadow-sm"
+                                : "border-slate-200 bg-white dark:bg-slate-950 dark:border-slate-800 text-slate-500 dark:text-slate-400 hover:border-primary-light hover:text-primary-dark dark:hover:text-primary-light"
                             }`}
                             title="Show only quizzes you haven't passed yet"
                           >

--- a/src/pages/quizzes/linked-list.tsx
+++ b/src/pages/quizzes/linked-list.tsx
@@ -299,7 +299,7 @@ const LinkedListQuiz: React.FC = () => {
             animate={{ opacity: 1, y: 0 }}
             className="bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-800 shadow-md rounded-2xl p-8 max-w-md w-full text-center"
           >
-            <div className="w-14 h-14 bg-cyan-500/10 text-cyan-500 rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-cyan-500/20">
+            <div className="w-14 h-14 bg-primary/10 text-primary rounded-2xl flex items-center justify-center text-2xl mx-auto mb-5 border border-solid border-primary/20">
               <FaLink />
             </div>
             <h2 className="text-2xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-2">Linked List Quiz</h2>
@@ -314,12 +314,12 @@ const LinkedListQuiz: React.FC = () => {
                 value={usernameInput}
                 onChange={(e) => setUsernameInput(e.target.value)}
                 maxLength={24}
-                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-cyan-500 text-sm font-semibold transition-all"
+                className="w-full px-4 py-3 rounded-xl border border-solid border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-primary text-sm font-semibold transition-all"
                 required
               />
               <button
                 type="submit"
-                className="w-full py-3 bg-cyan-600 hover:bg-cyan-500 text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-xs"
+                className="w-full py-3 bg-primary-dark hover:bg-primary text-white font-bold rounded-xl border-none transition-all cursor-pointer text-sm shadow-xs"
               >
                 Start Linked List Quiz
               </button>
@@ -372,7 +372,7 @@ const LinkedListQuiz: React.FC = () => {
                       <span className="text-[10px] font-mono tracking-wider text-slate-400 uppercase font-black flex items-center gap-1 justify-end">
                         <FaClock /> Time
                       </span>
-                      <div className="text-base font-mono font-bold text-cyan-600 dark:text-cyan-400">
+                      <div className="text-base font-mono font-bold text-primary-dark dark:text-primary-light">
                         {formatDuration(timeSpent)}
                       </div>
                     </div>
@@ -414,7 +414,7 @@ const LinkedListQuiz: React.FC = () => {
                           onClick={() => handleAnswer(option)} role="radio" aria-checked={isSelected}
                           className={`w-full text-left p-4 rounded-xl border border-solid transition-all text-xs md:text-sm font-semibold tracking-wide cursor-pointer flex items-center justify-between min-h-[54px] ${
                             isSelected
-                              ? "bg-cyan-600 border-cyan-600 text-white shadow-xs"
+                              ? "bg-primary-dark border-primary-dark text-white shadow-xs"
                               : "bg-slate-50 dark:bg-slate-950 border-slate-200/80 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
                           }`}
                         >
@@ -453,7 +453,7 @@ const LinkedListQuiz: React.FC = () => {
                   <div className="bg-slate-50 dark:bg-slate-950 border border-solid border-slate-200 dark:border-slate-800 rounded-2xl p-6 md:p-8 text-center relative overflow-hidden">
                     <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(8,145,178,0.03),transparent_50%)]" />
                     <h3 className="text-xl font-black text-slate-900 dark:text-white uppercase tracking-tight m-0 mb-4">Quiz Results</h3>
-                    <div className="inline-flex items-baseline gap-1 text-5xl font-mono font-black text-cyan-600 dark:text-cyan-500">
+                    <div className="inline-flex items-baseline gap-1 text-5xl font-mono font-black text-primary-dark dark:text-primary">
                       {score}
                       <span className="text-xl text-slate-400 font-sans font-normal">/ {QUESTIONS.length}</span>
                     </div>
@@ -531,7 +531,7 @@ const LinkedListQuiz: React.FC = () => {
                           </div>
                         </div>
                         <div className="text-right space-y-1">
-                          <div className="font-mono font-black text-sm text-cyan-600 dark:text-cyan-400">
+                          <div className="font-mono font-black text-sm text-primary-dark dark:text-primary-light">
                             {att.score} <span className="text-[10px] text-slate-400 font-sans font-normal">/ {totalCount}</span>
                           </div>
                           <div className="text-[10px] text-slate-400 font-mono">

--- a/src/pages/quizzes/review.tsx
+++ b/src/pages/quizzes/review.tsx
@@ -168,7 +168,7 @@ function SpacedRepetitionReviewContent() {
               </div>
             </div>
             <div className="p-4 rounded-2xl bg-slate-50 dark:bg-slate-800/60 border border-slate-200 dark:border-slate-700/50 text-center">
-              <div className="text-2xl font-black font-mono text-blue-500">
+              <div className="text-2xl font-black font-mono text-primary">
                 {accuracy}%
               </div>
               <div className="text-[10px] font-bold uppercase tracking-wider text-slate-400 mt-1">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,7 +22,17 @@ module.exports = {
         sm: "0px",
         lg: "997px",
       },
-      colors: {},
+      colors: {
+        primary: {
+          DEFAULT: "var(--ifm-color-primary)",
+          dark: "var(--ifm-color-primary-dark)",
+          darker: "var(--ifm-color-primary-darker)",
+          darkest: "var(--ifm-color-primary-darkest)",
+          light: "var(--ifm-color-primary-light)",
+          lighter: "var(--ifm-color-primary-lighter)",
+          lightest: "var(--ifm-color-primary-lightest)",
+        }
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR improves theme consistency by extending the existing accent theme system to Tailwind-heavy pages, primarily the Leaderboard and Quiz interfaces.

Currently, the Neon (and other accent) themes correctly update Docusaurus variables such as --ifm-color-primary, but many Tailwind components continue using hardcoded utility classes (e.g. bg-cyan-500, text-slate-900, border-cyan-400). As a result, these pages barely change appearance when users switch accent themes.

This PR replaces hardcoded accent colors with CSS variables (or scoped theme overrides) so that accent themes are reflected consistently across the application while preserving existing layouts and accessibility.

Fixes #3590 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
