### PR TITLE
feat(ui): add side-by-side multi-language algorithm comparator

### DIFF
--- a/docs/extra/advance-data-structure/heavy-light-decomposition.md
+++ b/docs/extra/advance-data-structure/heavy-light-decomposition.md
@@ -251,6 +251,10 @@ function pathQuery(u, v):
     return result
 ```
 
+## Compare Languages Side-by-Side
+
+<LanguageComparator algorithm="heavy-light-decomposition" />
+
 ## Complexity Cheat Sheet
 
 | Operation | Time Complexity | Space Complexity |

--- a/docs/extra/advance-data-structure/persistent-segment-tree.md
+++ b/docs/extra/advance-data-structure/persistent-segment-tree.md
@@ -246,6 +246,10 @@ function query(node, start, end, l, r):
     return query(node.left, start, mid, l, r) + query(node.right, mid + 1, end, l, r)
 ```
 
+## Compare Languages Side-by-Side
+
+<LanguageComparator algorithm="persistent-segment-tree" />
+
 ## Complexity Cheat Sheet
 
 | Operation | Time Complexity | Extra Space per Call |

--- a/docs/extra/advance-data-structure/sqrt-decomposition.md
+++ b/docs/extra/advance-data-structure/sqrt-decomposition.md
@@ -188,6 +188,12 @@ function update(idx, val):
     arr[idx] = val
 ```
 
+## Compare Languages Side-by-Side
+
+Pick any two languages below to see the same logic next to each other — useful if you know one of these languages and are mapping the syntax onto the other.
+
+<LanguageComparator algorithm="sqrt-decomposition" />
+
 ## Complexity Cheat Sheet
 
 | Operation | Time Complexity | Space Complexity |

--- a/src/components/LanguageComparator/index.tsx
+++ b/src/components/LanguageComparator/index.tsx
@@ -1,0 +1,134 @@
+import React, { useMemo, useState } from "react";
+import CodeBlock from "@theme/CodeBlock";
+import { FaExchangeAlt } from "react-icons/fa";
+import { CODE_SNIPPET_REGISTRY, ComparatorEntry, LanguageSnippet } from "../../data/codeSnippets";
+import styles from "./styles.module.css";
+
+interface LanguageComparatorProps {
+  /**
+   * Key into CODE_SNIPPET_REGISTRY (src/data/codeSnippets/index.ts).
+   * Use this in docs: <LanguageComparator algorithm="sqrt-decomposition" />
+   */
+  algorithm?: string;
+  /**
+   * Or pass a snippet set directly, e.g. from an MDX file that wants
+   * one-off snippets without touching the shared registry.
+   */
+  snippets?: Record<string, LanguageSnippet>;
+  title?: string;
+  /** Which two languages are pre-selected on first render (language keys) */
+  defaultLeft?: string;
+  defaultRight?: string;
+}
+
+/**
+ * Renders two dropdowns for picking a language on each side, then shows
+ * the matching code for the same algorithm side-by-side (stacked on
+ * mobile). Distinct from Docusaurus <Tabs>, which only shows one
+ * language at a time — this lets a learner map syntax between two
+ * languages directly, e.g. "what does this Python line look like in Rust?"
+ */
+const LanguageComparator: React.FC<LanguageComparatorProps> = ({
+  algorithm,
+  snippets,
+  title,
+  defaultLeft,
+  defaultRight,
+}) => {
+  const entry: ComparatorEntry | undefined = algorithm
+    ? CODE_SNIPPET_REGISTRY[algorithm]
+    : snippets
+    ? { title: title ?? "Compare Languages", languages: snippets }
+    : undefined;
+
+  const languageKeys = useMemo(() => (entry ? Object.keys(entry.languages) : []), [entry]);
+
+  const [leftLang, setLeftLang] = useState(
+    defaultLeft && languageKeys.includes(defaultLeft) ? defaultLeft : languageKeys[0]
+  );
+  const [rightLang, setRightLang] = useState(
+    defaultRight && languageKeys.includes(defaultRight)
+      ? defaultRight
+      : languageKeys[1] ?? languageKeys[0]
+  );
+
+  if (!entry || languageKeys.length === 0) {
+    if (algorithm) {
+      // Fail loudly in a way that's easy to spot in a PR review, rather than
+      // silently rendering nothing if someone typos an algorithm id.
+      return (
+        <div className={styles.container} style={{ padding: 16 }}>
+          <strong>LanguageComparator:</strong> no snippets found for algorithm id{" "}
+          <code>{algorithm}</code>. Check <code>src/data/codeSnippets/index.ts</code>.
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const handleSwap = () => {
+    setLeftLang(rightLang);
+    setRightLang(leftLang);
+  };
+
+  const left = entry.languages[leftLang];
+  const right = entry.languages[rightLang];
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <h4 className={styles.title}>{title ?? entry.title}</h4>
+        <div className={styles.controls}>
+          <select
+            className={styles.select}
+            value={leftLang}
+            onChange={(e) => setLeftLang(e.target.value)}
+            aria-label="Left language"
+          >
+            {languageKeys.map((key) => (
+              <option key={key} value={key}>
+                {entry.languages[key].label}
+              </option>
+            ))}
+          </select>
+
+          <button
+            type="button"
+            className={styles.swapButton}
+            onClick={handleSwap}
+            aria-label="Swap languages"
+            title="Swap sides"
+          >
+            <FaExchangeAlt />
+          </button>
+
+          <select
+            className={styles.select}
+            value={rightLang}
+            onChange={(e) => setRightLang(e.target.value)}
+            aria-label="Right language"
+          >
+            {languageKeys.map((key) => (
+              <option key={key} value={key}>
+                {entry.languages[key].label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className={styles.panes}>
+        <div className={styles.pane}>
+          <div className={styles.paneLabel}>{left.label}</div>
+          <CodeBlock language={left.language}>{left.code}</CodeBlock>
+        </div>
+        <div className={styles.pane}>
+          <div className={styles.paneLabel}>{right.label}</div>
+          <CodeBlock language={right.language}>{right.code}</CodeBlock>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LanguageComparator;

--- a/src/components/LanguageComparator/styles.module.css
+++ b/src/components/LanguageComparator/styles.module.css
@@ -1,0 +1,105 @@
+.container {
+  margin: 1.75rem 0;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 12px;
+  background: var(--ifm-background-surface-color);
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-color-emphasis-100);
+}
+
+.title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--ifm-heading-color);
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.select {
+  font-size: 0.85rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 600;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  cursor: pointer;
+}
+
+.swapButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+  color: var(--ifm-color-primary);
+  cursor: pointer;
+  font-size: 13px;
+  flex-shrink: 0;
+}
+
+.swapButton:hover {
+  background: var(--ifm-color-primary-lightest);
+}
+
+.panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.pane {
+  min-width: 0;
+}
+
+.pane:first-child {
+  border-right: 1px solid var(--ifm-color-emphasis-300);
+}
+
+.paneLabel {
+  font-size: 0.7rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-font-color-secondary);
+  padding: 8px 14px 0;
+  opacity: 0.75;
+}
+
+.pane :global(div[class*="codeBlockContainer"]) {
+  border-radius: 0;
+  border: none;
+  margin: 0;
+}
+
+/* Stack panes on narrow viewports instead of squeezing two columns */
+@media (max-width: 760px) {
+  .panes {
+    grid-template-columns: 1fr;
+  }
+
+  .pane:first-child {
+    border-right: none;
+    border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  }
+}

--- a/src/data/codeSnippets/index.ts
+++ b/src/data/codeSnippets/index.ts
@@ -1,0 +1,471 @@
+/**
+ * Central registry of code-snippet sets used by <LanguageComparator />.
+ *
+ * Each entry maps an algorithm id to a small set of language implementations.
+ * Doc authors reference an entry by id (see MDXComponents.js registration):
+ *
+ *   <LanguageComparator algorithm="sqrt-decomposition" />
+ *
+ * Add a new algorithm by adding a new key here — no changes needed to the
+ * component itself.
+ */
+
+export interface LanguageSnippet {
+  label: string;
+  language: string; // Prism language id
+  code: string;
+}
+
+export interface ComparatorEntry {
+  title: string;
+  languages: Record<string, LanguageSnippet>;
+}
+
+export const CODE_SNIPPET_REGISTRY: Record<string, ComparatorEntry> = {
+  "sqrt-decomposition": {
+    title: "Sqrt Decomposition — Range Sum Query",
+    languages: {
+      cpp: {
+        label: "C++",
+        language: "cpp",
+        code: `class SqrtDecomposition {
+    vector<int> arr;
+    vector<long long> blockSum;
+    int n, blockSize;
+
+public:
+    SqrtDecomposition(vector<int>& input) {
+        arr = input;
+        n = arr.size();
+        blockSize = max(1, (int)sqrt(n));
+        blockSum.assign((n / blockSize) + 1, 0);
+        for (int i = 0; i < n; i++) {
+            blockSum[i / blockSize] += arr[i];
+        }
+    }
+
+    long long query(int l, int r) {
+        long long sum = 0;
+        while (l <= r) {
+            int startOfBlock = (l / blockSize) * blockSize;
+            int endOfBlock = min(startOfBlock + blockSize - 1, n - 1);
+            if (startOfBlock == l && endOfBlock <= r) {
+                sum += blockSum[l / blockSize];
+                l = endOfBlock + 1;
+            } else {
+                sum += arr[l];
+                l++;
+            }
+        }
+        return sum;
+    }
+
+    void update(int idx, int val) {
+        blockSum[idx / blockSize] += (val - arr[idx]);
+        arr[idx] = val;
+    }
+};`,
+      },
+      java: {
+        label: "Java",
+        language: "java",
+        code: `class SqrtDecomposition {
+    private int[] arr;
+    private long[] blockSum;
+    private int n, blockSize;
+
+    public SqrtDecomposition(int[] input) {
+        arr = input.clone();
+        n = arr.length;
+        blockSize = Math.max(1, (int) Math.sqrt(n));
+        blockSum = new long[(n / blockSize) + 1];
+        for (int i = 0; i < n; i++) {
+            blockSum[i / blockSize] += arr[i];
+        }
+    }
+
+    public long query(int l, int r) {
+        long sum = 0;
+        while (l <= r) {
+            int startOfBlock = (l / blockSize) * blockSize;
+            int endOfBlock = Math.min(startOfBlock + blockSize - 1, n - 1);
+            if (startOfBlock == l && endOfBlock <= r) {
+                sum += blockSum[l / blockSize];
+                l = endOfBlock + 1;
+            } else {
+                sum += arr[l];
+                l++;
+            }
+        }
+        return sum;
+    }
+
+    public void update(int idx, int val) {
+        blockSum[idx / blockSize] += (val - arr[idx]);
+        arr[idx] = val;
+    }
+}`,
+      },
+      python: {
+        label: "Python",
+        language: "python",
+        code: `import math
+
+class SqrtDecomposition:
+    def __init__(self, arr):
+        self.arr = arr[:]
+        self.n = len(arr)
+        self.block_size = max(1, int(math.sqrt(self.n)))
+        self.block_sum = [0] * ((self.n // self.block_size) + 1)
+        for i, val in enumerate(arr):
+            self.block_sum[i // self.block_size] += val
+
+    def query(self, l, r):
+        total = 0
+        while l <= r:
+            start_of_block = (l // self.block_size) * self.block_size
+            end_of_block = min(start_of_block + self.block_size - 1, self.n - 1)
+            if start_of_block == l and end_of_block <= r:
+                total += self.block_sum[l // self.block_size]
+                l = end_of_block + 1
+            else:
+                total += self.arr[l]
+                l += 1
+        return total
+
+    def update(self, idx, val):
+        self.block_sum[idx // self.block_size] += (val - self.arr[idx])
+        self.arr[idx] = val`,
+      },
+    },
+  },
+
+  "persistent-segment-tree": {
+    title: "Persistent Segment Tree — Versioned Range Sum",
+    languages: {
+      cpp: {
+        label: "C++",
+        language: "cpp",
+        code: `struct Node {
+    long long sum;
+    Node *left, *right;
+    Node(long long val = 0, Node* l = nullptr, Node* r = nullptr)
+        : sum(val), left(l), right(r) {}
+};
+
+class PersistentSegmentTree {
+    int n;
+    vector<Node*> roots; // roots[v] = root of version v
+
+    Node* build(vector<int>& arr, int start, int end) {
+        if (start == end) return new Node(arr[start]);
+        int mid = (start + end) / 2;
+        Node* l = build(arr, start, mid);
+        Node* r = build(arr, mid + 1, end);
+        return new Node(l->sum + r->sum, l, r);
+    }
+
+    Node* update(Node* prev, int start, int end, int idx, int val) {
+        if (start == end) return new Node(val);
+        int mid = (start + end) / 2;
+        if (idx <= mid) {
+            Node* newLeft = update(prev->left, start, mid, idx, val);
+            return new Node(newLeft->sum + prev->right->sum, newLeft, prev->right);
+        } else {
+            Node* newRight = update(prev->right, mid + 1, end, idx, val);
+            return new Node(prev->left->sum + newRight->sum, prev->left, newRight);
+        }
+    }
+
+    long long query(Node* node, int start, int end, int l, int r) {
+        if (r < start || end < l) return 0;
+        if (l <= start && end <= r) return node->sum;
+        int mid = (start + end) / 2;
+        return query(node->left, start, mid, l, r) +
+               query(node->right, mid + 1, end, l, r);
+    }
+
+public:
+    PersistentSegmentTree(vector<int>& arr) {
+        n = arr.size();
+        roots.push_back(build(arr, 0, n - 1)); // version 0
+    }
+
+    int update(int version, int idx, int val) {
+        roots.push_back(update(roots[version], 0, n - 1, idx, val));
+        return roots.size() - 1;
+    }
+
+    long long query(int version, int l, int r) {
+        return query(roots[version], 0, n - 1, l, r);
+    }
+};`,
+      },
+      java: {
+        label: "Java",
+        language: "java",
+        code: `class PersistentSegmentTree {
+    static class Node {
+        long sum;
+        Node left, right;
+        Node(long sum, Node left, Node right) {
+            this.sum = sum;
+            this.left = left;
+            this.right = right;
+        }
+    }
+
+    private int n;
+    private java.util.List<Node> roots = new java.util.ArrayList<>();
+
+    private Node build(int[] arr, int start, int end) {
+        if (start == end) return new Node(arr[start], null, null);
+        int mid = (start + end) / 2;
+        Node l = build(arr, start, mid);
+        Node r = build(arr, mid + 1, end);
+        return new Node(l.sum + r.sum, l, r);
+    }
+
+    private Node update(Node prev, int start, int end, int idx, int val) {
+        if (start == end) return new Node(val, null, null);
+        int mid = (start + end) / 2;
+        if (idx <= mid) {
+            Node newLeft = update(prev.left, start, mid, idx, val);
+            return new Node(newLeft.sum + prev.right.sum, newLeft, prev.right);
+        } else {
+            Node newRight = update(prev.right, mid + 1, end, idx, val);
+            return new Node(prev.left.sum + newRight.sum, prev.left, newRight);
+        }
+    }
+
+    private long query(Node node, int start, int end, int l, int r) {
+        if (r < start || end < l) return 0;
+        if (l <= start && end <= r) return node.sum;
+        int mid = (start + end) / 2;
+        return query(node.left, start, mid, l, r) + query(node.right, mid + 1, end, l, r);
+    }
+
+    public PersistentSegmentTree(int[] arr) {
+        n = arr.length;
+        roots.add(build(arr, 0, n - 1)); // version 0
+    }
+
+    public int update(int version, int idx, int val) {
+        roots.add(update(roots.get(version), 0, n - 1, idx, val));
+        return roots.size() - 1;
+    }
+
+    public long query(int version, int l, int r) {
+        return query(roots.get(version), 0, n - 1, l, r);
+    }
+}`,
+      },
+      python: {
+        label: "Python",
+        language: "python",
+        code: `class Node:
+    __slots__ = ("sum", "left", "right")
+    def __init__(self, sum_val=0, left=None, right=None):
+        self.sum = sum_val
+        self.left = left
+        self.right = right
+
+class PersistentSegmentTree:
+    def __init__(self, arr):
+        self.n = len(arr)
+        self.roots = [self._build(arr, 0, self.n - 1)]  # version 0
+
+    def _build(self, arr, start, end):
+        if start == end:
+            return Node(arr[start])
+        mid = (start + end) // 2
+        left = self._build(arr, start, mid)
+        right = self._build(arr, mid + 1, end)
+        return Node(left.sum + right.sum, left, right)
+
+    def _update(self, prev, start, end, idx, val):
+        if start == end:
+            return Node(val)
+        mid = (start + end) // 2
+        if idx <= mid:
+            new_left = self._update(prev.left, start, mid, idx, val)
+            return Node(new_left.sum + prev.right.sum, new_left, prev.right)
+        else:
+            new_right = self._update(prev.right, mid + 1, end, idx, val)
+            return Node(prev.left.sum + new_right.sum, prev.left, new_right)
+
+    def update(self, version, idx, val):
+        """Creates a new version from \`version\`; returns the new version index."""
+        self.roots.append(self._update(self.roots[version], 0, self.n - 1, idx, val))
+        return len(self.roots) - 1
+
+    def _query(self, node, start, end, l, r):
+        if r < start or end < l:
+            return 0
+        if l <= start and end <= r:
+            return node.sum
+        mid = (start + end) // 2
+        return self._query(node.left, start, mid, l, r) + self._query(node.right, mid + 1, end, l, r)
+
+    def query(self, version, l, r):
+        return self._query(self.roots[version], 0, self.n - 1, l, r)`,
+      },
+    },
+  },
+
+  "heavy-light-decomposition": {
+    title: "Heavy-Light Decomposition — Path Max Query",
+    languages: {
+      cpp: {
+        label: "C++",
+        language: "cpp",
+        code: `const int MAXN = 100005;
+vector<int> adj[MAXN];
+int parent_[MAXN], depth_[MAXN], subtreeSize[MAXN], heavyChild[MAXN];
+int chainHead[MAXN], posInBase[MAXN], nodeValue[MAXN];
+int baseArray[MAXN];
+int timer_ = 0;
+int seg[4 * MAXN];
+
+void build(int node, int start, int end) {
+    if (start == end) { seg[node] = baseArray[start]; return; }
+    int mid = (start + end) / 2;
+    build(2 * node, start, mid);
+    build(2 * node + 1, mid + 1, end);
+    seg[node] = max(seg[2 * node], seg[2 * node + 1]);
+}
+
+int query(int node, int start, int end, int l, int r) {
+    if (r < start || end < l) return INT_MIN;
+    if (l <= start && end <= r) return seg[node];
+    int mid = (start + end) / 2;
+    return max(query(2 * node, start, mid, l, r), query(2 * node + 1, mid + 1, end, l, r));
+}
+
+int dfsSize(int u, int p) {
+    parent_[u] = p;
+    subtreeSize[u] = 1;
+    int maxChildSize = 0;
+    for (int v : adj[u]) {
+        if (v == p) continue;
+        depth_[v] = depth_[u] + 1;
+        int childSize = dfsSize(v, u);
+        subtreeSize[u] += childSize;
+        if (childSize > maxChildSize) {
+            maxChildSize = childSize;
+            heavyChild[u] = v;
+        }
+    }
+    return subtreeSize[u];
+}
+
+void dfsHLD(int u, int head) {
+    chainHead[u] = head;
+    posInBase[u] = timer_++;
+    baseArray[posInBase[u]] = nodeValue[u];
+    if (heavyChild[u] != -1)
+        dfsHLD(heavyChild[u], head); // continue same chain
+    for (int v : adj[u]) {
+        if (v != parent_[u] && v != heavyChild[u])
+            dfsHLD(v, v); // start a new chain
+    }
+}
+
+int pathQuery(int u, int v) {
+    int result = INT_MIN;
+    while (chainHead[u] != chainHead[v]) {
+        if (depth_[chainHead[u]] < depth_[chainHead[v]]) swap(u, v);
+        result = max(result, query(1, 0, timer_ - 1, posInBase[chainHead[u]], posInBase[u]));
+        u = parent_[chainHead[u]];
+    }
+    if (depth_[u] > depth_[v]) swap(u, v);
+    result = max(result, query(1, 0, timer_ - 1, posInBase[u], posInBase[v]));
+    return result;
+}`,
+      },
+      python: {
+        label: "Python",
+        language: "python",
+        code: `class HeavyLightDecomposition:
+    def __init__(self, n, adj, values):
+        self.n = n
+        self.adj = adj
+        self.values = values
+        self.parent = [0] * n
+        self.depth = [0] * n
+        self.subtree_size = [1] * n
+        self.heavy_child = [-1] * n
+        self.chain_head = [0] * n
+        self.pos_in_base = [0] * n
+        self.timer = 0
+        self.base_array = [0] * n
+
+        self._dfs_size(0, -1)
+        self._dfs_hld(0, 0)
+        self.seg = [float("-inf")] * (4 * n)
+        self._build(1, 0, n - 1)
+
+    def _dfs_size(self, u, p):
+        self.parent[u] = p
+        size = 1
+        max_child_size = 0
+        for v in self.adj[u]:
+            if v == p:
+                continue
+            self.depth[v] = self.depth[u] + 1
+            child_size = self._dfs_size(v, u)
+            size += child_size
+            if child_size > max_child_size:
+                max_child_size = child_size
+                self.heavy_child[u] = v
+        self.subtree_size[u] = size
+        return size
+
+    def _dfs_hld(self, u, head):
+        self.chain_head[u] = head
+        self.pos_in_base[u] = self.timer
+        self.base_array[self.timer] = self.values[u]
+        self.timer += 1
+        if self.heavy_child[u] != -1:
+            self._dfs_hld(self.heavy_child[u], head)  # extend same chain
+        for v in self.adj[u]:
+            if v != self.parent[u] and v != self.heavy_child[u]:
+                self._dfs_hld(v, v)  # new chain
+
+    def _build(self, node, start, end):
+        if start == end:
+            self.seg[node] = self.base_array[start]
+            return
+        mid = (start + end) // 2
+        self._build(2 * node, start, mid)
+        self._build(2 * node + 1, mid + 1, end)
+        self.seg[node] = max(self.seg[2 * node], self.seg[2 * node + 1])
+
+    def _query(self, node, start, end, l, r):
+        if r < start or end < l:
+            return float("-inf")
+        if l <= start and end <= r:
+            return self.seg[node]
+        mid = (start + end) // 2
+        return max(self._query(2 * node, start, mid, l, r),
+                    self._query(2 * node + 1, mid + 1, end, l, r))
+
+    def path_query(self, u, v):
+        result = float("-inf")
+        while self.chain_head[u] != self.chain_head[v]:
+            if self.depth[self.chain_head[u]] < self.depth[self.chain_head[v]]:
+                u, v = v, u
+            result = max(result, self._query(1, 0, self.n - 1,
+                                               self.pos_in_base[self.chain_head[u]],
+                                               self.pos_in_base[u]))
+            u = self.parent[self.chain_head[u]]
+        if self.depth[u] > self.depth[v]:
+            u, v = v, u
+        result = max(result, self._query(1, 0, self.n - 1, self.pos_in_base[u], self.pos_in_base[v]))
+        return result`,
+      },
+    },
+  },
+};
+
+export type ComparatorAlgorithmId = keyof typeof CODE_SNIPPET_REGISTRY;

--- a/src/data/generated/algorithmDigest.json
+++ b/src/data/generated/algorithmDigest.json
@@ -1,5 +1,53 @@
 [
   {
+    "id": "heavy-light-decomposition",
+    "title": "Heavy-Light Decomposition",
+    "description": "Heavy-Light Decomposition breaks a tree into chains so that path queries and updates can be answered in O(log^2 n) using a Segment Tree.",
+    "permalink": "https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition",
+    "category": "extra",
+    "tags": [
+      "heavy-light decomposition",
+      "trees",
+      "segment trees",
+      "advance data structures"
+    ],
+    "author": "Algo Community",
+    "pubDate": "2026-08-06T03:34:47.389Z",
+    "pubDateFormatted": "Thu, 06 Aug 2026 03:34:47 GMT"
+  },
+  {
+    "id": "persistent-segment-tree",
+    "title": "Persistent Segment Tree",
+    "description": "A Persistent Segment Tree keeps every previous version of itself accessible after an update, enabling efficient queries on historical states of an array.",
+    "permalink": "https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree",
+    "category": "extra",
+    "tags": [
+      "persistent segment tree",
+      "segment trees",
+      "advance data structures",
+      "range queries"
+    ],
+    "author": "Algo Community",
+    "pubDate": "2026-08-06T03:33:55.443Z",
+    "pubDateFormatted": "Thu, 06 Aug 2026 03:33:55 GMT"
+  },
+  {
+    "id": "sqrt-decomposition",
+    "title": "Sqrt Decomposition",
+    "description": "Sqrt Decomposition is a technique that splits an array into blocks of size sqrt(n) to answer range queries and updates faster than brute force.",
+    "permalink": "https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition",
+    "category": "extra",
+    "tags": [
+      "sqrt decomposition",
+      "block decomposition",
+      "advance data structures",
+      "range queries"
+    ],
+    "author": "Algo Community",
+    "pubDate": "2026-08-06T03:33:03.982Z",
+    "pubDateFormatted": "Thu, 06 Aug 2026 03:33:03 GMT"
+  },
+  {
     "id": "roadmap-to-learning-dsa",
     "title": "Roadmap to Learning DSA",
     "description": "A structured roadmap to guide you through mastering Data Structures and Algorithms.",
@@ -12,8 +60,25 @@
       "data-structures"
     ],
     "author": "Algo Community",
-    "pubDate": "2026-08-05T11:23:27.457Z",
-    "pubDateFormatted": "Wed, 05 Aug 2026 11:23:27 GMT"
+    "pubDate": "2026-08-06T03:13:35.060Z",
+    "pubDateFormatted": "Thu, 06 Aug 2026 03:13:35 GMT"
+  },
+  {
+    "id": "accounts-merge",
+    "title": "Accounts Merge",
+    "description": "Solution for LeetCode 721: Accounts Merge, utilizing Graph Traversal and Disjoint Set Union (DSU) to group connected components.",
+    "permalink": "https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/accounts-merge",
+    "category": "dsa-problems",
+    "tags": [
+      "DSA",
+      "leetcode",
+      "graph",
+      "dsu",
+      "union-find"
+    ],
+    "author": "Algo Community",
+    "pubDate": "2026-08-06T03:13:35.060Z",
+    "pubDateFormatted": "Thu, 06 Aug 2026 03:13:35 GMT"
   },
   {
     "id": "algorithm-visualizer",
@@ -31,54 +96,6 @@
     "author": "Algo Community",
     "pubDate": "2026-08-05T11:23:27.446Z",
     "pubDateFormatted": "Wed, 05 Aug 2026 11:23:27 GMT"
-  },
-  {
-    "id": "sqrt-decomposition",
-    "title": "Sqrt Decomposition",
-    "description": "Sqrt Decomposition is a technique that splits an array into blocks of size sqrt(n) to answer range queries and updates faster than brute force.",
-    "permalink": "https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition",
-    "category": "extra",
-    "tags": [
-      "sqrt decomposition",
-      "block decomposition",
-      "advance data structures",
-      "range queries"
-    ],
-    "author": "Algo Community",
-    "pubDate": "2026-08-05T03:21:54.212Z",
-    "pubDateFormatted": "Wed, 05 Aug 2026 03:21:54 GMT"
-  },
-  {
-    "id": "heavy-light-decomposition",
-    "title": "Heavy-Light Decomposition",
-    "description": "Heavy-Light Decomposition breaks a tree into chains so that path queries and updates can be answered in O(log^2 n) using a Segment Tree.",
-    "permalink": "https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition",
-    "category": "extra",
-    "tags": [
-      "heavy-light decomposition",
-      "trees",
-      "segment trees",
-      "advance data structures"
-    ],
-    "author": "Algo Community",
-    "pubDate": "2026-08-05T03:21:54.211Z",
-    "pubDateFormatted": "Wed, 05 Aug 2026 03:21:54 GMT"
-  },
-  {
-    "id": "persistent-segment-tree",
-    "title": "Persistent Segment Tree",
-    "description": "A Persistent Segment Tree keeps every previous version of itself accessible after an update, enabling efficient queries on historical states of an array.",
-    "permalink": "https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree",
-    "category": "extra",
-    "tags": [
-      "persistent segment tree",
-      "segment trees",
-      "advance data structures",
-      "range queries"
-    ],
-    "author": "Algo Community",
-    "pubDate": "2026-08-05T03:21:54.211Z",
-    "pubDateFormatted": "Wed, 05 Aug 2026 03:21:54 GMT"
   },
   {
     "id": "code-editor-sandbox",

--- a/src/data/generated/dsaProblemsIndex.json
+++ b/src/data/generated/dsaProblemsIndex.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-08-05T11:18:02.540Z",
-  "count": 87,
+  "generatedAt": "2026-08-06T03:35:46.348Z",
+  "count": 88,
   "difficulties": [
     "Easy",
     "Medium",
@@ -82,6 +82,10 @@
     {
       "value": "divide-and-conquer",
       "label": "Divide And Conquer"
+    },
+    {
+      "value": "dsu",
+      "label": "Dsu"
     },
     {
       "value": "dynamic-programming",
@@ -230,6 +234,21 @@
     "Netflix"
   ],
   "problems": [
+    {
+      "id": "accounts-merge",
+      "title": "Accounts Merge",
+      "description": "Solution for LeetCode 721: Accounts Merge, utilizing Graph Traversal and Disjoint Set Union (DSU) to group connected components.",
+      "difficulty": "Medium",
+      "tags": [
+        "graph",
+        "dsu",
+        "union-find",
+        "hash-table",
+        "sorting"
+      ],
+      "companies": [],
+      "url": "/docs/dsa-problems/medium/accounts-merge"
+    },
     {
       "id": "add-two-numbers-as-linked-lists",
       "title": "Add two numbers represented as linked lists",
@@ -1469,6 +1488,21 @@
     }
   ],
   "problemsById": {
+    "accounts-merge": {
+      "id": "accounts-merge",
+      "title": "Accounts Merge",
+      "description": "Solution for LeetCode 721: Accounts Merge, utilizing Graph Traversal and Disjoint Set Union (DSU) to group connected components.",
+      "difficulty": "Medium",
+      "tags": [
+        "graph",
+        "dsu",
+        "union-find",
+        "hash-table",
+        "sorting"
+      ],
+      "companies": [],
+      "url": "/docs/dsa-problems/medium/accounts-merge"
+    },
     "add-two-numbers-as-linked-lists": {
       "id": "add-two-numbers-as-linked-lists",
       "title": "Add two numbers represented as linked lists",

--- a/src/theme/MDXComponents.js
+++ b/src/theme/MDXComponents.js
@@ -24,6 +24,7 @@ import RelatedTopics from '@site/src/components/RelatedTopics';
 import DocCardList from '@theme/DocCardList';
 import ComingSoon from '@site/src/components/ComingSoon';
 import CheatSheetExport from '@site/src/components/CheatSheetExport';
+import LanguageComparator from '@site/src/components/LanguageComparator';
  
 export default {
   // Re-use the default mapping
@@ -31,6 +32,7 @@ export default {
   // custom
   Tabs,
   TabItem,
+  LanguageComparator,
   Highlight,
   ArrayVisualizations,
   BubbleSortVisualization,

--- a/static/algorithm-digest.xml
+++ b/static/algorithm-digest.xml
@@ -5,16 +5,52 @@
     <link>https://ajay-dhangar.github.io/algo/newsletter</link>
     <description>Periodic digest summarizing newly merged algorithm docs and problem walkthroughs in Algo.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 05 Aug 2026 11:31:29 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Aug 2026 03:35:48 GMT</lastBuildDate>
     <atom:link href="https://ajay-dhangar.github.io/algo/algorithm-digest.xml" rel="self" type="application/rss+xml"/>
     
+    <item>
+      <title>Heavy-Light Decomposition</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</guid>
+      <description>Heavy-Light Decomposition breaks a tree into chains so that path queries and updates can be answered in O(log^2 n) using a Segment Tree.</description>
+      <pubDate>Thu, 06 Aug 2026 03:34:47 GMT</pubDate>
+      <category>extra</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
+    <item>
+      <title>Persistent Segment Tree</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</guid>
+      <description>A Persistent Segment Tree keeps every previous version of itself accessible after an update, enabling efficient queries on historical states of an array.</description>
+      <pubDate>Thu, 06 Aug 2026 03:33:55 GMT</pubDate>
+      <category>extra</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
+    <item>
+      <title>Sqrt Decomposition</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</guid>
+      <description>Sqrt Decomposition is a technique that splits an array into blocks of size sqrt(n) to answer range queries and updates faster than brute force.</description>
+      <pubDate>Thu, 06 Aug 2026 03:33:03 GMT</pubDate>
+      <category>extra</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
     <item>
       <title>Roadmap to Learning DSA</title>
       <link>https://ajay-dhangar.github.io/algo/docs/data-structures/roadmap-to-dsa</link>
       <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/data-structures/roadmap-to-dsa</guid>
       <description>A structured roadmap to guide you through mastering Data Structures and Algorithms.</description>
-      <pubDate>Wed, 05 Aug 2026 11:23:27 GMT</pubDate>
+      <pubDate>Thu, 06 Aug 2026 03:13:35 GMT</pubDate>
       <category>data-structures</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
+    <item>
+      <title>Accounts Merge</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/accounts-merge</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/accounts-merge</guid>
+      <description>Solution for LeetCode 721: Accounts Merge, utilizing Graph Traversal and Disjoint Set Union (DSU) to group connected components.</description>
+      <pubDate>Thu, 06 Aug 2026 03:13:35 GMT</pubDate>
+      <category>dsa-problems</category>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
     </item>
     <item>
@@ -24,33 +60,6 @@
       <description>An interactive step-by-step visualization sandbox for Bubble Sort, Quick Sort, Merge Sort, and Binary Search algorithms.</description>
       <pubDate>Wed, 05 Aug 2026 11:23:27 GMT</pubDate>
       <category>algorithms</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Sqrt Decomposition</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</guid>
-      <description>Sqrt Decomposition is a technique that splits an array into blocks of size sqrt(n) to answer range queries and updates faster than brute force.</description>
-      <pubDate>Wed, 05 Aug 2026 03:21:54 GMT</pubDate>
-      <category>extra</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Heavy-Light Decomposition</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</guid>
-      <description>Heavy-Light Decomposition breaks a tree into chains so that path queries and updates can be answered in O(log^2 n) using a Segment Tree.</description>
-      <pubDate>Wed, 05 Aug 2026 03:21:54 GMT</pubDate>
-      <category>extra</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Persistent Segment Tree</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</guid>
-      <description>A Persistent Segment Tree keeps every previous version of itself accessible after an update, enabling efficient queries on historical states of an array.</description>
-      <pubDate>Wed, 05 Aug 2026 03:21:54 GMT</pubDate>
-      <category>extra</category>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
     </item>
     <item>
@@ -445,15 +454,6 @@
       <link>https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/cheapest-flights-within-k-stops</link>
       <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/cheapest-flights-within-k-stops</guid>
       <description>Solution for LeetCode 787: Cheapest Flights Within K Stops, utilizing BFS (Modified Dijkstra) to find the cheapest flight path within K stops.</description>
-      <pubDate>Mon, 03 Aug 2026 12:58:55 GMT</pubDate>
-      <category>dsa-problems</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Binary Tree Right Side View</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/binary-tree-right-side-view</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/binary-tree-right-side-view</guid>
-      <description>Solving the Binary Tree Right Side View problem using a Depth-First Search (DFS) approach.</description>
       <pubDate>Mon, 03 Aug 2026 12:58:55 GMT</pubDate>
       <category>dsa-problems</category>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>

--- a/static/rss/algorithm-digest.xml
+++ b/static/rss/algorithm-digest.xml
@@ -5,16 +5,52 @@
     <link>https://ajay-dhangar.github.io/algo/newsletter</link>
     <description>Periodic digest summarizing newly merged algorithm docs and problem walkthroughs in Algo.</description>
     <language>en-us</language>
-    <lastBuildDate>Wed, 05 Aug 2026 11:31:29 GMT</lastBuildDate>
+    <lastBuildDate>Thu, 06 Aug 2026 03:35:48 GMT</lastBuildDate>
     <atom:link href="https://ajay-dhangar.github.io/algo/algorithm-digest.xml" rel="self" type="application/rss+xml"/>
     
+    <item>
+      <title>Heavy-Light Decomposition</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</guid>
+      <description>Heavy-Light Decomposition breaks a tree into chains so that path queries and updates can be answered in O(log^2 n) using a Segment Tree.</description>
+      <pubDate>Thu, 06 Aug 2026 03:34:47 GMT</pubDate>
+      <category>extra</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
+    <item>
+      <title>Persistent Segment Tree</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</guid>
+      <description>A Persistent Segment Tree keeps every previous version of itself accessible after an update, enabling efficient queries on historical states of an array.</description>
+      <pubDate>Thu, 06 Aug 2026 03:33:55 GMT</pubDate>
+      <category>extra</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
+    <item>
+      <title>Sqrt Decomposition</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</guid>
+      <description>Sqrt Decomposition is a technique that splits an array into blocks of size sqrt(n) to answer range queries and updates faster than brute force.</description>
+      <pubDate>Thu, 06 Aug 2026 03:33:03 GMT</pubDate>
+      <category>extra</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
     <item>
       <title>Roadmap to Learning DSA</title>
       <link>https://ajay-dhangar.github.io/algo/docs/data-structures/roadmap-to-dsa</link>
       <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/data-structures/roadmap-to-dsa</guid>
       <description>A structured roadmap to guide you through mastering Data Structures and Algorithms.</description>
-      <pubDate>Wed, 05 Aug 2026 11:23:27 GMT</pubDate>
+      <pubDate>Thu, 06 Aug 2026 03:13:35 GMT</pubDate>
       <category>data-structures</category>
+      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
+    </item>
+    <item>
+      <title>Accounts Merge</title>
+      <link>https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/accounts-merge</link>
+      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/accounts-merge</guid>
+      <description>Solution for LeetCode 721: Accounts Merge, utilizing Graph Traversal and Disjoint Set Union (DSU) to group connected components.</description>
+      <pubDate>Thu, 06 Aug 2026 03:13:35 GMT</pubDate>
+      <category>dsa-problems</category>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
     </item>
     <item>
@@ -24,33 +60,6 @@
       <description>An interactive step-by-step visualization sandbox for Bubble Sort, Quick Sort, Merge Sort, and Binary Search algorithms.</description>
       <pubDate>Wed, 05 Aug 2026 11:23:27 GMT</pubDate>
       <category>algorithms</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Sqrt Decomposition</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/sqrt-decomposition</guid>
-      <description>Sqrt Decomposition is a technique that splits an array into blocks of size sqrt(n) to answer range queries and updates faster than brute force.</description>
-      <pubDate>Wed, 05 Aug 2026 03:21:54 GMT</pubDate>
-      <category>extra</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Heavy-Light Decomposition</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/heavy-light-decomposition</guid>
-      <description>Heavy-Light Decomposition breaks a tree into chains so that path queries and updates can be answered in O(log^2 n) using a Segment Tree.</description>
-      <pubDate>Wed, 05 Aug 2026 03:21:54 GMT</pubDate>
-      <category>extra</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Persistent Segment Tree</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/extra/advance-data-structure/persistent-segment-tree</guid>
-      <description>A Persistent Segment Tree keeps every previous version of itself accessible after an update, enabling efficient queries on historical states of an array.</description>
-      <pubDate>Wed, 05 Aug 2026 03:21:54 GMT</pubDate>
-      <category>extra</category>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
     </item>
     <item>
@@ -445,15 +454,6 @@
       <link>https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/cheapest-flights-within-k-stops</link>
       <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/cheapest-flights-within-k-stops</guid>
       <description>Solution for LeetCode 787: Cheapest Flights Within K Stops, utilizing BFS (Modified Dijkstra) to find the cheapest flight path within K stops.</description>
-      <pubDate>Mon, 03 Aug 2026 12:58:55 GMT</pubDate>
-      <category>dsa-problems</category>
-      <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>
-    </item>
-    <item>
-      <title>Binary Tree Right Side View</title>
-      <link>https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/binary-tree-right-side-view</link>
-      <guid isPermaLink="true">https://ajay-dhangar.github.io/algo/docs/dsa-problems/medium/binary-tree-right-side-view</guid>
-      <description>Solving the Binary Tree Right Side View problem using a Depth-First Search (DFS) approach.</description>
       <pubDate>Mon, 03 Aug 2026 12:58:55 GMT</pubDate>
       <category>dsa-problems</category>
       <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Algo Community</dc:creator>


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces a Multi-Language Side-by-Side Comparator that allows learners to compare the implementation of the same algorithm across two programming languages simultaneously.

Instead of navigating between separate language tabs or pages, users can select any two supported languages (e.g. Python vs Rust, Java vs C++, JavaScript vs Go) from dropdowns and instantly view both implementations next to each other.

This significantly improves the learning experience for users transitioning between programming languages by making syntax differences immediately visible.

Fixes #3668 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
