### PR TITLE
PR: Fix Repeated Search Result Highlighting

### DIFF
--- a/src/__tests__/components/ChallengeSearchModal.test.tsx
+++ b/src/__tests__/components/ChallengeSearchModal.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "../testUtils";
+import userEvent from "@testing-library/user-event";
+import ChallengeSearchModal from "../../components/ChallengeSearchModal";
+
+jest.mock("../../data/challengeData", () => [
+  {
+    title: "Search in Rotated Search Array",
+    description: "Practice binary search on a rotated sorted search array.",
+    link: "/challenges/search-in-rotated-search-array",
+    difficulty: "Medium",
+    category: "Arrays",
+    tags: ["search"],
+  },
+  {
+    title: "Binary Search Tree Traversal",
+    description: "Traverse a binary search tree.",
+    link: "/challenges/bst-traversal",
+    difficulty: "Easy",
+    category: "Trees",
+    tags: ["search"],
+  },
+]);
+
+describe("ChallengeSearchModal highlight()", () => {
+  test("wraps every repeated match in <mark>, not just alternating ones", async () => {
+    const user = userEvent.setup();
+    render(<ChallengeSearchModal isOpen={true} onClose={jest.fn()} />);
+
+    const input = screen.getByPlaceholderText(/search challenges/i);
+    await user.type(input, "search");
+
+    // The first result's title, "Search in Rotated Search Array", contains
+    // the query "search" TWICE (case-insensitively). Both occurrences must
+    // be highlighted — with the old regex.test()-in-a-loop bug, only every
+    // other occurrence (in the worst case) would get wrapped in <mark>.
+    const marks = document.querySelectorAll("mark");
+    const searchMarks = Array.from(marks).filter(
+      (el) => el.textContent?.toLowerCase() === "search"
+    );
+
+    expect(searchMarks.length).toBeGreaterThanOrEqual(2);
+    searchMarks.forEach((el) => {
+      expect(el.textContent?.toLowerCase()).toBe("search");
+    });
+  });
+});

--- a/src/components/ChallengeSearchModal.tsx
+++ b/src/components/ChallengeSearchModal.tsx
@@ -82,12 +82,20 @@ const QUICK_FILTERS = [
 
 function highlight(text: string, query: string): React.ReactNode {
   if (!query.trim()) return text;
-  const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(${escaped})`, "gi");
   const parts = text.split(regex);
+  // `text.split(regex)` with a single capturing group always returns
+  // alternating [nonMatch, match, nonMatch, match, ...] segments, so the
+  // parity of the index tells us whether a part matched — no need to
+  // re-run the (stateful, `g`-flagged) regex against each part. Reusing a
+  // global regex's `.test()` across a loop is a classic pitfall: `.test()`
+  // advances `regex.lastIndex` as a side effect, so repeated calls on the
+  // same regex object silently alternate/skip matches.
   return (
     <>
       {parts.map((part, i) =>
-        regex.test(part) ? (
+        i % 2 === 1 ? (
           <mark key={i} className="bg-yellow-200 dark:bg-yellow-500/30 text-inherit rounded-sm px-0.5">
             {part}
           </mark>


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR fixes an issue in ChallengeSearchModal where repeated occurrences of a search term were not always highlighted correctly.

The highlight() function reused a global regular expression with .test() inside a .map() loop. Because global regular expressions maintain lastIndex, successive .test() calls could produce inconsistent results and cause legitimate matches to be skipped.
Fixes #3752 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
