### PR TITLE
fix: prevent same language on both sides in LanguageComparator

### DIFF
--- a/src/components/LanguageComparator/index.tsx
+++ b/src/components/LanguageComparator/index.tsx
@@ -71,8 +71,35 @@ const LanguageComparator: React.FC<LanguageComparatorProps> = ({
     setRightLang(leftLang);
   };
 
+  /**
+   * When the user picks a language that is already shown on the other side,
+   * automatically move the other side to the next available language so the
+   * two panes never show identical code. Iterates forward from the current
+   * other-side index to find the first key that is not the newly selected one.
+   */
+  const handleLeftChange = (newLeft: string) => {
+    setLeftLang(newLeft);
+    if (newLeft === rightLang) {
+      const fallback = languageKeys.find((k) => k !== newLeft) ?? newLeft;
+      setRightLang(fallback);
+    }
+  };
+
+  const handleRightChange = (newRight: string) => {
+    setRightLang(newRight);
+    if (newRight === leftLang) {
+      const fallback = languageKeys.find((k) => k !== newRight) ?? newRight;
+      setLeftLang(fallback);
+    }
+  };
+
   const left = entry.languages[leftLang];
   const right = entry.languages[rightLang];
+
+  // Only disable the cross-selection option when there are 3+ languages;
+  // with exactly 2 languages the auto-swap above already handles it and
+  // disabling would leave the user unable to reach the other language at all.
+  const canDisable = languageKeys.length > 2;
 
   return (
     <div className={styles.container}>
@@ -82,11 +109,11 @@ const LanguageComparator: React.FC<LanguageComparatorProps> = ({
           <select
             className={styles.select}
             value={leftLang}
-            onChange={(e) => setLeftLang(e.target.value)}
+            onChange={(e) => handleLeftChange(e.target.value)}
             aria-label="Left language"
           >
             {languageKeys.map((key) => (
-              <option key={key} value={key}>
+              <option key={key} value={key} disabled={canDisable && key === rightLang}>
                 {entry.languages[key].label}
               </option>
             ))}
@@ -105,11 +132,11 @@ const LanguageComparator: React.FC<LanguageComparatorProps> = ({
           <select
             className={styles.select}
             value={rightLang}
-            onChange={(e) => setRightLang(e.target.value)}
+            onChange={(e) => handleRightChange(e.target.value)}
             aria-label="Right language"
           >
             {languageKeys.map((key) => (
-              <option key={key} value={key}>
+              <option key={key} value={key} disabled={canDisable && key === leftLang}>
                 {entry.languages[key].label}
               </option>
             ))}


### PR DESCRIPTION
Fix #3698 

Previously both dropdowns used bare onChange handlers that called setLeftLang/setRightLang directly with no guard, allowing the user to select the same language on both sides and render two identical code blocks - a meaningless comparison.

Two complementary fixes:

1. handleLeftChange / handleRightChange - when the newly selected language matches what is already shown on the other side, automatically advance the other side to the first available different language. This handles the 2-language case (only one swap option exists) and makes the 3+ language case feel instant and non-disruptive.

2. disabled option attribute - when there are 3+ languages, the option for the currently selected language on each side is marked disabled in the opposite dropdown. This gives the user a clear visual affordance that the selection is unavailable before they even click. With exactly 2 languages the disabled attr is omitted because it would make the second option permanently un-selectable; the auto-swap above still prevents collisions in that case.


