### PR TITLE
fix: check isBugWord before isDocsWord in categorizePRTitle 

### DIFF
--- a/src/utils/prAchievements.ts
+++ b/src/utils/prAchievements.ts
@@ -48,8 +48,16 @@ export function categorizePRTitle(title: string): PRCategory {
     );
   const isFeatureWord = /\bfeat(ure)?\b|\badd(ed|s)?\b|\bnew\b|\bimplement/.test(t);
 
-  if (isFix && isDocsWord) return "docs";
+  // Check isFix+isBugWord before isFix+isDocsWord: an explicit bug keyword
+  // ("bug", "error", "crash", "issue", "broken") is more specific than a docs
+  // keyword that happened to appear in the same title.
+  // Example that was broken before this fix:
+  //   "fix bug in algorithm documentation" → matched isFix+isDocsWord first → "docs"
+  //   Correct category: "bugfix" (explicit bug keyword wins)
+  // Pure docs fixes like "fix: resolve issue in README" are handled by the
+  // isFix+isDocsWord branch below once isBugWord is confirmed absent.
   if (isFix && isBugWord) return "bugfix";
+  if (isFix && isDocsWord) return "docs";
   if (isAlgoWord) return "algorithm";
   if (isDocsWord) return "docs";
   if (isFeatureWord) return "feature";


### PR DESCRIPTION
fix #3701 

The priority chain in categorizePRTitle() checked (isFix && isDocsWord) before (isFix && isBugWord). A PR title that contains both a docs keyword and a bug keyword - e.g. 'fix bug in algorithm documentation' - matched the docs branch first and was counted as a docs fix, silently removing it from the bugfix count and potentially blocking the contributor from reaching a bugfix-badge tier they had legitimately earned.

Fix: swap the two branches so (isFix && isBugWord) is evaluated first. An explicit bug keyword ('bug', 'error', 'crash', 'issue', 'broken') is more specific than a docs keyword that appeared incidentally in the same title, so it should take precedence.

Pure docs fixes that also happen to match isBugWord (e.g. 'fix: resolve issue in README' - 'issue' is a bug word, 'readme' is a docs word) now correctly classify as 'bugfix'. This is the right outcome: the contributor filed a fix driven by an issue/bug signal. The docs-only path (isFix && isDocsWord with no bug word) is unchanged and still returns 'docs'.

Added explanatory comments above the two branches to make the ordering intent explicit for future contributors.


