### PR TITLE
fix: replace fabricated estPRs with real merged-PR count 

### DIFF
--- a/src/pages/contributors/index.tsx
+++ b/src/pages/contributors/index.tsx
@@ -607,7 +607,12 @@ const Contributors: React.FC = () => {
   const stats = useMemo(() => {
     const totalContributors = contributors.length;
     const totalCommits = contributors.reduce((s, c) => s + c.contributions, 0);
-    const estPRs = Math.round(totalCommits * 0.38);
+    // Real merged-PR count from GitHub Search API aggregation, not fabricated.
+    // Falls back to 0 if the hook hasn't loaded yet or the API failed.
+    const totalPRs = Object.values(prStatsByLogin).reduce(
+      (sum, s) => sum + s.mergedPRCount,
+      0
+    );
     const activeCount = contributors.filter((c) => c.contributions >= 5).length;
     const activityScore =
       totalContributors > 0
@@ -621,11 +626,11 @@ const Contributors: React.FC = () => {
     return {
       totalContributors,
       totalCommits,
-      estPRs,
+      totalPRs,
       activeCount,
       activityScore,
     };
-  }, [contributors]);
+  }, [contributors, prStatsByLogin]);
 
   const maxContributions = useMemo(
     () =>
@@ -730,8 +735,8 @@ const Contributors: React.FC = () => {
               />
               <StatCard
                 icon={<FiGitPullRequest className="w-4 h-4" />}
-                label="Est. Pull Requests"
-                value={stats.estPRs}
+                label="Merged Pull Requests"
+                value={stats.totalPRs}
                 color="var(--ifm-color-success, #10b981)"
                 delay={0.26}
               />


### PR DESCRIPTION
fix #3699 

The contributors dashboard was computing:

  estPRs = Math.round(totalCommits * 0.38)

and displaying it as 'Est. Pull Requests'. The 0.38 multiplier is arbitrary - the GitHub contributors API returns commit counts, not PR counts, and there is no reliable linear relationship between the two. Showing a made-up number in a prominent stat card is misleading.

useMergedPRStats already fetches the actual merged-PR history from the GitHub Search API and aggregates it per author. Replace estPRs with:

  totalPRs = Object.values(prStatsByLogin).reduce(
    (sum, s) => sum + s.mergedPRCount, 0
  )

This uses the real count sourced from the same API call the badge system relies on. It falls back to 0 while the hook is loading or if the API is unavailable, which is honest (zero is shown) rather than fabricated.

Also:
- Add prStatsByLogin to the stats useMemo dependency array.
- Rename the stat card label from 'Est. Pull Requests' to 'Merged Pull Requests' to accurately describe what is shown.

