### PR TITLE
fix: resolve TS2362/2363 arithmetic type errors in TrieVisualizer sort comparators

### DIFF
--- a/src/components/Visualizing/TrieVisualizer.tsx
+++ b/src/components/Visualizing/TrieVisualizer.tsx
@@ -82,7 +82,7 @@ function deleteWord(root: TrieNode, word: string): TrieNode {
 function collectWords(node: TrieNode, prefix: string): string[] {
   const words: string[] = [];
   if (node.isEnd) words.push(prefix);
-  const sortedKeys = Array.from(node.children.keys()).sort((a, b) => a - b);
+  const sortedKeys = Array.from(node.children.keys()).sort((a, b) => a.localeCompare(b));
   for (const ch of sortedKeys) {
     words.push(...collectWords(node.children.get(ch)!, prefix + ch));
   }
@@ -106,7 +106,7 @@ const NODE_RADIUS = 20;
 const LEVEL_HEIGHT = 70;
 
 function computeLayout(node: TrieNode, char: string): LayoutNode {
-  const sortedKeys = Array.from(node.children.keys()).sort((a, b) => a - b);
+  const sortedKeys = Array.from(node.children.keys()).sort((a, b) => a.localeCompare(b));
   const childLayouts = sortedKeys.map((ch) =>
     computeLayout(node.children.get(ch)!, ch)
   );


### PR DESCRIPTION
fix #3765

## Problem 

node.children is Map<string, TrieNode>, so .keys() returns strings. The sort comparator (a, b) => a - b performed arithmetic on strings, causing TS2362/2363 errors at lines 85 and 109.

## Fix 

Replaced (a, b) => a - b with (a, b) => a.localeCompare(b) in both sortedKeys sort calls (collectWords and computeLayout). This is also semantically correct — trie keys are characters and should be sorted alphabetically.

## Testing 

tsc --noEmit confirms the TS2362/2363 errors are resolved.