### PR TITLE
fix: apply custom-cursor-active class so CSS rule is no longer dead code

### DIFF
--- a/src/contexts/CursorContext.tsx
+++ b/src/contexts/CursorContext.tsx
@@ -36,11 +36,14 @@ export function CursorProvider({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
-    if (cursor === "default") {
-      document.body.style.cursor = "auto";
-    } else {
-      document.body.style.cursor = "none";
-    }
+    const isActive = cursor !== "default";
+    // Toggle the CSS class that applies `cursor: none !important` to body and
+    // all its descendants. This is more robust than an inline style, which can
+    // be silently overridden by any component-level CSS that sets `cursor`.
+    document.body.classList.toggle("custom-cursor-active", isActive);
+    // Also clear any residual inline cursor style so the CSS class is the
+    // sole source of truth.
+    document.body.style.cursor = "";
   }, [cursor]);
 
   const value = useMemo(() => ({ cursor, setCursor }), [cursor]);

--- a/src/css/custom-cursor.css
+++ b/src/css/custom-cursor.css
@@ -3,7 +3,9 @@
   user-select: none;
 }
 
-/* Ensure custom cursor overrides standard cursor when active */
+/* Applied by CursorContext when any non-default cursor is active.
+   Using !important on both body and all descendants ensures no component-level
+   cursor style can leak through and show the system pointer over the custom one. */
 body.custom-cursor-active,
 body.custom-cursor-active * {
   cursor: none !important;


### PR DESCRIPTION
Fix #3680

CursorContext.tsx was only setting document.body.style.cursor inline, leaving the body.custom-cursor-active CSS rule in custom-cursor.css as dead code. An inline cursor style can be overridden by any component-level CSS that also sets cursor, silently breaking the custom cursor overlay.

Fix: replace the inline style toggle with classList.toggle() so the CSS class is the authoritative source of truth. The class uses !important and covers all descendants (body.custom-cursor-active *), making it resistant to component-level overrides.

Also clear any residual inline cursor style (style.cursor = '') when the effect runs so the class is never competing with a stale inline value.

Updated the comment in custom-cursor.css to reflect that the class is now actively managed by CursorContext rather than being aspirational.

