### PR TITLE
fix(exportQuizData): use tab for formula injection escape 

### DIFF
--- a/src/__tests__/utils/exportQuizData.test.ts
+++ b/src/__tests__/utils/exportQuizData.test.ts
@@ -78,7 +78,7 @@ describe("exportQuizData utility", () => {
       const csv = serializeQuizStatsToCsv(dangerousStats);
       const lines = csv.split("\n");
 
-      expect(lines[1]).toContain("'=HACK,0,0,0,0,1,in-progress,,");
+      expect(lines[1]).toContain("\t=HACK,0,0,0,0,1,in-progress,,");
     });
   });
 

--- a/src/utils/exportQuizData.ts
+++ b/src/utils/exportQuizData.ts
@@ -9,7 +9,7 @@ function escapeCsvField(val: string | number | null | undefined): string {
 
   const str = String(val);
   const needsFormulaEscape = /^[=+\-@]/.test(str);
-  const safeValue = needsFormulaEscape ? `'${str}` : str;
+  const safeValue = needsFormulaEscape ? `\t${str}` : str;
 
   if (safeValue.includes(",") || safeValue.includes('"') || safeValue.includes("\n") || safeValue.includes("\r")) {
     return `"${safeValue.replace(/"/g, '""')}"`;


### PR DESCRIPTION
Description
Fixes an issue with CSV formula injection escape where a single quote (') was prepended before quoting, causing programmatic RFC 4180–compliant parsers to receive corrupted data like "'=SUM(A1)".

This PR changes the formula injection escape prefix from a single quote (') to a tab character (\t). Spreadsheet apps (like Excel) will ignore the tab visually and prevent formula execution, but this stops the spurious ' character from bleeding into programmatically parsed strings.

Fix #3841

Changes Made

Changed the needsFormulaEscape prefix from ' to \t in escapeCsvField logic within exportQuizData.ts.
Updated test assertions to match the new \t prefix for formula escapes.