### PR TITLE
docs: add description and tags frontmatter to DLX.md (#3540)

### DIFF
--- a/docs/extra/algorithms/DLX algorithm/DLX.md
+++ b/docs/extra/algorithms/DLX algorithm/DLX.md
@@ -4,6 +4,8 @@ id: dancing-links
 sidebar_position: 20  
 title: "Dancing Links (DLX)"  
 sidebar_label: Dancing Links  
+description: "The Dancing Links (DLX) algorithm is a highly efficient implementation of the Exact Cover Problem based on dancing links technique."
+tags: [algorithm, exact cover, backtracking, dlx, dancing links]
 
 ---
 


### PR DESCRIPTION
## 📥 Pull Request

### Description
Added the `description` and `tags` fields to the frontmatter of `docs/extra/algorithms/DLX algorithm/DLX.md`. 
This documentation update improves the SEO discoverability of the DLX page, ensures that the file passes the `validate:docs` CI gate, and maintains consistency across the algorithm documentation within the project.

Fixes #3540

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
