### PR TITLE
fix: use safeGetItem in week-rollover path of WeeklyChallengeSpotlight

### DIFF
--- a/src/components/WeeklyChallengeSpotlight.tsx
+++ b/src/components/WeeklyChallengeSpotlight.tsx
@@ -177,9 +177,7 @@ const WeeklyChallengeSpotlight: React.FC = () => {
         setChallenge(newChallenge);
         setActiveStorageKey(newStorageKey);
         setWeekLabel(`Week ${getISOWeek(tickNow)} · ${tickNow.getUTCFullYear()}`);
-        try {
-          setIsSolved(localStorage.getItem(newStorageKey) === "solved");
-        } catch { /* ignore */ }
+        setIsSolved(safeGetItem(newStorageKey) === "solved");
       }
 
       setCountdown(msToCountdown(msUntilNextMonday(tickNow)));


### PR DESCRIPTION
Fix #3697 

The refactor that introduced safeGetItem/safeSetItem/safeRemoveItem updated the initial useEffect mount and handleToggleSolved, but missed one call site: the tick() inner function that fires on every 1-second interval and refreshes the challenge when the ISO week rolls over.

That path still called localStorage.getItem(newStorageKey) directly inside a bare try/catch, which is the exact pattern the refactor was meant to eliminate and is inconsistent with every other storage access in the component.

Replace with safeGetItem(newStorageKey) and drop the surrounding try/catch - safeGetItem already handles SSR, unavailable storage, and corrupt values internally.


