### PR TITLE
fix: remove duplicate quizId key in makeStat to resolve TS2783 

### DIFF
--- a/src/__tests__/utils/recommendations.test.ts
+++ b/src/__tests__/utils/recommendations.test.ts
@@ -5,7 +5,6 @@ import { QUIZZES_CONFIG } from "../../data/quizzesConfig";
 
 function makeStat(overrides: Partial<QuizStat> & { quizId: string }): QuizStat {
   return {
-    quizId: overrides.quizId,
     attempts: [],
     bestScore: 0,
     bestPercent: 0,


### PR DESCRIPTION
fix #3786 

## Problem 

makeStat set quizId: overrides.quizId explicitly and then spread ...overrides immediately after, causing TS2783 - the explicit property is always overwritten by the spread, making it dead code.

## Fix 

Removed the redundant quizId: overrides.quizId line. The spread already includes quizId since overrides is typed as Partial<QuizStat> & { quizId: string }.

## Testing 

tsc --noEmit confirms TS2783 is resolved in recommendations.test.ts.
