### PR TITLE
fix: Escape dismiss and focus management for NavbarAuthButton dropdown

### DIFF
--- a/src/components/NavbarAuthButton/index.tsx
+++ b/src/components/NavbarAuthButton/index.tsx
@@ -7,6 +7,7 @@ export default function NavbarAuthButton(): JSX.Element | null {
   const { user, isAuthenticated, isLoading, logout } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const firstItemRef = useRef<HTMLAnchorElement>(null);
 
   // Close profile dropdown when clicking outside
   useEffect(() => {
@@ -20,6 +21,28 @@ export default function NavbarAuthButton(): JSX.Element | null {
 
     document.addEventListener("mousedown", handleClickOutside);
     return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  // Close profile dropdown on Escape key
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  // Move focus into the dropdown when it opens so keyboard users don't
+  // have to Tab from the trigger button through the whole page to reach it.
+  useEffect(() => {
+    if (isOpen && firstItemRef.current) {
+      firstItemRef.current.focus();
+    }
   }, [isOpen]);
 
   // Prevent layout shifts during initial local storage check
@@ -68,6 +91,7 @@ export default function NavbarAuthButton(): JSX.Element | null {
         onClick={() => setIsOpen((prev) => !prev)}
         className="inline-flex items-center gap-2 rounded-full border border-neutral-200 bg-white/80 p-1 pr-2.5 text-xs font-medium text-neutral-700 shadow-sm transition-all hover:bg-neutral-100 dark:border-neutral-800 dark:bg-neutral-900/80 dark:text-neutral-200 dark:hover:bg-neutral-800 focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
         aria-expanded={isOpen}
+        aria-haspopup="menu"
       >
         <div className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-600 font-bold text-white text-[10px] shadow-sm">
           {initials}
@@ -77,7 +101,11 @@ export default function NavbarAuthButton(): JSX.Element | null {
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-xl border border-neutral-200/80 bg-white/95 p-1.5 shadow-xl backdrop-blur-xl dark:border-neutral-800/80 dark:bg-neutral-900/95">
+        <div
+          role="menu"
+          aria-label="User profile menu"
+          className="absolute right-0 z-50 mt-2 w-48 origin-top-right rounded-xl border border-neutral-200/80 bg-white/95 p-1.5 shadow-xl backdrop-blur-xl dark:border-neutral-800/80 dark:bg-neutral-900/95"
+        >
           <div className="px-3 py-2 border-b border-neutral-100 dark:border-neutral-800">
             <p className="text-xs font-semibold text-neutral-900 dark:text-neutral-100 m-0 truncate">
               {user?.name}
@@ -89,6 +117,8 @@ export default function NavbarAuthButton(): JSX.Element | null {
 
           <Link
             to="/profile"
+            ref={firstItemRef}
+            role="menuitem"
             onClick={() => setIsOpen(false)}
             className="flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs text-neutral-700 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800/60 no-underline"
           >
@@ -98,6 +128,7 @@ export default function NavbarAuthButton(): JSX.Element | null {
 
           <button
             type="button"
+            role="menuitem"
             onClick={() => {
               logout();
               setIsOpen(false);


### PR DESCRIPTION
fix #3735

The profile dropdown had mousedown outside-click handling but no keyboard support. A keyboard user who opened the dropdown had no way to close it with Escape and focus remained on the trigger button, requiring them to Tab through all dropdown items (and potentially the rest of the page) to escape it.

Three changes mirroring the same fix applied to ReadmeBadgeButton:

1. Escape key dismiss - new useEffect that listens for keydown on document while the dropdown is open, calls setIsOpen(false) on Escape, and cleans up the listener on close.

2. Focus management - firstItemRef added to the Profile Settings link. A useEffect watching isOpen calls .focus() on it whenever the dropdown opens. Keyboard focus jumps straight to the first actionable item.

3. ARIA attributes:
   - aria-haspopup='menu' added to the trigger button so screen readers announce it as a menu button (was only aria-expanded before).
   - role='menu' and aria-label='User profile menu' added to the dropdown container.
   - role='menuitem' added to both the Profile Settings link and Log Out button so assistive technologies announce them correctly within the menu context.

