### PR TITLE
fix: replace styled-jsx style block with dangerouslySetInnerHTML to resolve TS2322

### DIFF
--- a/src/components/Homepage/UserTestimonialsSection.tsx
+++ b/src/components/Homepage/UserTestimonialsSection.tsx
@@ -255,7 +255,9 @@ const UserTestimonialsSection: React.FC = () => {
       </div>
 
       {/* Swiper styles */}
-      <style jsx global>{`
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
         .testimonial-swiper .swiper-wrapper {
           transition-timing-function: linear !important;
         }
@@ -280,7 +282,9 @@ const UserTestimonialsSection: React.FC = () => {
           .swiper-pagination-bullet-active {
           background: #fff !important;
         }
-      `}</style>
+      `,
+        }}
+      />
     </section>
   );
 };


### PR DESCRIPTION
Fix #3767

## Problem

`<style jsx global>` uses styled-jsx attributes (`jsx`, `global`) that aren't part of standard React `StyleHTMLAttributes`, causing TS2322 at line 258. This project has no styled-jsx Babel plugin or type definitions configured.

## Fix

Replaced the styled-jsx block with a standard `<style dangerouslySetInnerHTML={{ __html: ... }} />`. CSS content is identical - no visual change, no new dependencies.

## Testing

`tsc --noEmit` confirms no errors remain in `UserTestimonialsSection.tsx`.
