### PR TITLE
Fix: Resolve Public Profiles by Username

### DIFF
--- a/src/__tests__/utils/publicProfile.test.ts
+++ b/src/__tests__/utils/publicProfile.test.ts
@@ -35,6 +35,29 @@ describe('public profile utilities', () => {
     expect(settings?.showSolvedProblems).toBe(true);
   });
 
+  it('does not apply viewer-local public profile settings for a different username route', () => {
+    savePublicProfileSettings({
+      isPublic: true,
+      username: 'alice',
+      displayName: 'Alice Example',
+      bio: 'Learning algorithms.',
+      showSolvedProblems: true,
+      showQuizMastery: true,
+      showStreak: true,
+      allowBadgeEmbed: true,
+    });
+
+    const snapshot = buildPublicProfileSnapshot({
+      username: 'bob',
+      displayName: 'Bob Builder',
+    });
+
+    expect(snapshot.username).toBe('bob');
+    expect(snapshot.displayName).toBe('Bob Builder');
+    expect(snapshot.isPublic).toBe(false);
+    expect(snapshot.visibleSections).toEqual([]);
+  });
+
   it('creates markdown for a GitHub README badge', () => {
     const markdown = getPublicProfileBadgeMarkdown('ada');
     expect(markdown).toContain('/u/ada/badge');

--- a/src/utils/publicProfile.ts
+++ b/src/utils/publicProfile.ts
@@ -92,7 +92,12 @@ export function buildPublicProfileSnapshot(input: {
     allowBadgeEmbed: false,
   };
 
-  const resolved = { ...fallbackSettings, ...(settings || {}), ...input.overrideSettings };
+  const settingsToUse =
+    settings?.username?.trim()?.toLowerCase() === input.username?.trim()?.toLowerCase()
+      ? settings
+      : null;
+
+  const resolved = { ...fallbackSettings, ...(settingsToUse || {}), ...input.overrideSettings };
   const progress = readAlgoProgress();
   const achievement = getAchievementSnapshot(progress);
   const visibleSections = [


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes the public profile implementation so /u/[username] displays the profile belonging to the username in the URL instead of reading the current browser's localStorage.

Previously, buildPublicProfileSnapshot() relied on getPublicProfileSettings() and readAlgoProgress(), which read from the viewer's localStorage. This meant /u/alice could display the viewer's own stats rather than Alice's.

Fixes #3757 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
