### PR TITLE
fix: avoid setState in componentDidMount

### DIFF
--- a/src/__tests__/components/QuizErrorBoundary.test.tsx
+++ b/src/__tests__/components/QuizErrorBoundary.test.tsx
@@ -18,12 +18,7 @@ describe("QuizErrorBoundary", () => {
 
   test("renders the fallback UI when a child throws", () => {
     // Error boundaries still log to console.error during tests; suppress noise.
-    const spy = jest
-    .spyOn(console, "error")
-    .mockImplementation((...args) => {
-      // Error boundaries log to console.error during tests; suppress the noise.
-      void args;
-    });
+    const spy = jest.spyOn(console, "error").mockReturnValue(undefined);
     render(
       <QuizErrorBoundary>
         <Bomb />

--- a/src/__tests__/components/QuizErrorBoundary.test.tsx
+++ b/src/__tests__/components/QuizErrorBoundary.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { render, screen } from "../testUtils";
+import QuizErrorBoundary from "../../components/Quiz/QuizErrorBoundary";
+
+function Bomb(): JSX.Element {
+  throw new Error("boom");
+}
+
+describe("QuizErrorBoundary", () => {
+  test("renders children normally when there is no error", () => {
+    render(
+      <QuizErrorBoundary>
+        <div>Quiz content</div>
+      </QuizErrorBoundary>
+    );
+    expect(screen.getByText("Quiz content")).toBeInTheDocument();
+  });
+
+  test("renders the fallback UI when a child throws", () => {
+    // Error boundaries still log to console.error during tests; suppress noise.
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <QuizErrorBoundary>
+        <Bomb />
+      </QuizErrorBoundary>
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  test("renders the toast container (no longer gated behind componentDidMount/setState)", () => {
+    const { container } = render(
+      <QuizErrorBoundary>
+        <div>Quiz content</div>
+      </QuizErrorBoundary>
+    );
+    // react-toastify renders a container div with this class immediately,
+    // since BrowserOnly's mock resolves synchronously — confirming the
+    // toast UI is present without needing a post-mount setState render.
+    expect(container.querySelector(".Toastify")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/QuizErrorBoundary.test.tsx
+++ b/src/__tests__/components/QuizErrorBoundary.test.tsx
@@ -18,7 +18,13 @@ describe("QuizErrorBoundary", () => {
 
   test("renders the fallback UI when a child throws", () => {
     // Error boundaries still log to console.error during tests; suppress noise.
-    const spy = jest.spyOn(console, "error").mockReturnValue(undefined);
+    const suppressConsoleError = (..._args: unknown[]): void => {
+  // Intentionally suppress console.error output from error-boundary tests.
+};
+
+const spy = jest
+  .spyOn(console, "error")
+  .mockImplementation(suppressConsoleError);
     render(
       <QuizErrorBoundary>
         <Bomb />

--- a/src/__tests__/components/QuizErrorBoundary.test.tsx
+++ b/src/__tests__/components/QuizErrorBoundary.test.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { render, screen } from "../testUtils";
 import QuizErrorBoundary from "../../components/Quiz/QuizErrorBoundary";
 
-function Bomb(): JSX.Element {
+const Bomb = (): JSX.Element => {
   throw new Error("boom");
-}
+};
 
 describe("QuizErrorBoundary", () => {
   test("renders children normally when there is no error", () => {
@@ -18,7 +18,12 @@ describe("QuizErrorBoundary", () => {
 
   test("renders the fallback UI when a child throws", () => {
     // Error boundaries still log to console.error during tests; suppress noise.
-    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const spy = jest
+    .spyOn(console, "error")
+    .mockImplementation((...args) => {
+      // Error boundaries log to console.error during tests; suppress the noise.
+      void args;
+    });
     render(
       <QuizErrorBoundary>
         <Bomb />

--- a/src/components/Quiz/QuizErrorBoundary.tsx
+++ b/src/components/Quiz/QuizErrorBoundary.tsx
@@ -1,5 +1,6 @@
 import React, { Component, ReactNode } from "react";
 import { ToastContainer } from "react-toastify";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 import "react-toastify/dist/ReactToastify.css";
 
 interface Props {
@@ -9,26 +10,20 @@ interface Props {
 interface State {
   hasError: boolean;
   errorMessage: string;
-  isMounted: boolean;
 }
 
 class QuizErrorBoundary extends Component<Props, State> {
   public state: State = {
     hasError: false,
     errorMessage: "",
-    isMounted: false,
   };
 
   public static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, errorMessage: error.message, isMounted: true };
+    return { hasError: true, errorMessage: error.message };
   }
 
   public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     console.error("Quiz Error:", error, errorInfo);
-  }
-
-  public componentDidMount() {
-    this.setState({ isMounted: true });
   }
 
   public render() {
@@ -55,7 +50,9 @@ class QuizErrorBoundary extends Component<Props, State> {
     return (
       <>
         {content}
-        {this.state.isMounted && <ToastContainer theme="dark" position="top-right" toastClassName="font-mono text-sm" />}
+        <BrowserOnly>
+          {() => <ToastContainer theme="dark" position="top-right" toastClassName="font-mono text-sm" />}
+        </BrowserOnly>
       </>
     );
   }


### PR DESCRIPTION
## 📥 Pull Request

### Description
This PR addresses JS-0442: Avoid using setState in componentDidMount reported by DeepSource.

What changed
Located the single occurrence of setState() being used inside componentDidMount().
Refactored the component initialization logic to avoid triggering an unnecessary state update immediately after mounting.
Preserved the existing component behavior and UI output.
Ensured that the required initial state is established before rendering where possible.

Fixes #3824 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
