### PR TITLE
Use Canonical Problem IDs Instead of Title-Derived Slugs

### DIFF
--- a/src/__tests__/utils/slugUtils.test.ts
+++ b/src/__tests__/utils/slugUtils.test.ts
@@ -1,0 +1,58 @@
+import { toCanonicalSlug, slugify, getCanonicalAlgoKey } from '../../utils/slugUtils';
+
+describe('slugUtils', () => {
+  describe('toCanonicalSlug', () => {
+    it('returns empty string for empty or nullish values', () => {
+      expect(toCanonicalSlug('')).toBe('');
+      expect(toCanonicalSlug('   ')).toBe('');
+    });
+
+    it('converts titles, IDs, and symbols into clean canonical slugs', () => {
+      expect(toCanonicalSlug('Binary Search')).toBe('binary-search');
+      expect(toCanonicalSlug('Implement Bubble Sort')).toBe('bubble-sort');
+      expect(toCanonicalSlug('Quiz on Binary Search Tree')).toBe('binary-search-tree');
+      expect(toCanonicalSlug("Dijkstra's Algorithm!")).toBe('dijkstras-algorithm');
+      expect(toCanonicalSlug('Depth-First Search (DFS)')).toBe('depth-first-search-dfs');
+    });
+
+    it('strips accents and special diacritics', () => {
+      expect(toCanonicalSlug('Café Algorithmique')).toBe('cafe-algorithmique');
+    });
+  });
+
+  describe('slugify', () => {
+    it('returns fallback when string is empty or invalid', () => {
+      expect(slugify('', 'custom-fallback')).toBe('custom-fallback');
+      expect(slugify('   ', 'fallback')).toBe('fallback');
+    });
+
+    it('returns slugified string when valid', () => {
+      expect(slugify('My Great Quiz')).toBe('my-great-quiz');
+    });
+  });
+
+  describe('getCanonicalAlgoKey', () => {
+    it('resolves canonical AlgoKey from titles, IDs, and slugs', () => {
+      expect(getCanonicalAlgoKey('binary-search')).toBe('Binary Search');
+      expect(getCanonicalAlgoKey('so-01')).toBeNull(); // ID without slug/title
+      expect(getCanonicalAlgoKey('Implement Bubble Sort')).toBe('Bubble Sort');
+      expect(getCanonicalAlgoKey('dijkstra')).toBe('Dijkstra Algorithm');
+      expect(getCanonicalAlgoKey("dijkstra's algorithm")).toBe('Dijkstra Algorithm');
+      expect(getCanonicalAlgoKey('depth-first-search')).toBe('DFS');
+      expect(getCanonicalAlgoKey('breadth-first-search')).toBe('BFS');
+      expect(getCanonicalAlgoKey('linked-list')).toBe('Linked List');
+      expect(getCanonicalAlgoKey('dynamic-programming')).toBe('Dynamic Programming');
+    });
+
+    it('resolves category fallback when title/id does not directly match', () => {
+      expect(getCanonicalAlgoKey('Custom Unmatched Problem Title', 'sorting')).toBe('Quick Sort');
+      expect(getCanonicalAlgoKey(null, 'graph')).toBe('Graphs');
+      expect(getCanonicalAlgoKey(undefined, 'dp')).toBe('Dynamic Programming');
+      expect(getCanonicalAlgoKey('', 'greedy')).toBe('Greedy Algorithms');
+    });
+
+    it('returns null when neither input nor category matches', () => {
+      expect(getCanonicalAlgoKey('completely-unknown-topic-xyz', 'unknown-cat')).toBeNull();
+    });
+  });
+});

--- a/src/components/AlgorithmUseCases.tsx
+++ b/src/components/AlgorithmUseCases.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { getCanonicalAlgoKey } from "../utils/slugUtils";
 import {
   FiCpu,
   FiCompass,
@@ -628,8 +629,15 @@ const AlgorithmUseCases: React.FC = () => {
     if (typeof window !== "undefined") {
       const params = new URLSearchParams(window.location.search);
       const algoParam = params.get("algo");
-      if (algoParam && algorithmData[algoParam]) {
-        setSelected(algoParam);
+      if (algoParam) {
+        if (algorithmData[algoParam]) {
+          setSelected(algoParam);
+        } else {
+          const resolvedKey = getCanonicalAlgoKey(algoParam);
+          if (resolvedKey && algorithmData[resolvedKey]) {
+            setSelected(resolvedKey);
+          }
+        }
       }
     }
   }, []);

--- a/src/components/CheatSheetExport/index.tsx
+++ b/src/components/CheatSheetExport/index.tsx
@@ -6,6 +6,7 @@ import {
   FiAlertCircle,
   FiLoader,
 } from "react-icons/fi";
+import { slugify } from "../../utils/slugUtils";
 import styles from "./styles.module.css";
 
 interface CheatSheetExportProps {
@@ -54,12 +55,7 @@ export default function CheatSheetExport({
     }, RESET_DELAY_MS);
   }, []);
 
-  const slugify = (value: string): string =>
-    (value || "cheatsheet")
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "") || "cheatsheet";
+  const slugifyFilename = (value: string): string => slugify(value, "cheatsheet");
 
   const captureCanvas = useCallback(async () => {
     if (typeof document === "undefined") {
@@ -143,7 +139,7 @@ export default function CheatSheetExport({
         heightLeft -= PDF_PAGE_HEIGHT_PX;
       }
 
-      pdf.save(`${slugify(title)}.pdf`);
+      pdf.save(`${slugifyFilename(title)}.pdf`);
       setPdfStatus("done");
     } catch (err) {
       console.error("[CheatSheetExport] PDF export failed:", err);
@@ -191,7 +187,7 @@ export default function CheatSheetExport({
         const url = URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
-        link.download = `${slugify(title)}.png`;
+        link.download = `${slugifyFilename(title)}.png`;
         link.click();
         URL.revokeObjectURL(url);
       }

--- a/src/components/CustomDocItems/ShareButton.jsx
+++ b/src/components/CustomDocItems/ShareButton.jsx
@@ -13,6 +13,7 @@ import {
   FiAlertCircle,
   FiLoader,
 } from "react-icons/fi";
+import { slugify } from "../../utils/slugUtils";
 import styles from "./shareButton.module.css";
 
 // A4 at 96 DPI – matches CheatSheetExport dimensions.
@@ -66,12 +67,7 @@ function ShareButton({ title }) {
     resetTimerRef.current = setTimeout(() => setStatus("idle"), RESET_DELAY_MS);
   }, []);
 
-  const slugify = (value) =>
-    (value || "cheatsheet")
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "") || "cheatsheet";
+  const slugifyFilename = (value) => slugify(value, "cheatsheet");
 
   /** Capture the main article content via html2canvas (same logic as CheatSheetExport) */
   const captureCanvas = useCallback(async () => {
@@ -148,7 +144,7 @@ function ShareButton({ title }) {
         heightLeft -= PDF_PAGE_HEIGHT_PX;
       }
 
-      pdf.save(`${slugify(title)}.pdf`);
+      pdf.save(`${slugifyFilename(title)}.pdf`);
       setPdfStatus("done");
     } catch (err) {
       console.error("[ShareButton] PDF export failed:", err);
@@ -191,7 +187,7 @@ function ShareButton({ title }) {
         const url = URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
-        link.download = `${slugify(title)}.png`;
+        link.download = `${slugifyFilename(title)}.png`;
         link.click();
         URL.revokeObjectURL(url);
       }

--- a/src/components/DPChallengeLayout.tsx
+++ b/src/components/DPChallengeLayout.tsx
@@ -253,7 +253,7 @@ export default function DPChallengeLayout({ challenge }: Props) {
               ) : activeTab === "pseudocode" ? (
                 <PseudocodeTab solution={challenge.solution} customPseudocode={challenge.pseudocode} />
               ) : (
-                <RealWorldUsesTab challengeTitle={challenge.title} category="dp" />
+                <RealWorldUsesTab challengeId={challenge.id} challengeSlug={challenge.slug} challengeTitle={challenge.title} category="dp" />
               )}
             </div>
           </div>

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -684,7 +684,7 @@ export default function GraphChallengeLayout({ challenge }: Props) {
             {/* ── Real-World tab ── */}
             {activeTab === "real-world" && (
               <div className="flex-1 overflow-y-auto">
-                <RealWorldUsesTab challengeTitle={challenge.title} category="graph" />
+                <RealWorldUsesTab challengeId={challenge.id} challengeSlug={challenge.slug} challengeTitle={challenge.title} category="graph" />
               </div>
             )}
           </div>

--- a/src/components/GreedyChallengeLayout.tsx
+++ b/src/components/GreedyChallengeLayout.tsx
@@ -253,7 +253,7 @@ export default function GreedyChallengeLayout({ challenge }: Props) {
               ) : activeTab === "pseudocode" ? (
                 <PseudocodeTab solution={challenge.solution} customPseudocode={challenge.pseudocode} />
               ) : (
-                <RealWorldUsesTab challengeTitle={challenge.title} category="greedy" />
+                <RealWorldUsesTab challengeId={challenge.id} challengeSlug={challenge.slug} challengeTitle={challenge.title} category="greedy" />
               )}
             </div>
           </div>

--- a/src/components/Quiz/ShareResultModal.tsx
+++ b/src/components/Quiz/ShareResultModal.tsx
@@ -6,6 +6,7 @@ import { FaLinkedin } from 'react-icons/fa';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import ShareResultCard from './ShareResultCard';
 import { renderShareCardToPngBlob } from '../../utils/shareResultImage';
+import { slugify } from '../../utils/slugUtils';
 import styles from './ShareResultModal.module.css';
 
 export interface ShareResultModalProps {
@@ -20,14 +21,8 @@ export interface ShareResultModalProps {
 type ActionStatus = 'idle' | 'working' | 'done' | 'error';
 const RESET_DELAY_MS = 2500;
 
-function slugify(value: string): string {
-  return (
-    value
-      .toLowerCase()
-      .trim()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/(^-|-$)/g, '') || 'quiz-result'
-  );
+function getShareSlug(value: string): string {
+  return slugify(value, 'quiz-result');
 }
 
 export default function ShareResultModal({
@@ -66,7 +61,7 @@ export default function ShareResultModal({
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `${slugify(topic)}-quiz-result.png`;
+      link.download = `${getShareSlug(topic)}-quiz-result.png`;
       link.click();
       URL.revokeObjectURL(url);
       setDownloadStatus('done');
@@ -94,7 +89,7 @@ export default function ShareResultModal({
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
         link.href = url;
-        link.download = `${slugify(topic)}-quiz-result.png`;
+        link.download = `${getShareSlug(topic)}-quiz-result.png`;
         link.click();
         URL.revokeObjectURL(url);
       }

--- a/src/components/RealWorldUsesTab.tsx
+++ b/src/components/RealWorldUsesTab.tsx
@@ -8,6 +8,7 @@
  */
 import React, { useState } from "react";
 import Link from "@docusaurus/Link";
+import { getCanonicalAlgoKey, toCanonicalSlug, type AlgoKey } from "../utils/slugUtils";
 import {
   FiCompass,
   FiExternalLink,
@@ -23,26 +24,7 @@ import {
   FiLayers,
 } from "react-icons/fi";
 
-/* ── All keys that exist in AlgorithmUseCases ───────────────────── */
-type AlgoKey =
-  | "Binary Search"
-  | "Merge Sort"
-  | "Bubble Sort"
-  | "Quick Sort"
-  | "DFS"
-  | "BFS"
-  | "Dijkstra Algorithm"
-  | "Stack"
-  | "Queue"
-  | "Linked List"
-  | "Recursion"
-  | "Dynamic Programming"
-  | "Trees"
-  | "Graphs"
-  | "Backtracking"
-  | "Greedy Algorithms"
-  | "Heaps"
-  | "Tries";
+/* ── AlgoKey type is imported from ../utils/slugUtils ──────────── */
 
 /* ── Map challenge title keywords → AlgoKey ────────────────────── */
 const TITLE_MAP: { pattern: RegExp; key: AlgoKey }[] = [
@@ -318,13 +300,25 @@ const DATA: Record<AlgoKey, AlgoDetails> = {
   },
 };
 
-/* ── Resolve challenge title + category to an AlgoKey ──────────── */
-function resolveKey(title: string, category?: string): AlgoKey | null {
+/* ── Resolve challenge ID, slug, title + category to an AlgoKey ──────────── */
+function resolveKey(
+  challengeTitle: string,
+  category?: string,
+  challengeId?: string,
+  challengeSlug?: string
+): AlgoKey | null {
+  const canonical =
+    getCanonicalAlgoKey(challengeId, category) ||
+    getCanonicalAlgoKey(challengeSlug, category) ||
+    getCanonicalAlgoKey(challengeTitle, category);
+
+  if (canonical) return canonical;
+
   for (const { pattern, key } of TITLE_MAP) {
-    if (pattern.test(title)) return key;
+    if (pattern.test(challengeTitle)) return key;
   }
   if (category) {
-    const normalized = category.toLowerCase().replace(/\s+/g, "-");
+    const normalized = toCanonicalSlug(category);
     if (CATEGORY_MAP[normalized]) return CATEGORY_MAP[normalized];
   }
   return null;
@@ -332,6 +326,10 @@ function resolveKey(title: string, category?: string): AlgoKey | null {
 
 /* ── Props ──────────────────────────────────────────────────────── */
 interface RealWorldUsesTabProps {
+  /** Optional challenge ID */
+  challengeId?: string;
+  /** Optional challenge slug */
+  challengeSlug?: string;
   /** Challenge title, used for keyword matching */
   challengeTitle: string;
   /** Optional category hint ("sorting", "graph", "dp", "greedy", etc.) */
@@ -339,8 +337,13 @@ interface RealWorldUsesTabProps {
 }
 
 /* ── Component ──────────────────────────────────────────────────── */
-export default function RealWorldUsesTab({ challengeTitle, category }: RealWorldUsesTabProps) {
-  const algoKey = resolveKey(challengeTitle, category);
+export default function RealWorldUsesTab({
+  challengeId,
+  challengeSlug,
+  challengeTitle,
+  category,
+}: RealWorldUsesTabProps) {
+  const algoKey = resolveKey(challengeTitle, category, challengeId, challengeSlug);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
   if (!algoKey) {

--- a/src/components/RelatedProblems.tsx
+++ b/src/components/RelatedProblems.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import dsaProblemsIndex from '../data/generated/dsaProblemsIndex.json';
+import { toCanonicalSlug } from '../utils/slugUtils';
 
 export interface DsaProblemIndexItem {
   id: string;
@@ -106,11 +107,7 @@ export function getRelatedDsaProblems(
     targetTags = currentDoc.tags
       .map((t) => {
         const raw = typeof t === 'string' ? t : t.label || '';
-        return raw
-          .toLowerCase()
-          .trim()
-          .replace(/[^a-z0-9\s-]/g, '')
-          .replace(/\s+/g, '-');
+        return toCanonicalSlug(raw);
       })
       .filter(Boolean);
   }

--- a/src/components/SortingChallengeLayout.tsx
+++ b/src/components/SortingChallengeLayout.tsx
@@ -253,7 +253,7 @@ export default function SortingChallengeLayout({ challenge }: Props) {
               ) : activeTab === "pseudocode" ? (
                 <PseudocodeTab solution={challenge.solution} customPseudocode={challenge.pseudocode} />
               ) : (
-                <RealWorldUsesTab challengeTitle={challenge.title} category="sorting" />
+                <RealWorldUsesTab challengeId={challenge.id} challengeSlug={challenge.slug} challengeTitle={challenge.title} category="sorting" />
               )}
             </div>
           </div>

--- a/src/utils/slugUtils.ts
+++ b/src/utils/slugUtils.ts
@@ -1,0 +1,152 @@
+/**
+ * Centralized utility for canonical ID and slug conversion across the application.
+ * Unifies title, topic ID, challenge ID, and frontmatter ID handling to avoid mismatched lookups.
+ */
+
+export type AlgoKey =
+  | "Binary Search"
+  | "Merge Sort"
+  | "Bubble Sort"
+  | "Quick Sort"
+  | "DFS"
+  | "BFS"
+  | "Dijkstra Algorithm"
+  | "Stack"
+  | "Queue"
+  | "Linked List"
+  | "Recursion"
+  | "Dynamic Programming"
+  | "Trees"
+  | "Graphs"
+  | "Backtracking"
+  | "Greedy Algorithms"
+  | "Heaps"
+  | "Tries";
+
+/**
+ * Converts any string (title, id, or slug) into a clean, canonical URL-safe slug.
+ */
+export function toCanonicalSlug(value: string): string {
+  if (!value) return "";
+  return value
+    .toLowerCase()
+    .trim()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/['’]/g, "")
+    .replace(/^quiz\s+on\s+/i, "")
+    .replace(/^implement\s+/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+/**
+ * Standardized slugify function with custom default fallback for component exports / share links.
+ */
+export function slugify(value: string, fallback: string = "cheatsheet"): string {
+  const slug = toCanonicalSlug(value);
+  return slug || fallback;
+}
+
+const ALGO_KEY_BY_CANONICAL_SLUG: Record<string, AlgoKey> = {
+  "binary-search": "Binary Search",
+  "merge-sort": "Merge Sort",
+  "bubble-sort": "Bubble Sort",
+  "quick-sort": "Quick Sort",
+  "dfs": "DFS",
+  "depth-first-search": "DFS",
+  "bfs": "BFS",
+  "breadth-first-search": "BFS",
+  "dijkstra": "Dijkstra Algorithm",
+  "dijkstra-algorithm": "Dijkstra Algorithm",
+  "dijkstras-algorithm": "Dijkstra Algorithm",
+  "bellman-ford": "Dijkstra Algorithm",
+  "floyd-warshall": "Dijkstra Algorithm",
+  "stack": "Stack",
+  "stacks": "Stack",
+  "queue": "Queue",
+  "queues": "Queue",
+  "linked-list": "Linked List",
+  "linked-lists": "Linked List",
+  "recursion": "Recursion",
+  "recurs": "Recursion",
+  "dynamic-programming": "Dynamic Programming",
+  "dp": "Dynamic Programming",
+  "tree": "Trees",
+  "trees": "Trees",
+  "binary-tree": "Trees",
+  "binary-trees": "Trees",
+  "bst": "Trees",
+  "binary-search-tree": "Trees",
+  "graph": "Graphs",
+  "graphs": "Graphs",
+  "backtracking": "Backtracking",
+  "greedy": "Greedy Algorithms",
+  "greedy-algorithms": "Greedy Algorithms",
+  "heap": "Heaps",
+  "heaps": "Heaps",
+  "trie": "Tries",
+  "tries": "Tries",
+};
+
+const CATEGORY_MAP: Record<string, AlgoKey> = {
+  sorting: "Quick Sort",
+  graph: "Graphs",
+  graphs: "Graphs",
+  dp: "Dynamic Programming",
+  "dynamic-programming": "Dynamic Programming",
+  greedy: "Greedy Algorithms",
+  tree: "Trees",
+  trees: "Trees",
+  backtracking: "Backtracking",
+  heap: "Heaps",
+  heaps: "Heaps",
+  trie: "Tries",
+  tries: "Tries",
+  "linked-list": "Linked List",
+  stack: "Stack",
+  queue: "Queue",
+  recursion: "Recursion",
+};
+
+/**
+ * Resolves a given identifier (challenge ID, slug, title, or topic) and optional category
+ * into the canonical AlgoKey for algorithm use cases.
+ */
+export function getCanonicalAlgoKey(input?: string | null, category?: string | null): AlgoKey | null {
+  if (input) {
+    const slug = toCanonicalSlug(input);
+    if (ALGO_KEY_BY_CANONICAL_SLUG[slug]) {
+      return ALGO_KEY_BY_CANONICAL_SLUG[slug];
+    }
+
+    // Secondary substring matches for complex problem titles
+    if (slug.includes("binary-search")) return "Binary Search";
+    if (slug.includes("merge-sort")) return "Merge Sort";
+    if (slug.includes("bubble-sort")) return "Bubble Sort";
+    if (slug.includes("quick-sort")) return "Quick Sort";
+    if (slug.includes("heap-sort") || slug.includes("priority-queue")) return "Heaps";
+    if (slug.includes("dijkstra") || slug.includes("shortest-path")) return "Dijkstra Algorithm";
+    if (slug.includes("dfs") || slug.includes("depth-first")) return "DFS";
+    if (slug.includes("bfs") || slug.includes("breadth-first")) return "BFS";
+    if (slug.includes("tree") || slug.includes("inorder") || slug.includes("preorder") || slug.includes("postorder") || slug.includes("lca")) return "Trees";
+    if (slug.includes("graph")) return "Graphs";
+    if (slug.includes("trie")) return "Tries";
+    if (slug.includes("linked-list")) return "Linked List";
+    if (slug.includes("stack")) return "Stack";
+    if (slug.includes("queue")) return "Queue";
+    if (slug.includes("backtrack")) return "Backtracking";
+    if (slug.includes("greedy") || slug.includes("cookie") || slug.includes("knapsack-fractional")) return "Greedy Algorithms";
+    if (slug.includes("dp") || slug.includes("dynamic") || slug.includes("knapsack") || slug.includes("lcs") || slug.includes("fibonacci")) return "Dynamic Programming";
+    if (slug.includes("recurs")) return "Recursion";
+  }
+
+  if (category) {
+    const catSlug = toCanonicalSlug(category);
+    if (CATEGORY_MAP[catSlug]) {
+      return CATEGORY_MAP[catSlug];
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes the brittle title → slug ID generation pattern used by AlgorithmUseCases and other tag-based components.

Instead of independently generating identifiers from display titles, components now use the canonical problem.id / frontmatter ID wherever available.

This prevents mismatches between components that reference the same algorithm using different ID-generation rules.

Fixes #3801 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
