### PR TITLE
fix(ts): add explicit number type to formatTime seconds parameter to resolve TS7006

### DIFF
--- a/src/pages/challenges/challenge1.tsx
+++ b/src/pages/challenges/challenge1.tsx
@@ -222,7 +222,7 @@ const DataStructuresQuiz: React.FC = () => {
 
 
   // Format time as MM:SS
-  const formatTime = (seconds) => {
+  const formatTime = (seconds: number) => {
     const minutes = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${String(minutes).padStart(2, "0")}:${String(secs).padStart(

--- a/src/pages/challenges/challenge2.tsx
+++ b/src/pages/challenges/challenge2.tsx
@@ -245,7 +245,7 @@ const DataStructuresQuiz = () => {
 
 
   // Format time as MM:SS
-  const formatTime = (seconds) => {
+  const formatTime = (seconds: number) => {
     const minutes = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${String(minutes).padStart(2, "0")}:${String(secs).padStart(

--- a/src/pages/challenges/challenge3.tsx
+++ b/src/pages/challenges/challenge3.tsx
@@ -331,7 +331,7 @@ const DataStructuresQuiz = () => {
 
 
   // Format time as MM:SS
-  const formatTime = (seconds) => {
+  const formatTime = (seconds: number) => {
     const minutes = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${String(minutes).padStart(2, "0")}:${String(secs).padStart(


### PR DESCRIPTION
## Description
This PR resolves issue #3809 by explicitly typing the `seconds` parameter in the `formatTime` helper functions across the coding challenges (`challenge1.tsx`, `challenge2.tsx`, and `challenge3.tsx`).

This addresses the `TS7006` (implicit `any` type) compilation errors.

## Changes Made
- Added the `: number` explicit type annotation to `seconds` in `formatTime`.

## Related Issues
Closes #3809