### PR TITLE
fix: fall back to default not-started stat for quizzes missing from stats record

### DIFF
--- a/src/utils/recommendations.ts
+++ b/src/utils/recommendations.ts
@@ -132,8 +132,23 @@ export function getRecommendedNextQuiz(
 
   const candidates: Recommendation[] = quizzes
     .map((quiz) => {
-      const stat = stats[quiz.id];
-      if (!stat || stat.status === "mastered") return null;
+      // Fall back to a default not-started stat so quizzes that have never
+      // been started (no entry in stats yet) are still eligible candidates.
+      const stat: QuizStat = stats[quiz.id] ?? {
+        quizId: quiz.id,
+        attempts: [],
+        bestScore: 0,
+        bestPercent: 0,
+        latestScore: 0,
+        latestPercent: 0,
+        latestAttemptAt: null,
+        totalAttempts: 0,
+        totalQuestions: 0,
+        averagePercent: 0,
+        status: "not-started",
+      };
+
+      if (stat.status === "mastered") return null;
 
       const weakness = computeWeaknessScore(stat);
       const recency = computeRecencyScore(stat.latestAttemptAt);


### PR DESCRIPTION
fix #3787

## Problem 

getRecommendedNextQuiz returned null for any quiz with no entry in stats. Quizzes never started by the user - including newly added ones - were silently excluded from recommendations even when the user had practice history.

## Fix 

Replaced if (!stat || stat.status === "mastered") return null with a ?? fallback that synthesizes a default not-started stat when stats[quiz.id] is undefined. The mastered guard is retained separately.

## Testing 

All 3 existing recommendation tests pass. tsc --noEmit shows no errors in recommendations.ts.


