### PR TITLE
auto GSSoC label to PR

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,0 +1,26 @@
+name: Auto GSSoC label to PR
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions: 
+  pull-requests: write
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Add GSSoC label
+        uses: actions/github-script@v7
+        
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ["gssoc:approved"],
+            });
+            


### PR DESCRIPTION
### Description

This pull request introduces a new GitHub Actions workflow to automate the process of labeling incoming pull requests with gssoc:approved. This removes the manual overhead for maintainers who previously had to tag these PRs by hand.

Fixes #3676

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas

<img width="802" height="537" alt="Screenshot 2026-07-28 171751" src="https://github.com/user-attachments/assets/a04f8e5b-3876-4d97-9364-ced4034fe724" />

reveiw under gssoc 