### PR TITLE
feat: add spaced-repetition flashcard reviewer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -304,6 +304,10 @@ const config = {
             position: "right",
           },
           {
+            type: "custom-reviewBadge",
+            position: "right",
+          },
+          {
             type: "search",
             position: "right",
           },

--- a/src/__tests__/utils/spacedRepetition.test.ts
+++ b/src/__tests__/utils/spacedRepetition.test.ts
@@ -4,6 +4,7 @@ import {
   saveSpacedRepetitionQueue,
   recordQuestionReview,
   getDueItems,
+  getDueReviewCount,
   getQuestionsForReviewSession,
   STORAGE_PREFIX,
 } from "../../utils/spacedRepetition";
@@ -111,6 +112,35 @@ describe("spacedRepetition", () => {
       const due = getDueItems(queue, new Date("2026-08-01T00:00:00Z"));
       expect(due.length).toBe(1);
       expect(due[0].uniqueId).toBe("arrays_1");
+    });
+
+    test("counts due review items from the active queue", () => {
+      const past = new Date("2026-01-01T00:00:00Z").toISOString();
+      const future = new Date("2026-12-31T00:00:00Z").toISOString();
+      const queue = {
+        arrays_1: {
+          uniqueId: "arrays_1",
+          topicId: "arrays",
+          questionId: 1,
+          nextReviewDate: past,
+          intervalDays: 1,
+          easeFactor: 2.5,
+          repetitions: 0,
+          missedCount: 1,
+        },
+        arrays_2: {
+          uniqueId: "arrays_2",
+          topicId: "arrays",
+          questionId: 2,
+          nextReviewDate: future,
+          intervalDays: 5,
+          easeFactor: 2.5,
+          repetitions: 2,
+          missedCount: 1,
+        },
+      };
+
+      expect(getDueReviewCount(queue, new Date("2026-08-01T00:00:00Z"))).toBe(1);
     });
   });
 

--- a/src/components/ReviewBadgeNavItem.tsx
+++ b/src/components/ReviewBadgeNavItem.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useMemo, useState } from "react";
+import Link from "@docusaurus/Link";
+import { FiRepeat } from "react-icons/fi";
+import { getDueReviewCount, getSpacedRepetitionQueue, syncMissedQuestionsFromHistory } from "../utils/spacedRepetition";
+import { useQuizProgress } from "../hooks/useQuizProgress";
+import { QUIZ_IDS, QUESTION_COUNTS } from "../data/quizzesConfig";
+
+export default function ReviewBadgeNavItem() {
+  const { stats, userId, loaded } = useQuizProgress(QUIZ_IDS, QUESTION_COUNTS);
+  const [count, setCount] = useState(0);
+
+  const queue = useMemo(() => {
+    if (!loaded) return {};
+    return syncMissedQuestionsFromHistory(stats, userId);
+  }, [loaded, stats, userId]);
+
+  useEffect(() => {
+    if (!loaded) return;
+    setCount(getDueReviewCount(queue));
+  }, [loaded, queue]);
+
+  if (!loaded) {
+    return null;
+  }
+
+  const dueCount = getDueReviewCount(queue);
+
+  return (
+    <Link
+      to="/quizzes/review"
+      className="navbar__item navbar__link inline-flex items-center gap-2 rounded-full bg-indigo-50/80 px-3 py-1.5 text-sm font-semibold text-indigo-700 transition-colors hover:bg-indigo-100 dark:bg-indigo-950/40 dark:text-indigo-200 dark:hover:bg-indigo-900/60"
+      title={`${dueCount} review item${dueCount === 1 ? "" : "s"} due`}
+    >
+      <FiRepeat size={14} />
+      <span>Review</span>
+      {dueCount > 0 ? (
+        <span className="rounded-full bg-indigo-600 px-2 py-0.5 text-[10px] font-black uppercase tracking-wide text-white">
+          {dueCount}
+        </span>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/pages/review.tsx
+++ b/src/pages/review.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import BrowserOnly from "@docusaurus/BrowserOnly";
+import SpacedRepetitionReviewPage from "./quizzes/review";
+
+export default function ReviewPage() {
+  return (
+    <Layout
+      title="Review — Spaced Repetition | Algo"
+      description="Review your missed quiz questions on a spaced-repetition schedule."
+    >
+      <BrowserOnly fallback={<div className="p-8 text-center">Loading review session...</div>}>
+        {() => <SpacedRepetitionReviewPage />}
+      </BrowserOnly>
+    </Layout>
+  );
+}

--- a/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/src/theme/NavbarItem/ComponentTypes.tsx
@@ -3,6 +3,7 @@ import ThemePicker from '@site/src/components/ThemePicker';
 import CodeThemePicker from '@site/src/components/CodeThemePicker';
 import CursorSwitcher from '@site/src/components/CursorSwitcher';
 import NavbarAuthButton from '@site/src/components/NavbarAuthButton';
+import ReviewBadgeNavItem from '@site/src/components/ReviewBadgeNavItem';
 
 export default {
   ...ComponentTypes,
@@ -10,4 +11,5 @@ export default {
   'custom-codeThemePicker': CodeThemePicker,
   'custom-cursorSwitcher': CursorSwitcher,
   'custom-authButton': NavbarAuthButton,
+  'custom-reviewBadge': ReviewBadgeNavItem,
 };

--- a/src/utils/spacedRepetition.ts
+++ b/src/utils/spacedRepetition.ts
@@ -177,6 +177,13 @@ export function getDueItems(
     .sort((a, b) => new Date(a.nextReviewDate).getTime() - new Date(b.nextReviewDate).getTime());
 }
 
+export function getDueReviewCount(
+  queue: Record<string, SpacedRepetitionItem>,
+  now: Date = new Date()
+): number {
+  return getDueItems(queue, now).length;
+}
+
 /**
  * Prepares a set of questions for a review session.
  * 1. Checks due items in queue.


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces a spaced-repetition flashcard reviewer that turns questions users previously answered incorrectly into an ongoing review queue.

Instead of showing missed questions only as part of a quiz result, the feature resurfaces them at increasing intervals so users can reinforce weak areas and improve long-term retention.

The implementation reuses the existing QuizAttemptRecord.missedQuestionIds data stored in the quiz_attempts_* localStorage keys.

Fixes #3743 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
