### PR TITLE
feat: add GitHub-native discussion threads to documentation pages

### DIFF
--- a/src/components/DocDiscussion/index.tsx
+++ b/src/components/DocDiscussion/index.tsx
@@ -25,7 +25,7 @@ interface DocDiscussionProps {
  */
 export default function DocDiscussion({ title }: DocDiscussionProps): JSX.Element {
   return (
-    <section className="docusaurus-mt-lg mt-10 border-t border-solid border-[var(--ifm-toc-border-color)] pt-8">
+    <section className="docusaurus-mt-lg mt-10 border-t border-solid border-[var(--ifm-toc-border-color)] pt-8 text-center">
       <h2 className="mb-1 text-xl font-semibold">💬 Discuss this page</h2>
       <p className="mb-4 text-sm opacity-80">
         Have a question or spot something confusing{title ? ` in "${title}"` : ""}? Ask below —

--- a/src/components/DocDiscussion/index.tsx
+++ b/src/components/DocDiscussion/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import GiscusComponent from "@site/src/components/GiscusComponent";
+
+interface DocDiscussionProps {
+  /**
+   * Page title, used only for the section heading copy.
+   */
+  title?: string;
+}
+
+/**
+ * DocDiscussion
+ *
+ * Renders a "Discuss this page" section at the bottom of a doc page,
+ * backed by Giscus (GitHub Discussions). Each doc page gets its own
+ * thread because Giscus is configured with `mapping="pathname"` in
+ * GiscusComponent, so a question asked on one page doesn't mix with
+ * another page's thread.
+ *
+ * Maintainers get notified the normal GitHub way (Discussions
+ * notifications) whenever someone comments, with no extra backend.
+ *
+ * Opt-out: set `hide_discussion: true` in a doc's frontmatter to skip
+ * rendering this section on that page (e.g. index/overview pages).
+ */
+export default function DocDiscussion({ title }: DocDiscussionProps): JSX.Element {
+  return (
+    <section className="docusaurus-mt-lg mt-10 border-t border-solid border-[var(--ifm-toc-border-color)] pt-8">
+      <h2 className="mb-1 text-xl font-semibold">💬 Discuss this page</h2>
+      <p className="mb-4 text-sm opacity-80">
+        Have a question or spot something confusing{title ? ` in "${title}"` : ""}? Ask below —
+        it's backed by GitHub Discussions, so maintainers get notified like any other GitHub
+        activity.
+      </p>
+      <GiscusComponent />
+    </section>
+  );
+}

--- a/src/data/generated/docsCatalogIndex.json
+++ b/src/data/generated/docsCatalogIndex.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T16:59:44.062Z",
+  "generatedAt": "2026-08-08T02:35:33.768Z",
   "count": 719,
   "difficulties": [
     "Easy",

--- a/src/data/generated/dsaProblemsIndex.json
+++ b/src/data/generated/dsaProblemsIndex.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-07T16:59:41.203Z",
+  "generatedAt": "2026-08-08T02:35:32.447Z",
   "count": 88,
   "difficulties": [
     "Easy",

--- a/src/theme/DocItem/Footer/index.tsx
+++ b/src/theme/DocItem/Footer/index.tsx
@@ -7,10 +7,10 @@ type Props = Record<string, never>;
 import ProgressTracker from '@site/src/components/ProgressTracker';
 import DocInlineQuiz from '@site/src/components/DocInlineQuiz';
 import RelatedProblems from '@site/src/components/RelatedProblems';
+import DocDiscussion from '@site/src/components/DocDiscussion';
 
 export default function DocItemFooter(props: Props): JSX.Element | null {
-  const { metadata } = useDoc();
-  console.log(metadata);
+  const { metadata, frontMatter } = useDoc();
   const { tags } = metadata;
 
   const topicId = metadata.id.replace(/\//g, '-');
@@ -18,12 +18,17 @@ export default function DocItemFooter(props: Props): JSX.Element | null {
 
   const canRenderTags = tags && tags.length > 0;
 
+  // Allow individual pages to opt out (e.g. category landing / index pages)
+  // by setting `hide_discussion: true` in their frontmatter.
+  const hideDiscussion = Boolean((frontMatter as any)?.hide_discussion);
+
   if (!canRenderTags) {
     return (
       <>
         <DocInlineQuiz />
         <ProgressTracker topicId={topicId} topicTitle={topicTitle} />
         <RelatedProblems />
+        {!hideDiscussion && <DocDiscussion title={topicTitle} />}
       </>
     );
   }
@@ -47,6 +52,8 @@ export default function DocItemFooter(props: Props): JSX.Element | null {
           </div>
         )}
       </footer>
+
+      {!hideDiscussion && <DocDiscussion title={topicTitle} />}
     </>
   );
 }


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR adds GitHub-native discussion threads to every documentation page using Giscus.

Readers can now ask questions, report confusing explanations, share suggestions, and discuss algorithms directly at the bottom of each documentation page. Discussions are backed by GitHub Discussions, so maintainers can manage and respond to them using the existing GitHub workflow without requiring a separate backend or database.

<img width="1600" height="863" alt="image" src="https://github.com/user-attachments/assets/ed22e004-2ca8-4d1f-a99a-bde15e52bbf8" />


Fixes #3711 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
