### PR TITLE
fix: clear container before re-injecting Razorpay script on buttonId change

### DIFF
--- a/src/components/RazorpayButton.tsx
+++ b/src/components/RazorpayButton.tsx
@@ -16,19 +16,30 @@ export default function RazorpayButton({
     const container = containerRef.current;
     if (!container) return;
 
-    if (container.children.length === 0) {
-      const form = document.createElement('form');
-      const script = document.createElement('script');
+    // Clear any previously injected form+script so that a changed buttonId
+    // (or a remount) always injects a fresh script with the correct ID.
+    // Without this, the children.length guard would silently skip the
+    // re-injection and leave the old payment button ID loaded.
+    container.innerHTML = '';
+    setIsLoaded(false);
 
-      script.src = 'https://checkout.razorpay.com/v1/payment-button.js';
-      script.setAttribute('data-payment_button_id', buttonId);
-      script.async = true;
+    const form = document.createElement('form');
+    const script = document.createElement('script');
 
-      script.onload = () => setIsLoaded(true);
+    script.src = 'https://checkout.razorpay.com/v1/payment-button.js';
+    script.setAttribute('data-payment_button_id', buttonId);
+    script.async = true;
 
-      form.appendChild(script);
-      container.appendChild(form);
-    }
+    script.onload = () => setIsLoaded(true);
+
+    form.appendChild(script);
+    container.appendChild(form);
+
+    // Cleanup: clear the container if the component unmounts or buttonId
+    // changes before the script finishes loading.
+    return () => {
+      container.innerHTML = '';
+    };
   }, [buttonId]);
 
   return (


### PR DESCRIPTION
Fix #3737

The useEffect had [buttonId] in its dependency array, implying the component supports dynamic buttonId changes. But the injection was guarded by:

  if (container.children.length === 0) { ... }

After the first mount, children.length is always > 0, so any subsequent run of the effect (triggered by a buttonId prop change) would silently skip the injection, leaving the original payment button ID loaded. The prop appeared to work but was effectively ignored after mount.

Fix: remove the children.length guard and instead unconditionally clear the container (innerHTML = '') and reset isLoaded at the start of every effect run before injecting a fresh form+script. This makes the component behave consistently with what its dependency array advertises - changing buttonId always produces a new Razorpay button for the new ID.

Also add a cleanup function that clears the container on unmount or before the next effect run, preventing a stale script from lingering if the component unmounts while a script load is still in flight.


