### PR TITLE
fix(theme): use clsx instead of comma operator for className to resolve TS18007

### DIFF
--- a/src/theme/DocCard/index.tsx
+++ b/src/theme/DocCard/index.tsx
@@ -86,7 +86,7 @@ function CardCategory({ item }: { item: PropSidebarItemCategory }): ReactNode {
 function CardLink({ item }: { item: PropSidebarItemLink }): ReactNode {
   const doc = useDocById(item.docId ?? undefined);
   return (
-    <div className={styles.responsiveCardWrapper, item.className}>
+    <div className={clsx(styles.responsiveCardWrapper, item.className)}>
       <Layout
         item={item}
         href={item.href}


### PR DESCRIPTION
## Description
This PR resolves issue #3810 by fixing an invalid comma operator used in JSX (`TS18007`). In `src/theme/DocCard/index.tsx`, the `className` prop incorrectly contained a comma operator (`className={styles.responsiveCardWrapper, item.className}`).

## Changes Made
- Wrapped the class names properly using the `clsx` package, converting it to `className={clsx(styles.responsiveCardWrapper, item.className)}`.

## Related Issues
Closes #3810
