### PR TITLE
fix: call normalizeQuizId when building localStorage read key in useQuizProgress

### DIFF
--- a/src/hooks/useQuizProgress.ts
+++ b/src/hooks/useQuizProgress.ts
@@ -12,7 +12,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
-import { safeJsonParse } from "../utils/safeStorage";
+import { safeJsonParse, normalizeQuizId } from "../utils/safeStorage";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -109,7 +109,7 @@ export function useQuizProgress(quizIds: string[], questionCounts: Record<string
     const weakTopics: string[] = [];
 
     quizIds.forEach(quizId => {
-      const key = `quiz_attempts_${uid}_${quizId}`;
+      const key = `quiz_attempts_${uid}_${normalizeQuizId(quizId)}`;
       const attempts = safeJsonParse<QuizAttempt[]>(key, []);
       const total = questionCounts[quizId] ?? 10;
 


### PR DESCRIPTION
fix #3654

Issue #3654: saveQuizAttemptLocal (safeStorage.ts) calls normalizeQuizId() before writing - e.g. quiz id 'graph' is stored under the key quiz_attempts_<uid>_graphs. But useQuizProgress built its read key as quiz_attempts_<uid>_graph (no normalisation), so it would always read an empty array and report those quizzes as 'not-started'.

Fix: import normalizeQuizId from safeStorage and apply it to quizId when constructing the localStorage lookup key, matching the write path exactly. The quizId stored in the resulting QuizStat object is intentionally kept as the original (un-normalised) id since the UI uses it as a lookup key.

