### PR TITLE
fix(components): check if midVal is undefined before comparison to resolve TS18048

### DIFF
--- a/src/components/Visualizing/RecursionVisualizer.tsx
+++ b/src/components/Visualizing/RecursionVisualizer.tsx
@@ -418,7 +418,7 @@ function RecursionVisualizer() {
         nodes[parentId].children.push(id);
       }
       
-      if (hasMid && midVal !== target) {
+      if (hasMid && midVal !== undefined && midVal !== target) {
         if (midVal < target) {
           buildTree(mid + 1, high, id);
         } else {


### PR DESCRIPTION
## Description
This PR resolves issue #3811 by fixing a `TS18048` error where `midVal` was possibly undefined before a comparison was made. 

In `src/components/Visualizing/RecursionVisualizer.tsx`, the `midVal` variable is now explicitly checked (`midVal !== undefined`) before executing the `<` comparison with `target`.

## Changes Made
- Added a `!== undefined` check to the `midVal` condition in `RecursionVisualizer.tsx`.

## Related Issues
Closes #3811
