### PR TITLE
fix(ts): enable downlevelIteration to resolve TS2802

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "downlevelIteration": true,
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Description
This PR resolves issue #3807 where TypeScript compilation failed with `TS2802` when iterating over `Set` and `Map` collections in several components (e.g., `AStarVisualizer.tsx`, `GraphVisualizer.tsx`, `DSALearningRoadmap/index.tsx`).

The issue was caused by targeting `es5` without enabling `downlevelIteration` in `tsconfig.json`.

## Changes Made
- Enabled `"downlevelIteration": true` in `tsconfig.json` to properly compile iterations over `Map` and `Set` collections.

## Related Issues
Closes #3807