### PR TITLE
fix: group hint content into paragraph blocks to eliminate empty DOM nodes

### DIFF
--- a/src/components/DsaProblemHintLadder.tsx
+++ b/src/components/DsaProblemHintLadder.tsx
@@ -65,11 +65,28 @@ function isDsaProblemDoc(metadata: any): boolean {
 }
 
 function renderHintContent(content: string) {
-  return content.split('\n').map((line, index) => (
-    <p key={index} className="m-0 leading-relaxed">
-      {line}
-    </p>
-  ));
+  // Split on one or more blank lines to form paragraph blocks, preserving the
+  // author's intended structure. Empty lines are paragraph separators, not
+  // invisible <p> nodes. Lines within a block are joined with a <br /> to
+  // keep inline line breaks (e.g. pseudocode steps) intact.
+  const blocks = content
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter((block) => block.length > 0);
+
+  return blocks.map((block, blockIndex) => {
+    const lines = block.split('\n');
+    return (
+      <p key={blockIndex} className="m-0 leading-relaxed">
+        {lines.map((line, lineIndex) => (
+          <React.Fragment key={lineIndex}>
+            {line}
+            {lineIndex < lines.length - 1 && <br />}
+          </React.Fragment>
+        ))}
+      </p>
+    );
+  });
 }
 
 export default function DsaProblemHintLadder() {


### PR DESCRIPTION
fix #3789

## Problem 

renderHintContent split on every \n and rendered each line as a <p>, turning blank lines into invisible empty <p> nodes. Multi-line hint content (pseudocode, step lists) was also flattened into unrelated individual paragraphs, losing all intended block structure.

## Fix 

Rewrote the function to split on double-newlines (\n{2,}) to form semantic paragraph blocks, filtering out blank ones. Lines within a block are rendered with <br /> separators inside a single <p>, preserving inline line breaks (e.g. pseudocode steps) without creating spurious empty elements. No new dependencies required.

## Testing 

tsc --noEmit confirms no errors in DsaProblemHintLadder.tsx.