### PR TITLE
fix: keyboard dismiss and focus management for ReadmeBadgeButton popover

### DIFF
--- a/src/components/ContributorBadges/index.tsx
+++ b/src/components/ContributorBadges/index.tsx
@@ -46,7 +46,9 @@ export const ReadmeBadgeButton: React.FC<ReadmeBadgeButtonProps> = ({
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const copyButtonRef = useRef<HTMLButtonElement>(null);
 
+  // Outside-click dismiss
   useEffect(() => {
     if (!open) return;
     const handleClickOutside = (e: MouseEvent) => {
@@ -56,6 +58,25 @@ export const ReadmeBadgeButton: React.FC<ReadmeBadgeButtonProps> = ({
     };
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Keyboard dismiss (Escape key)
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  // Focus management: move focus into the popover when it opens
+  useEffect(() => {
+    if (open && copyButtonRef.current) {
+      copyButtonRef.current.focus();
+    }
   }, [open]);
 
   const best = topBadge(badges);
@@ -83,13 +104,20 @@ export const ReadmeBadgeButton: React.FC<ReadmeBadgeButtonProps> = ({
           e.stopPropagation();
           setOpen((o) => !o);
         }}
+        aria-expanded={open}
+        aria-haspopup="dialog"
       >
         <span aria-hidden="true">🎖️</span>
         README Badge
       </button>
 
       {open && (
-        <div className={styles.popover} onClick={(e) => e.stopPropagation()}>
+        <div 
+          className={styles.popover} 
+          onClick={(e) => e.stopPropagation()}
+          role="dialog"
+          aria-label="README badge markdown"
+        >
           <p className={styles.popoverTitle}>Add this to your README</p>
           <div className={styles.popoverPreview}>
             <img src={imgUrl} alt={`${best.label} badge`} />
@@ -97,7 +125,7 @@ export const ReadmeBadgeButton: React.FC<ReadmeBadgeButtonProps> = ({
           <div className={styles.popoverCodeBox}>
             <code className={styles.popoverCode}>{markdown}</code>
           </div>
-          <button type="button" className={styles.copyButton} onClick={handleCopy}>
+          <button type="button" className={styles.copyButton} onClick={handleCopy} ref={copyButtonRef}>
             {copied ? "Copied!" : "Copy Markdown"}
           </button>
         </div>


### PR DESCRIPTION
fix #3700 

The README Badge popover had outside-click dismiss but no keyboard support, making it inaccessible to keyboard-only users: pressing Escape had no effect and focus remained on the trigger button when the popover opened, leaving users unable to reach the popover content without tabbing through the rest of the page.

Three changes:

1. Escape key dismiss - add a keydown listener on document (active only while open, cleaned up on close) that calls setOpen(false) when Escape is pressed. Follows the same pattern as the existing mousedown listener.

2. Focus management - add copyButtonRef and a useEffect that calls copyButtonRef.current.focus() whenever open transitions to true. This moves keyboard focus into the popover immediately on open, so the user can tab through the content or press Escape to close without hunting.

3. ARIA attributes - add aria-expanded and aria-haspopup='dialog' to the trigger button so screen readers announce the popover state, and role='dialog' with aria-label on the popover element itself so it is announced as a dialog region when focused.


