### PR TITLE
feat: add public shareable profile and portfolio page

### DIFF
--- a/src/__tests__/utils/publicProfile.test.ts
+++ b/src/__tests__/utils/publicProfile.test.ts
@@ -1,0 +1,43 @@
+import { buildPublicProfileSnapshot, getPublicProfileSettings, savePublicProfileSettings, getPublicProfileBadgeMarkdown } from '../../utils/publicProfile';
+
+describe('public profile utilities', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns a private snapshot by default when no visibility setting exists', () => {
+    const snapshot = buildPublicProfileSnapshot({
+      username: 'ada',
+      displayName: 'Ada Lovelace',
+      email: 'ada@example.com',
+    });
+
+    expect(snapshot.isPublic).toBe(false);
+    expect(snapshot.visibleSections).toEqual([]);
+    expect(snapshot.username).toBe('ada');
+  });
+
+  it('persists and reads public profile settings', () => {
+    savePublicProfileSettings({
+      isPublic: true,
+      username: 'ada',
+      displayName: 'Ada Lovelace',
+      bio: 'Building better study habits.',
+      showSolvedProblems: true,
+      showQuizMastery: true,
+      showStreak: true,
+      allowBadgeEmbed: true,
+    });
+
+    const settings = getPublicProfileSettings();
+    expect(settings?.isPublic).toBe(true);
+    expect(settings?.bio).toBe('Building better study habits.');
+    expect(settings?.showSolvedProblems).toBe(true);
+  });
+
+  it('creates markdown for a GitHub README badge', () => {
+    const markdown = getPublicProfileBadgeMarkdown('ada');
+    expect(markdown).toContain('/u/ada/badge');
+    expect(markdown).toContain('Algo profile');
+  });
+});

--- a/src/components/PublicProfileSettingsCard.tsx
+++ b/src/components/PublicProfileSettingsCard.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+import { getPublicProfileSettings, savePublicProfileSettings } from '../utils/publicProfile';
+
+export default function PublicProfileSettingsCard() {
+  const [settings, setSettings] = useState(() => getPublicProfileSettings() || {
+    isPublic: false,
+    username: '',
+    displayName: '',
+    bio: '',
+    showSolvedProblems: true,
+    showQuizMastery: true,
+    showStreak: true,
+    allowBadgeEmbed: false,
+  });
+
+  useEffect(() => {
+    const current = getPublicProfileSettings();
+    if (current) {
+      setSettings(current);
+    }
+  }, []);
+
+  const save = (next: typeof settings) => {
+    setSettings(next);
+    savePublicProfileSettings(next);
+  };
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-lg font-black">Shareable profile</h3>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Make your learning progress visible to recruiters or study partners with a persistent profile page.
+          </p>
+        </div>
+        <label className="flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1 text-sm font-semibold dark:border-slate-700">
+          <input
+            type="checkbox"
+            checked={settings.isPublic}
+            onChange={(event) => save({ ...settings, isPublic: event.target.checked })}
+          />
+          Public
+        </label>
+      </div>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-2">
+        <label className="text-sm font-semibold">
+          <span className="mb-1 block">Username</span>
+          <input
+            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+            value={settings.username}
+            onChange={(event) => save({ ...settings, username: event.target.value })}
+            placeholder="your-handle"
+          />
+        </label>
+        <label className="text-sm font-semibold">
+          <span className="mb-1 block">Display name</span>
+          <input
+            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+            value={settings.displayName}
+            onChange={(event) => save({ ...settings, displayName: event.target.value })}
+            placeholder="Ada Lovelace"
+          />
+        </label>
+      </div>
+
+      <label className="mt-4 block text-sm font-semibold">
+        <span className="mb-1 block">Short bio</span>
+        <textarea
+          className="min-h-24 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+          value={settings.bio}
+          onChange={(event) => save({ ...settings, bio: event.target.value })}
+          placeholder="Tell people what you're learning."
+        />
+      </label>
+
+      <div className="mt-6 space-y-3 text-sm">
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={settings.showSolvedProblems}
+            onChange={(event) => save({ ...settings, showSolvedProblems: event.target.checked })}
+          />
+          Show solved problems
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={settings.showQuizMastery}
+            onChange={(event) => save({ ...settings, showQuizMastery: event.target.checked })}
+          />
+          Show quiz mastery badges
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={settings.showStreak}
+            onChange={(event) => save({ ...settings, showStreak: event.target.checked })}
+          />
+          Show streak
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={settings.allowBadgeEmbed}
+            onChange={(event) => save({ ...settings, allowBadgeEmbed: event.target.checked })}
+          />
+          Allow badge embed for GitHub README
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -9,6 +9,7 @@ import {
 import { useAuth } from "../contexts/AuthContext";
 import PracticeActivityHeatmapWidget from "../components/PracticeActivityHeatmapWidget";
 import PracticeActivitySummaryCard from "../components/PracticeActivitySummaryCard";
+import PublicProfileSettingsCard from "../components/PublicProfileSettingsCard";
 import QuizStreakWidget from "../components/QuizStreakWidget";
 
 type DashboardTab = "overview" | "metrics" | "security";
@@ -238,6 +239,8 @@ export default function ProfilePage() {
                           : "Verify credentials or construct a workspace node to map algorithmic execution telemetry."}
                       </p>
                     </div>
+
+                    <PublicProfileSettingsCard />
 
                     <div 
                       className="rounded-2xl border p-6 shadow-sm flex flex-col justify-between"

--- a/src/pages/u/[username].tsx
+++ b/src/pages/u/[username].tsx
@@ -1,0 +1,103 @@
+import React, { useMemo } from 'react';
+import Layout from '@theme/Layout';
+import Link from '@docusaurus/Link';
+import { useLocation } from '@docusaurus/router';
+import { buildPublicProfileSnapshot } from '../../utils/publicProfile';
+
+function slugFromPath(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean);
+  return segments[segments.length - 1] || '';
+}
+
+export default function PublicProfilePage() {
+  const location = useLocation();
+  const username = slugFromPath(location.pathname);
+
+  const snapshot = useMemo(() => buildPublicProfileSnapshot({
+    username,
+    displayName: username.replace(/-/g, ' '),
+  }), [username]);
+
+  const title = snapshot.isPublic ? `${snapshot.displayName}'s profile` : 'Private profile';
+
+  if (!snapshot.isPublic) {
+    return (
+      <Layout title="Private profile" description="This profile is not public yet.">
+        <main className="min-h-screen px-6 py-20">
+          <div className="mx-auto max-w-3xl rounded-2xl border border-slate-200 bg-white p-10 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <h1 className="text-3xl font-black">This profile is private</h1>
+            <p className="mt-3 text-slate-600 dark:text-slate-300">
+              The owner has not enabled public sharing for this profile yet.
+            </p>
+            <Link className="mt-6 inline-flex items-center rounded-lg bg-[var(--ifm-color-primary)] px-4 py-2 text-sm font-semibold text-white" to="/profile">
+              Open your profile settings
+            </Link>
+          </div>
+        </main>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout title={title} description={`Public study profile for ${snapshot.displayName}`}>
+      <main className="min-h-screen bg-slate-50 px-6 py-16 dark:bg-[#060816]">
+        <div className="mx-auto max-w-5xl space-y-6">
+          <section className="rounded-2xl border border-slate-200 bg-white p-8 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.25em] text-[var(--ifm-color-primary)]">Public study profile</p>
+                <h1 className="mt-2 text-3xl font-black">{snapshot.displayName}</h1>
+                <p className="mt-3 max-w-2xl text-slate-600 dark:text-slate-300">
+                  {snapshot.bio || 'A growing Algo learner sharing progress, mastery, and streaks with friends and recruiters.'}
+                </p>
+              </div>
+              {snapshot.allowBadgeEmbed && (
+                <div className="rounded-xl border border-dashed border-slate-300 p-3 text-sm text-slate-600 dark:border-slate-700 dark:text-slate-300">
+                  Badge ready for your README
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="grid gap-4 md:grid-cols-3">
+            {snapshot.visibleSections.includes('solved') && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                <p className="text-xs font-bold uppercase tracking-[0.25em] text-slate-500">Solved problems</p>
+                <p className="mt-3 text-4xl font-black">{snapshot.solvedCount}</p>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Completed learning milestones tracked in Algo.</p>
+              </div>
+            )}
+            {snapshot.visibleSections.includes('quiz-mastery') && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                <p className="text-xs font-bold uppercase tracking-[0.25em] text-slate-500">Quiz mastery</p>
+                <p className="mt-3 text-4xl font-black">{snapshot.masteryCount}</p>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Quizzes scored 90% or higher.</p>
+              </div>
+            )}
+            {snapshot.visibleSections.includes('streak') && (
+              <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+                <p className="text-xs font-bold uppercase tracking-[0.25em] text-slate-500">Current streak</p>
+                <p className="mt-3 text-4xl font-black">{snapshot.streak}d</p>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{snapshot.lastActiveAt ? 'Last active recently.' : 'No activity yet.'}</p>
+              </div>
+            )}
+          </section>
+
+          {snapshot.allowBadgeEmbed && (
+            <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+              <h2 className="text-xl font-black">Embed this in your README</h2>
+              <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">Use the badge below in GitHub or any other profile page.</p>
+              <pre className="mt-4 overflow-x-auto rounded-xl bg-slate-950 p-4 text-sm text-slate-100">
+                {getPublicProfileBadgeMarkdown(snapshot.username)}
+              </pre>
+            </section>
+          )}
+        </div>
+      </main>
+    </Layout>
+  );
+}
+
+function getPublicProfileBadgeMarkdown(username: string): string {
+  return `[![Algo profile](https://img.shields.io/badge/Algo%20profile-${encodeURIComponent(username)}-blue)](${new URL(`/u/${username}/badge`, typeof window !== 'undefined' ? window.location.origin : 'https://example.com').toString()})`;
+}

--- a/src/pages/u/[username]/badge.tsx
+++ b/src/pages/u/[username]/badge.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import { useLocation } from '@docusaurus/router';
+
+function slugFromPath(pathname: string): string {
+  const segments = pathname.split('/').filter(Boolean);
+  return segments[segments.length - 2] || '';
+}
+
+export default function PublicProfileBadgePage() {
+  const location = useLocation();
+  const username = slugFromPath(location.pathname);
+
+  return (
+    <Layout title="Profile badge" description="Embeddable profile badge">
+      <main className="min-h-screen px-6 py-20">
+        <div className="mx-auto flex max-w-2xl justify-center">
+          <a
+            href={`/u/${username}`}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200"
+          >
+            <span className="mr-2 inline-flex h-2.5 w-2.5 rounded-full bg-emerald-500" />
+            Algo profile · {username || 'user'}
+          </a>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/src/utils/publicProfile.ts
+++ b/src/utils/publicProfile.ts
@@ -1,0 +1,127 @@
+import { getAchievementSnapshot, readAlgoProgress, safeJsonParse } from './safeStorage';
+
+export interface PublicProfileSettings {
+  isPublic: boolean;
+  username: string;
+  displayName: string;
+  bio: string;
+  showSolvedProblems: boolean;
+  showQuizMastery: boolean;
+  showStreak: boolean;
+  allowBadgeEmbed: boolean;
+}
+
+export interface PublicProfileSnapshot extends PublicProfileSettings {
+  visibleSections: string[];
+  solvedCount: number;
+  masteryCount: number;
+  streak: number;
+  lastActiveAt: string | null;
+  profileUrl: string;
+  badgeUrl: string;
+}
+
+const SETTINGS_KEY = 'algo.public_profile.settings.v1';
+
+function getCurrentHost(): string {
+  if (typeof window === 'undefined') {
+    return 'https://example.com';
+  }
+
+  const origin = window.location.origin;
+  return origin || 'https://example.com';
+}
+
+export function getPublicProfileSettings(): PublicProfileSettings | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const settings = safeJsonParse<PublicProfileSettings | null>(SETTINGS_KEY, null);
+  if (!settings) {
+    return null;
+  }
+
+  return {
+    isPublic: Boolean(settings.isPublic),
+    username: settings.username?.trim() || '',
+    displayName: settings.displayName?.trim() || settings.username?.trim() || '',
+    bio: settings.bio?.trim() || '',
+    showSolvedProblems: Boolean(settings.showSolvedProblems),
+    showQuizMastery: Boolean(settings.showQuizMastery),
+    showStreak: Boolean(settings.showStreak),
+    allowBadgeEmbed: Boolean(settings.allowBadgeEmbed),
+  };
+}
+
+export function savePublicProfileSettings(settings: Partial<PublicProfileSettings>): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const current = getPublicProfileSettings() || {
+    isPublic: false,
+    username: '',
+    displayName: '',
+    bio: '',
+    showSolvedProblems: true,
+    showQuizMastery: true,
+    showStreak: true,
+    allowBadgeEmbed: false,
+  };
+
+  const next = { ...current, ...settings };
+  window.localStorage.setItem(SETTINGS_KEY, JSON.stringify(next));
+}
+
+export function buildPublicProfileSnapshot(input: {
+  username: string;
+  displayName?: string;
+  email?: string;
+  overrideSettings?: Partial<PublicProfileSettings>;
+}): PublicProfileSnapshot {
+  const settings = getPublicProfileSettings();
+  const fallbackSettings: PublicProfileSettings = {
+    isPublic: false,
+    username: input.username,
+    displayName: input.displayName || input.username,
+    bio: '',
+    showSolvedProblems: false,
+    showQuizMastery: false,
+    showStreak: false,
+    allowBadgeEmbed: false,
+  };
+
+  const resolved = { ...fallbackSettings, ...(settings || {}), ...input.overrideSettings };
+  const progress = readAlgoProgress();
+  const achievement = getAchievementSnapshot(progress);
+  const visibleSections = [
+    resolved.showSolvedProblems ? 'solved' : null,
+    resolved.showQuizMastery ? 'quiz-mastery' : null,
+    resolved.showStreak ? 'streak' : null,
+  ].filter(Boolean) as string[];
+
+  return {
+    isPublic: Boolean(resolved.isPublic),
+    username: resolved.username?.trim() || input.username,
+    displayName: resolved.displayName?.trim() || input.displayName || input.username,
+    bio: resolved.bio?.trim() || '',
+    showSolvedProblems: Boolean(resolved.showSolvedProblems),
+    showQuizMastery: Boolean(resolved.showQuizMastery),
+    showStreak: Boolean(resolved.showStreak),
+    allowBadgeEmbed: Boolean(resolved.allowBadgeEmbed),
+    visibleSections,
+    solvedCount: achievement.completedCount,
+    masteryCount: achievement.quizzesMastered,
+    streak: achievement.streak,
+    lastActiveAt: achievement.lastActiveAt,
+    profileUrl: `${getCurrentHost()}/u/${resolved.username?.trim() || input.username}`,
+    badgeUrl: `${getCurrentHost()}/u/${resolved.username?.trim() || input.username}/badge`,
+  };
+}
+
+export function getPublicProfileBadgeMarkdown(username: string): string {
+  const slug = username.trim() || 'algo';
+  const host = getCurrentHost();
+  return `[![Algo profile](https://img.shields.io/badge/Algo%20profile-${encodeURIComponent(slug)}-blue)](${host}/u/${slug}/badge)`;
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR adds a public, shareable profile page that allows users to showcase their learning progress through a persistent URL such as:

/u/username

Unlike the existing ShareResultCard, which is designed to share a single quiz result as an image, this feature provides a complete portfolio-style view of a user's progress that can be shared with recruiters, mentors, classmates, or study partners.

The profile also includes an opt-in visibility control and an embeddable badge for GitHub READMEs.

Fixes #3744 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
