### PR TITLE
fix: load JSON digest directly, drop fragile XML pre-fetch 

### DIFF
--- a/src/pages/newsletter/index.tsx
+++ b/src/pages/newsletter/index.tsx
@@ -74,17 +74,19 @@ function NewsletterPageInner() {
   const { copied, copy } = useCopyText();
 
   useEffect(() => {
-    fetch(`${BASE_URL}/algorithm-digest.xml`)
-      .then(() => {
-        // XML loaded OK, now load JSON feed for UI
-        return import("@site/src/data/generated/algorithmDigest.json");
-      })
+    // Load the JSON digest directly — no dependency on the XML RSS file.
+    // The XML is a static asset for external feed readers; it adds no value
+    // to the in-page data load and silently breaks it in local dev where the
+    // static file may not be served.
+    import("@site/src/data/generated/algorithmDigest.json")
       .then((mod) => {
         const data = (mod.default || mod) as DigestEntry[];
         setItems(Array.isArray(data) ? data : []);
-        setLoading(false);
       })
       .catch(() => {
+        // JSON unavailable — page renders empty state, not a blank screen.
+      })
+      .finally(() => {
         setLoading(false);
       });
   }, []);


### PR DESCRIPTION
Fix #3681 

The useEffect previously fetched algorithm-digest.xml and only imported the JSON digest inside that fetch's .then() chain. If the XML fetch failed (e.g. in local dev where static files aren't served), the entire data load was silently swallowed and the page rendered nothing.

The XML file is a static asset for external feed readers; it carries no information needed by the in-page digest stream. Replace the chained fetch → import with a direct dynamic import() of algorithmDigest.json, which is a build-time webpack bundle chunk and is reliably available in every environment.

Also move setLoading(false) into a .finally() block so the loading state is always cleared, even if the import itself throws.


