### PR TITLE
feat: add interactive custom cursor switcher and global effects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -350,6 +350,10 @@ const config = {
             position: "right",
           },
           {
+            type: "custom-cursorSwitcher",
+            position: "right",
+          },
+          {
             type: "search",
             position: "right",
           },

--- a/src/components/CursorSwitcher.tsx
+++ b/src/components/CursorSwitcher.tsx
@@ -1,0 +1,66 @@
+import React, { useState, useRef, useEffect } from "react";
+import { useCursor, CursorType } from "@site/src/contexts/CursorContext";
+
+const cursorOptions: { type: CursorType; label: string; icon: string }[] = [
+  { type: "default", label: "Default", icon: "↖" },
+  { type: "glow", label: "Glow", icon: "✨" },
+  { type: "trail", label: "Trail", icon: "☄️" },
+  { type: "sparkle", label: "Sparkle", icon: "⭐" },
+];
+
+export default function CursorSwitcher() {
+  const { cursor, setCursor } = useCursor();
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const currentOption = cursorOptions.find((o) => o.type === cursor) || cursorOptions[0];
+
+  return (
+    <div className="relative inline-block text-left" ref={dropdownRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        type="button"
+        className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-lg border border-slate-300 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors shadow-sm"
+        aria-expanded={isOpen}
+      >
+        <span>{currentOption.icon}</span>
+        <span className="hidden sm:inline">Cursor: {currentOption.label}</span>
+        <svg className="w-4 h-4 ml-1 opacity-60" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-40 origin-top-right rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 shadow-xl py-1 z-50">
+          {cursorOptions.map((option) => (
+            <button
+              key={option.type}
+              onClick={() => {
+                setCursor(option.type);
+                setIsOpen(false);
+              }}
+              className={`w-full text-left px-4 py-2 text-sm flex items-center gap-2 transition-colors ${
+                cursor === option.type
+                  ? "bg-indigo-50 dark:bg-indigo-950/50 text-indigo-600 dark:text-indigo-400 font-semibold"
+                  : "text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800"
+              }`}
+            >
+              <span>{option.icon}</span>
+              <span>{option.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CustomCursor.tsx
+++ b/src/components/CustomCursor.tsx
@@ -1,0 +1,144 @@
+import React, { useEffect, useState } from "react";
+import { useCursor } from "@site/src/contexts/CursorContext";
+import "@site/src/css/custom-cursor.css";
+
+interface TrailPoint {
+  x: number;
+  y: number;
+  id: number;
+}
+
+interface SparkleParticle {
+  x: number;
+  y: number;
+  size: number;
+  color: string;
+  id: number;
+  vx: number;
+  vy: number;
+}
+
+export default function CustomCursor() {
+  const { cursor } = useCursor();
+  const [pos, setPos] = useState({ x: -100, y: -100 });
+  const [trail, setTrail] = useState<TrailPoint[]>([]);
+  const [sparkles, setSparkles] = useState<SparkleParticle[]>([]);
+
+  useEffect(() => {
+    if (cursor === "default") return;
+
+    let animationFrameId: number;
+    let lastSparkleTime = 0;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const { clientX: x, clientY: y } = e;
+      setPos({ x, y });
+
+      if (cursor === "trail") {
+        setTrail((prev) => [...prev.slice(-12), { x, y, id: Date.now() + Math.random() }]);
+      }
+
+      if (cursor === "sparkle" && Date.now() - lastSparkleTime > 50) {
+        lastSparkleTime = Date.now();
+        const colors = ["#60A5FA", "#38BDF8", "#818CF8", "#C084FC", "#34D399"];
+        const newSparkle: SparkleParticle = {
+          x,
+          y,
+          size: Math.random() * 6 + 4,
+          color: colors[Math.floor(Math.random() * colors.length)],
+          id: Date.now() + Math.random(),
+          vx: (Math.random() - 0.5) * 2,
+          vy: (Math.random() - 0.5) * 2 - 1,
+        };
+        setSparkles((prev) => [...prev.slice(-15), newSparkle]);
+      }
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+
+    const updateSparkles = () => {
+      setSparkles((prev) =>
+        prev
+          .map((p) => ({ ...p, x: p.x + p.vx, y: p.y + p.vy, size: p.size * 0.92 }))
+          .filter((p) => p.size > 0.5)
+      );
+      animationFrameId = requestAnimationFrame(updateSparkles);
+    };
+
+    if (cursor === "sparkle") {
+      animationFrameId = requestAnimationFrame(updateSparkles);
+    }
+
+    return () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      if (animationFrameId) cancelAnimationFrame(animationFrameId);
+    };
+  }, [cursor]);
+
+  if (cursor === "default") return null;
+
+  return (
+    <div className="custom-cursor-container pointer-events-none fixed inset-0 z-[999999] overflow-hidden">
+      {/* Glow Cursor */}
+      {cursor === "glow" && (
+        <div
+          className="absolute rounded-full pointer-events-none transition-transform duration-75 ease-out bg-indigo-500/20 blur-xl"
+          style={{
+            width: "120px",
+            height: "120px",
+            transform: `translate3d(${pos.x - 60}px, ${pos.y - 60}px, 0)`,
+          }}
+        />
+      )}
+
+      {/* Trail Cursor */}
+      {cursor === "trail" && (
+        <>
+          {trail.map((pt, idx) => (
+            <div
+              key={pt.id}
+              className="absolute rounded-full bg-cyan-400 pointer-events-none"
+              style={{
+                width: `${Math.max(2, (idx / trail.length) * 10)}px`,
+                height: `${Math.max(2, (idx / trail.length) * 10)}px`,
+                transform: `translate3d(${pt.x}px, ${pt.y}px, 0)`,
+                opacity: idx / trail.length,
+              }}
+            />
+          ))}
+          <div
+            className="absolute w-3 h-3 bg-cyan-400 rounded-full shadow-lg shadow-cyan-500/50 pointer-events-none"
+            style={{
+              transform: `translate3d(${pos.x - 6}px, ${pos.y - 6}px, 0)`,
+            }}
+          />
+        </>
+      )}
+
+      {/* Sparkle Cursor */}
+      {cursor === "sparkle" && (
+        <>
+          {sparkles.map((sp) => (
+            <div
+              key={sp.id}
+              className="absolute rounded-full pointer-events-none"
+              style={{
+                width: `${sp.size}px`,
+                height: `${sp.size}px`,
+                backgroundColor: sp.color,
+                boxShadow: `0 0 8px ${sp.color}`,
+                transform: `translate3d(${sp.x}px, ${sp.y}px, 0)`,
+              }}
+            />
+          ))}
+          <div
+            className="absolute w-4 h-4 border-2 border-purple-400 rotate-45 pointer-events-none"
+            style={{
+              transform: `translate3d(${pos.x - 8}px, ${pos.y - 8}px, 0) rotate(45deg)`,
+            }}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/contexts/CursorContext.tsx
+++ b/src/contexts/CursorContext.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, useState, useEffect, useMemo } from "react";
+
+export type CursorType = "default" | "glow" | "trail" | "sparkle";
+
+interface CursorContextValue {
+  cursor: CursorType;
+  setCursor: (cursor: CursorType) => void;
+}
+
+const CURSOR_STORAGE_KEY = "algo.cursor.v1";
+
+const CursorContext = createContext<CursorContextValue | undefined>(undefined);
+
+function safeWindow() {
+  return typeof window !== "undefined" ? window : undefined;
+}
+
+export function CursorProvider({ children }: { children: React.ReactNode }) {
+  const [cursor, setCursorState] = useState<CursorType>(() => {
+    const scope = safeWindow();
+    if (!scope) return "default";
+    try {
+      const stored = scope.localStorage.getItem(CURSOR_STORAGE_KEY) as CursorType;
+      return stored && ["default", "glow", "trail", "sparkle"].includes(stored) ? stored : "default";
+    } catch {
+      return "default";
+    }
+  });
+
+  const setCursor = (newCursor: CursorType) => {
+    setCursorState(newCursor);
+    const scope = safeWindow();
+    if (scope) {
+      scope.localStorage.setItem(CURSOR_STORAGE_KEY, newCursor);
+    }
+  };
+
+  useEffect(() => {
+    if (cursor === "default") {
+      document.body.style.cursor = "auto";
+    } else {
+      document.body.style.cursor = "none";
+    }
+  }, [cursor]);
+
+  const value = useMemo(() => ({ cursor, setCursor }), [cursor]);
+
+  return <CursorContext.Provider value={value}>{children}</CursorContext.Provider>;
+}
+
+export function useCursor() {
+  const context = useContext(CursorContext);
+  if (!context) {
+    throw new Error("useCursor must be used within a CursorProvider");
+  }
+  return context;
+}

--- a/src/css/custom-cursor.css
+++ b/src/css/custom-cursor.css
@@ -1,0 +1,10 @@
+.custom-cursor-container {
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Ensure custom cursor overrides standard cursor when active */
+body.custom-cursor-active,
+body.custom-cursor-active * {
+  cursor: none !important;
+}

--- a/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,9 +1,11 @@
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
 import ThemePicker from '@site/src/components/ThemePicker';
 import CodeThemePicker from '@site/src/components/CodeThemePicker';
+import CursorSwitcher from '@site/src/components/CursorSwitcher';
 
 export default {
   ...ComponentTypes,
   'custom-themePicker': ThemePicker,
   'custom-codeThemePicker': CodeThemePicker,
+  'custom-cursorSwitcher': CursorSwitcher,
 };

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -10,6 +10,8 @@ import useKeyboardShortcuts from "../hooks/useKeyboardShortcuts";
 import PageProgressIndicator from "../components/PageProgressIndicator";
 import SidebarUpdater from '../components/ProgressTracker/SidebarUpdater';
 import { AuthProvider } from "../contexts/AuthContext";
+import { CursorProvider } from "../contexts/CursorContext";
+import CustomCursor from "../components/CustomCursor";
  
 export default function Root({ children }) {
   const location = useLocation();
@@ -56,22 +58,25 @@ export default function Root({ children }) {
         <meta httpEquiv="Content-Security-Policy" content="frame-ancestors 'self';" />
       </Head>
       <AuthProvider>
-        <SidebarUpdater />
-        {isDocsPage && <PageProgressIndicator />}
-        {children}
-        <KeyboardShortcutsButton onClick={onOpenHelp} />
-        <KeyboardShortcutsModal
-          isOpen={showKeyboardModal}
-          onClose={onCloseHelp}
-        />
-        <ChallengeSearchModal
-          isOpen={showChallengeSearch}
-          onClose={onCloseSearch}
-        />
-        <ThemePickerModal
-          isOpen={showThemePicker}
-          onClose={onCloseThemePicker}
-        />
+        <CursorProvider>
+          <CustomCursor />
+          <SidebarUpdater />
+          {isDocsPage && <PageProgressIndicator />}
+          {children}
+          <KeyboardShortcutsButton onClick={onOpenHelp} />
+          <KeyboardShortcutsModal
+            isOpen={showKeyboardModal}
+            onClose={onCloseHelp}
+          />
+          <ChallengeSearchModal
+            isOpen={showChallengeSearch}
+            onClose={onCloseSearch}
+          />
+          <ThemePickerModal
+            isOpen={showThemePicker}
+            onClose={onCloseThemePicker}
+          />
+        </CursorProvider>
       </AuthProvider>
     </>
   );


### PR DESCRIPTION
## 📥 Pull Request

### Description
This pull request introduces an interactive custom cursor switcher feature to the Docusaurus project. It allows users to dynamically switch between different cursor modes (Default, Glow, Trail, and Sparkle) directly from the navigation bar, enhancing user engagement and visual interactivity across the site.

Fixes #3666

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Screenshot of working 
<img width="1710" height="985" alt="image" src="https://github.com/user-attachments/assets/13cfe533-8881-4b2f-b757-6e875d8ca66c" />
<img width="1710" height="985" alt="Screenshot 2026-08-05 at 4 07 39 PM" src="https://github.com/user-attachments/assets/751bbebb-ce5f-4891-aaca-1e1dfb77ea01" />
<img width="1710" height="985" alt="Screenshot 2026-08-05 at 4 07 31 PM" src="https://github.com/user-attachments/assets/a1aa0dd8-3a17-4388-a6f8-f44f1c6fb008" />
<img width="1710" height="985" alt="Screenshot 2026-08-05 at 4 07 46 PM" src="https://github.com/user-attachments/assets/9816908f-804f-43b2-a220-38a361315b38" />


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules