### PR TITLE
fix(ts): add @types/react-katex to resolve TS7016

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@testing-library/user-event": "^14.5.2",
         "@types/d3-force": "^3.0.10",
         "@types/jest": "^29.5.12",
+        "@types/react-katex": "^3.0.4",
         "autoprefixer": "^10.4.20",
         "concurrently": "^8.2.2",
         "cross-env": "^10.1.0",
@@ -8522,6 +8523,16 @@
       "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-katex": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/react-katex/-/react-katex-3.0.4.tgz",
+      "integrity": "sha512-aLkykKzSKLpXI6REJ3uClao6P47HAFfR1gcHOZwDeTuALsyjgMhz+oynLV4gX0kiJVnvHrBKF/TLXqyNTpHDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-router": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "@testing-library/user-event": "^14.5.2",
     "@types/d3-force": "^3.0.10",
     "@types/jest": "^29.5.12",
+    "@types/react-katex": "^3.0.4",
     "autoprefixer": "^10.4.20",
     "concurrently": "^8.2.2",
     "cross-env": "^10.1.0",


### PR DESCRIPTION
## Description
This PR resolves issue #3808 where TypeScript compilation failed with `TS7016` errors in files relying on math rendering (e.g., `complexity-comparison.tsx`, `complexity-visualizer.tsx`, and `bfs-dfs.tsx`) due to missing type declarations for the `react-katex` package.

## Changes Made
- Installed the community types package `@types/react-katex` as a development dependency.

## Related Issues
Closes #3808
