### PR TITLE
fix: resolve TS2345 keyboard/mouse event type mismatch in GraphVisualizer 

### DIFF
--- a/src/components/Visualizing/GraphVisualizer.tsx
+++ b/src/components/Visualizing/GraphVisualizer.tsx
@@ -141,7 +141,7 @@ const GraphVisualizer: React.FC = () => {
   };
 
   // Node selection and edge drawing logic
-  const handleNodeClick = (e: React.MouseEvent, id: number) => {
+  const handleNodeClick = (e: React.MouseEvent<Element> | React.KeyboardEvent<Element>, id: number) => {
     e.stopPropagation();
     if (isRunning) return;
 
@@ -193,7 +193,7 @@ const GraphVisualizer: React.FC = () => {
     setDraggingNode(null);
   };
 
-  const handleWeightClick = (e: React.MouseEvent, u: number, v: number) => {
+  const handleWeightClick = (e: React.MouseEvent<Element> | React.KeyboardEvent<Element>, u: number, v: number) => {
     e.stopPropagation();
     if (mode !== "edit" || isRunning) return;
     const edge = edges.find((edge) => edge.u === u && edge.v === v);


### PR DESCRIPTION
fix #3766 

## Problem 

handleNodeClick and handleWeightClick were typed as React.MouseEvent, but both were also called from onKeyDown handlers which pass a React.KeyboardEvent, causing TS2345 errors at lines 753 and 781.

## Fix 

Widened both handler signatures to accept React.MouseEvent<Element> | React.KeyboardEvent<Element>. No property access guards were needed since both handlers only call e.stopPropagation(), which is available on the base SyntheticEvent.

## Testing 

tsc --noEmit confirms the TS2345 errors are resolved.