### PR TITLE
fix: add aria-label='output console' to MonacoSandbox output section 

### DIFF
--- a/src/components/CodeEditor/MonacoSandbox.tsx
+++ b/src/components/CodeEditor/MonacoSandbox.tsx
@@ -427,7 +427,11 @@ export default function MonacoSandbox({
       )}
 
       {/* Output console */}
-      <div className="p-3 bg-gray-950 text-green-400 font-mono text-xs border-t border-gray-800 whitespace-pre-wrap">
+      <div
+        role="region"
+        aria-label="output console"
+        className="p-3 bg-gray-950 text-green-400 font-mono text-xs border-t border-gray-800 whitespace-pre-wrap"
+      >
         <div className="flex items-center justify-between text-gray-400 mb-2">
           <span className="text-gray-400 text-xs font-semibold uppercase tracking-wider">Console Output</span>
           {output ? (


### PR DESCRIPTION
fix #3764

## Problem 

The test shows the output section after running code was failing because screen.getByLabelText(/output console/i) found no matching element. The output console div had no aria-label.

## Fix 

Added role="region" and aria-label="output console" to the output console div in MonacoSandbox.tsx.

## Testing 

MonacoSandbox Component › shows the output section after running code now passes.
