### PR TITLE
fix(RelatedProblems): stricter url suffix matching 

### DIFF
--- a/src/components/RelatedProblems.tsx
+++ b/src/components/RelatedProblems.tsx
@@ -87,7 +87,7 @@ export function getRelatedDsaProblems(
   const isDsaProblemDoc =
     permalink.includes('/docs/dsa-problems/') ||
     docId.startsWith('dsa-problems/') ||
-    data.problems.some((p) => p.url === permalink || (permalink && permalink.endsWith(p.url)));
+    data.problems.some((p) => p.url === permalink || (permalink && permalink.endsWith('/' + p.url.replace(/^\//, ''))));
 
   if (!isDsaProblemDoc) return [];
 
@@ -95,9 +95,9 @@ export function getRelatedDsaProblems(
   const currentProblem = data.problems.find(
     (p) =>
       p.url === permalink ||
-      (permalink && permalink.endsWith(p.url)) ||
+      (permalink && permalink.endsWith('/' + p.url.replace(/^\//, ''))) ||
       p.id === docId ||
-      (docId && docId.endsWith(p.id))
+      (docId && docId.endsWith('/' + p.id.replace(/^\//, '')))
   );
 
   let targetTags: string[] = [];

--- a/src/components/RelatedProblems.tsx
+++ b/src/components/RelatedProblems.tsx
@@ -87,7 +87,7 @@ export function getRelatedDsaProblems(
   const isDsaProblemDoc =
     permalink.includes('/docs/dsa-problems/') ||
     docId.startsWith('dsa-problems/') ||
-    data.problems.some((p) => p.url === permalink || (permalink && permalink.endsWith('/' + p.url.replace(/^\//, ''))));
+    data.problems.some((p) => p.url === permalink || permalink.endsWith(`/${p.url.startsWith('/') ? p.url.slice(1) : p.url}`));
 
   if (!isDsaProblemDoc) return [];
 
@@ -95,9 +95,9 @@ export function getRelatedDsaProblems(
   const currentProblem = data.problems.find(
     (p) =>
       p.url === permalink ||
-      (permalink && permalink.endsWith('/' + p.url.replace(/^\//, ''))) ||
+      permalink.endsWith(`/${p.url.startsWith('/') ? p.url.slice(1) : p.url}`) ||
       p.id === docId ||
-      (docId && docId.endsWith('/' + p.id.replace(/^\//, '')))
+      docId.endsWith(`/${p.id.startsWith('/') ? p.id.slice(1) : p.id}`)
   );
 
   let targetTags: string[] = [];


### PR DESCRIPTION
Description

Fix #3840 

Fixes an issue in RelatedProblems.tsx where loose suffix matching produced false positive matches for related problems.

Previously, permalink.endsWith(p.url) and docId.endsWith(p.id) were used to identify the current problem being viewed. If p.url was a short path like /two-sum, any permalink ending in that string (like /not-two-sum) would incorrectly match it. This also caused unrelated problems to be silently excluded from recommendations.

This PR replaces endsWith(str) with stricter path-segment checks: endsWith('/' + str.replace(/^\//, '')) to ensure the suffix strictly starts at a / boundary.

Changes Made

Updated isDsaProblemDoc check to use strict path-boundary checking.
Updated currentProblem matching in getRelatedDsaProblems to use strict path-boundary checking.