### PR TITLE
Fix: Remove Broken g → s Keyboard Shortcut

### DIFF
--- a/src/__tests__/hooks/useKeyboardShortcuts.test.ts
+++ b/src/__tests__/hooks/useKeyboardShortcuts.test.ts
@@ -68,4 +68,20 @@ describe("useKeyboardShortcuts hook", () => {
 
     document.body.removeChild(input);
   });
+
+  test("does not navigate to a missing /settings route on gs sequential shortcut", async () => {
+    const user = userEvent.setup();
+
+    renderHook(() =>
+      useKeyboardShortcuts({
+        onOpenHelp: jest.fn(),
+        onCloseHelp: jest.fn(),
+      })
+    );
+
+    await user.keyboard("g");
+    await user.keyboard("s");
+
+    expect(mockPush).not.toHaveBeenCalledWith("/settings");
+  });
 });

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -25,7 +25,6 @@ const SEQUENTIAL_SHORTCUTS: SequentialShortcuts = {
   gb: "/blog",
   gq: "/quizzes",
   gc: "/challenges", // g then c -> go to challenges
-  gs: "/settings",
 };
 
 export default function useKeyboardShortcuts({


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes a broken sequential keyboard shortcut in src/hooks/useKeyboardShortcuts.ts.

The gs shortcut currently maps to /settings, but the application does not have a /settings route under src/pages. Pressing g followed by s therefore navigates users to a 404 page.

Since the shortcut is not currently exposed in the keyboard-shortcuts help modal and there is no settings page to navigate to, the broken shortcut is removed.

Fixes #3753 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
