### PR TITLE
fix: pass explicit height to Monaco DiffEditor in BruteForceOptimized Diff

### DIFF
--- a/src/components/BruteForceOptimizedDiff/index.tsx
+++ b/src/components/BruteForceOptimizedDiff/index.tsx
@@ -16,6 +16,13 @@ interface BruteForceOptimizedDiffProps {
   bruteForceCode: string;
   optimizedCode: string;
   annotations: DiffAnnotation[];
+  /**
+   * Explicit height for the Monaco DiffEditor.
+   * Monaco editors render into an absolutely-positioned internal container
+   * and cannot infer height from CSS — this prop must be set explicitly.
+   * Defaults to "360px", matching the .editorWrapper min-height in CSS.
+   */
+  editorHeight?: string;
 }
 
 export default function BruteForceOptimizedDiff({
@@ -26,6 +33,7 @@ export default function BruteForceOptimizedDiff({
   bruteForceCode,
   optimizedCode,
   annotations,
+  editorHeight = "360px",
 }: BruteForceOptimizedDiffProps) {
   return (
     <div className={styles.container}>
@@ -54,6 +62,7 @@ export default function BruteForceOptimizedDiff({
                     modified={optimizedCode}
                     language={language}
                     theme="vs-dark"
+                    height={editorHeight}
                     options={{
                       readOnly: true,
                       renderSideBySide: true,


### PR DESCRIPTION
fix #3736

The DiffEditor was rendered without a height prop. Monaco editors render into an absolutely-positioned internal container and cannot infer their height from a CSS min-height or flex:1 parent. Without an explicit height, Monaco sizes itself to 0px and the diff view is completely invisible.

The .editorWrapper CSS already set min-height: 360px but this value was never communicated to Monaco itself.

Changes:
- Add optional editorHeight prop (type string, default '360px') to BruteForceOptimizedDiffProps, matching the existing CSS min-height so the default looks correct out of the box.
- Pass editorHeight to the DiffEditor height prop.
- Document in the JSDoc comment why Monaco requires an explicit height rather than relying on CSS, so the next contributor understands the constraint and doesn't remove it thinking it's redundant.

Doc authors embedding <BruteForceOptimizedDiff> can now override the height for algorithms with more lines, e.g. editorHeight='520px'.


