### PR TITLE
fix: heatmap reads solved problems, not bookmarks 

### DIFF
--- a/src/components/PracticeActivityHeatmapWidget.tsx
+++ b/src/components/PracticeActivityHeatmapWidget.tsx
@@ -30,7 +30,7 @@ export default function PracticeActivityHeatmapWidget() {
   const heatmap = usePracticeActivityHeatmap(28);
   if (!heatmap.loaded) return null;
 
-  const { days, activeDays, totalAttempts } = heatmap;
+  const { days, activeDays, totalAttempts, totalSolved } = heatmap;
   const maxCount = Math.max(...days.map((day) => day.count), 1);
   const weeks = Array.from({ length: Math.ceil(days.length / 7) }, (_, rowIndex) =>
     days.slice(rowIndex * 7, rowIndex * 7 + 7)
@@ -50,12 +50,17 @@ export default function PracticeActivityHeatmapWidget() {
               Practice Activity
             </p>
             <h3 className="text-xl font-extrabold" style={{ color: "var(--ifm-heading-color)" }}>
-              Recent quiz calendar
+              Recent activity calendar
             </h3>
           </div>
           <div className="rounded-2xl bg-slate-50 dark:bg-slate-950/60 p-3 text-[11px] text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-800">
             <div className="font-semibold">{activeDays} active days</div>
-            <div className="mt-1 text-slate-500 dark:text-slate-400">{totalAttempts} quiz attempts</div>
+            {totalAttempts > 0 && (
+              <div className="mt-1 text-slate-500 dark:text-slate-400">{totalAttempts} quiz attempt{totalAttempts === 1 ? "" : "s"}</div>
+            )}
+            {totalSolved > 0 && (
+              <div className="mt-1 text-slate-500 dark:text-slate-400">{totalSolved} problem{totalSolved === 1 ? "" : "s"} solved</div>
+            )}
           </div>
         </div>
 
@@ -70,23 +75,29 @@ export default function PracticeActivityHeatmapWidget() {
 
           <div className="grid grid-cols-7 gap-2">
             {weeks.flatMap((week) =>
-              week.map((day) => (
-                <div
-                  key={day.date}
-                  className={`h-12 rounded-2xl transition-colors duration-200 ${getHeatmapClass(day.count, maxCount)}`}
-                  title={`${day.date}: ${day.count} attempt${day.count === 1 ? "" : "s"}`}
-                >
-                  <div className="flex h-full items-center justify-center text-[11px] font-semibold">
-                    {day.count > 0 ? day.count : ""}
+              week.map((day) => {
+                const parts: string[] = [];
+                if (day.quizCount > 0) parts.push(`${day.quizCount} quiz attempt${day.quizCount === 1 ? "" : "s"}`);
+                if (day.solvedCount > 0) parts.push(`${day.solvedCount} problem${day.solvedCount === 1 ? "" : "s"} solved`);
+                const tooltip = parts.length > 0 ? `${day.date}: ${parts.join(", ")}` : day.date;
+                return (
+                  <div
+                    key={day.date}
+                    className={`h-12 rounded-2xl transition-colors duration-200 ${getHeatmapClass(day.count, maxCount)}`}
+                    title={tooltip}
+                  >
+                    <div className="flex h-full items-center justify-center text-[11px] font-semibold">
+                      {day.count > 0 ? day.count : ""}
+                    </div>
                   </div>
-                </div>
-              ))
+                );
+              })
             )}
           </div>
         </div>
 
         <div className="text-xs leading-relaxed text-slate-500 dark:text-slate-400">
-          This heatmap is generated from quiz attempts already stored in your browser. No new tracking is added.
+          Counts quiz attempts and DSA problems you marked solved. All data stays in your browser.
         </div>
       </div>
     </motion.div>

--- a/src/hooks/usePracticeActivityHeatmap.ts
+++ b/src/hooks/usePracticeActivityHeatmap.ts
@@ -1,16 +1,20 @@
 import { useCallback, useEffect, useState } from "react";
 import { getUserId, safeJsonParse } from "../utils/safeStorage";
 import type { QuizAttemptRecord } from "../utils/safeStorage";
+import { readSolvedDates } from "./useSolvedProblems";
 
 export interface PracticeActivityHeatmapDay {
   date: string;
   count: number;
   dayLabel: string;
+  quizCount: number;
+  solvedCount: number;
 }
 
 export interface PracticeActivityHeatmapData {
   days: PracticeActivityHeatmapDay[];
   totalAttempts: number;
+  totalSolved: number;
   activeDays: number;
   loaded: boolean;
 }
@@ -69,6 +73,7 @@ function getDailyQuizCounts(userPrefix: string | null): Map<string, number> {
 const INITIAL_STATE: PracticeActivityHeatmapData = {
   days: [],
   totalAttempts: 0,
+  totalSolved: 0,
   activeDays: 0,
   loaded: false,
 };
@@ -83,27 +88,50 @@ export function usePracticeActivityHeatmap(windowDays = 28): PracticeActivityHea
 
     const userId = getUserId();
     const userPrefix = userId ? `quiz_attempts_${userId.toLowerCase()}_` : null;
-    const dailyCounts = getDailyQuizCounts(userPrefix);
+    const quizCounts = getDailyQuizCounts(userPrefix);
+
+    // Merge solved-problem timestamps as a second activity source.
+    // Each entry in readSolvedDates() is a Record<problemId, isoString[]>.
+    const solvedDates = readSolvedDates();
+    const solvedCounts = new Map<string, number>();
+    for (const timestamps of Object.values(solvedDates)) {
+      for (const ts of timestamps) {
+        const date = new Date(ts);
+        if (Number.isNaN(date.getTime())) continue;
+        const day = toUtcDateString(date);
+        solvedCounts.set(day, (solvedCounts.get(day) ?? 0) + 1);
+      }
+    }
+
     const windowDates = buildWindowDates(windowDays);
 
-    const days = windowDates.map((date) => ({
-      date,
-      count: dailyCounts.get(date) ?? 0,
-      dayLabel: getWeekdayLabel(date),
-    }));
+    const days = windowDates.map((date) => {
+      const quizCount = quizCounts.get(date) ?? 0;
+      const solvedCount = solvedCounts.get(date) ?? 0;
+      return {
+        date,
+        count: quizCount + solvedCount,
+        quizCount,
+        solvedCount,
+        dayLabel: getWeekdayLabel(date),
+      };
+    });
 
-    const totalAttempts = days.reduce((sum, day) => sum + day.count, 0);
+    const totalAttempts = days.reduce((sum, day) => sum + day.quizCount, 0);
+    const totalSolved = days.reduce((sum, day) => sum + day.solvedCount, 0);
     const activeDays = days.filter((day) => day.count > 0).length;
 
-    setState({ days, totalAttempts, activeDays, loaded: true });
+    setState({ days, totalAttempts, totalSolved, activeDays, loaded: true });
   }, [windowDays]);
 
   useEffect(() => {
     compute();
     window.addEventListener("quizCompleted", compute);
+    window.addEventListener("problemSolved", compute);
     window.addEventListener("storage", compute);
     return () => {
       window.removeEventListener("quizCompleted", compute);
+      window.removeEventListener("problemSolved", compute);
       window.removeEventListener("storage", compute);
     };
   }, [compute]);

--- a/src/hooks/useSolvedProblems.ts
+++ b/src/hooks/useSolvedProblems.ts
@@ -9,6 +9,11 @@
  * This separation fixes the issue where track progress was incorrectly driven
  * by bookmark count instead of actual completion state.
  *
+ * Solve timestamps are persisted separately under "algo.dsa.solved.dates.v1"
+ * as a Record<problemId, isoDateString[]>. This lets the practice activity
+ * heatmap count solved problems as real activity without ever touching the
+ * old bookmark storage key.
+ *
  * SSG-safe: localStorage is only accessed inside useEffect / callbacks,
  * so the initial render always starts with an empty set and hydrates
  * silently after mount.
@@ -16,18 +21,22 @@
 
 import { useState, useEffect, useCallback } from 'react';
 
-const STORAGE_KEY = 'algo.dsa.solved.v1';
+export const SOLVED_STORAGE_KEY = 'algo.dsa.solved.v1';
+export const SOLVED_DATES_STORAGE_KEY = 'algo.dsa.solved.dates.v1';
+
+/** Record<problemId, ISO-date-string[]> — one entry per solve event. */
+export type SolvedDatesMap = Record<string, string[]>;
 
 function readFromStorage(): Set<string> {
   if (typeof window === 'undefined') return new Set();
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.localStorage.getItem(SOLVED_STORAGE_KEY);
     if (!raw) return new Set();
     const parsed = JSON.parse(raw);
     if (Array.isArray(parsed)) return new Set(parsed as string[]);
   } catch {
     // Corrupt value — reset silently
-    window.localStorage.removeItem(STORAGE_KEY);
+    window.localStorage.removeItem(SOLVED_STORAGE_KEY);
   }
   return new Set();
 }
@@ -35,7 +44,35 @@ function readFromStorage(): Set<string> {
 function writeToStorage(ids: Set<string>): void {
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(ids)));
+    window.localStorage.setItem(SOLVED_STORAGE_KEY, JSON.stringify(Array.from(ids)));
+  } catch {
+    // Storage full or unavailable — ignore
+  }
+}
+
+/**
+ * Reads the solve-date map from localStorage.
+ * Returns an empty object on any error.
+ */
+export function readSolvedDates(): SolvedDatesMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(SOLVED_DATES_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as SolvedDatesMap;
+    }
+  } catch {
+    window.localStorage.removeItem(SOLVED_DATES_STORAGE_KEY);
+  }
+  return {};
+}
+
+function writeSolvedDates(map: SolvedDatesMap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SOLVED_DATES_STORAGE_KEY, JSON.stringify(map));
   } catch {
     // Storage full or unavailable — ignore
   }
@@ -61,11 +98,33 @@ export function useSolvedProblems(): UseSolvedProblemsReturn {
   const toggleSolved = useCallback((id: string) => {
     setSolved((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
+      const nowSolved = !next.has(id);
+
+      if (nowSolved) {
         next.add(id);
+        // Record the solve timestamp so the heatmap can count it as activity.
+        const dates = readSolvedDates();
+        dates[id] = [...(dates[id] ?? []), new Date().toISOString()];
+        writeSolvedDates(dates);
+        // Notify the heatmap (and any other listeners) that a solve occurred.
+        window.dispatchEvent(
+          new CustomEvent('problemSolved', { detail: { problemId: id } })
+        );
+      } else {
+        next.delete(id);
+        // Remove the most-recent solve entry on un-solve so the heatmap count
+        // stays consistent, but keep earlier entries so history isn't lost.
+        const dates = readSolvedDates();
+        if (dates[id] && dates[id].length > 0) {
+          dates[id] = dates[id].slice(0, -1);
+          if (dates[id].length === 0) delete dates[id];
+          writeSolvedDates(dates);
+        }
+        window.dispatchEvent(
+          new CustomEvent('problemSolved', { detail: { problemId: id } })
+        );
       }
+
       writeToStorage(next);
       return next;
     });

--- a/src/pages/dsa-problems/track-view.tsx
+++ b/src/pages/dsa-problems/track-view.tsx
@@ -39,7 +39,7 @@ export default function TrackViewPage() {
   const [track, setTrack] = useState<CompanyTrack | null>(null);
   const [notFound, setNotFound] = useState(false);
 
-  const { bookmarks, isBookmarked, toggleBookmark } = useBookmarks();
+  const { isBookmarked, toggleBookmark } = useBookmarks();
   const { isSolved, toggleSolved } = useSolvedProblems();
   const tagLabels = useMemo(() => new Map(data.tags.map((t) => [t.value, t.label])), []);
 
@@ -81,7 +81,6 @@ export default function TrackViewPage() {
 
   const stats = useMemo(() => {
     const byDifficulty = { Easy: 0, Medium: 0, Hard: 0 };
-    const bookmarkedCount = problems.filter((p) => isBookmarked(p.id)).length;
     const solvedCount = problems.filter((p) => p.isAvailable && isSolved(p.id)).length;
     const availableCount = problems.filter((p) => p.isAvailable).length;
 
@@ -93,7 +92,6 @@ export default function TrackViewPage() {
 
     return {
       total: availableCount,
-      bookmarked: bookmarkedCount,
       solved: solvedCount,
       byDifficulty,
       progressPercentage: availableCount > 0 ? Math.round((solvedCount / availableCount) * 100) : 0,


### PR DESCRIPTION
Fix #3684 

- useSolvedProblems: export SOLVED_DATES_STORAGE_KEY and readSolvedDates() helper. On each toggleSolved call, persist a timestamped entry to algo.dsa.solved.dates.v1 and dispatch a problemSolved CustomEvent so listeners can react in real time.

- usePracticeActivityHeatmap: import readSolvedDates and merge solve timestamps as a second activity source alongside quiz_attempts_* keys. Adds quizCount/solvedCount per day, exposes totalSolved in the returned data, and listens to the new problemSolved event so the heatmap updates immediately when a problem is marked solved.

- PracticeActivityHeatmapWidget: consume totalSolved; show separate quiz-attempt and problems-solved lines in the stats card; generate per-day tooltips that distinguish the two activity types; update heading and footer copy to reflect the combined data source.

- track-view.tsx: remove dead bookmarkedCount computation and the stats.bookmarked field - the header stats bar already used stats.solved as the primary metric; the bookmark stat was computed but never rendered.
