### PR TITLE
fix: reset modal state on open, resolve React hook warnings and DeepSource JS-0022/consistent-return

### DIFF
--- a/src/components/Quiz/ShareResultModal.tsx
+++ b/src/components/Quiz/ShareResultModal.tsx
@@ -40,15 +40,35 @@ export default function ShareResultModal({
   const [copyStatus, setCopyStatus] = useState<ActionStatus>('idle');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const downloadTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Reset all action state when the modal opens so stale errors from a
+  // previous session are never visible before the user takes any action.
+  useEffect(() => {
+    if (isOpen) {
+      setDownloadStatus('idle');
+      setCopyStatus('idle');
+      setErrorMessage('');
+    }
+  }, [isOpen, setDownloadStatus, setCopyStatus, setErrorMessage]);
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (downloadStatus === 'done' || downloadStatus === 'error') {
+      timer = setTimeout(() => setDownloadStatus('idle'), RESET_DELAY_MS);
+    }
     return () => {
-      if (downloadTimeoutRef.current) clearTimeout(downloadTimeoutRef.current);
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (timer) clearTimeout(timer);
     };
-  }, []);
+  }, [downloadStatus, setDownloadStatus]);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (copyStatus === 'done' || copyStatus === 'error') {
+      timer = setTimeout(() => setCopyStatus('idle'), RESET_DELAY_MS);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [copyStatus, setCopyStatus]);
 
   const shareText = `I scored ${score}/${total} on the ${topic} quiz on ${siteName}! 🎯`;
   const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
@@ -66,13 +86,10 @@ export default function ShareResultModal({
       URL.revokeObjectURL(url);
       setDownloadStatus('done');
     } catch (err) {
-      console.error('[ShareResultModal] Download failed:', err);
       setErrorMessage(err instanceof Error ? err.message : 'Download failed.');
       setDownloadStatus('error');
-    } finally {
-      downloadTimeoutRef.current = setTimeout(() => setDownloadStatus('idle'), RESET_DELAY_MS);
     }
-  }, [topic, score, total, siteName]);
+  }, [topic, score, total, siteName, setDownloadStatus, setErrorMessage]);
 
   const handleCopyImage = useCallback(async () => {
     setCopyStatus('working');
@@ -95,13 +112,10 @@ export default function ShareResultModal({
       }
       setCopyStatus('done');
     } catch (err) {
-      console.error('[ShareResultModal] Copy failed:', err);
       setErrorMessage(err instanceof Error ? err.message : 'Copy failed.');
       setCopyStatus('error');
-    } finally {
-      copyTimeoutRef.current = setTimeout(() => setCopyStatus('idle'), RESET_DELAY_MS);
     }
-  }, [topic, score, total, siteName]);
+  }, [topic, score, total, siteName, setCopyStatus, setErrorMessage]);
 
   const openShareWindow = (url: string) => {
     window.open(url, '_blank', 'noopener,noreferrer,width=600,height=500');
@@ -121,7 +135,9 @@ export default function ShareResultModal({
     openShareWindow(url);
   };
 
-  if (!isOpen) return null;
+  if (!isOpen) {
+    return null;
+  }
 
   const downloadLabel = { idle: 'Download PNG', working: 'Preparing…', done: 'Downloaded!', error: 'Try again' }[
     downloadStatus
@@ -129,9 +145,15 @@ export default function ShareResultModal({
   const copyLabel = { idle: 'Copy image', working: 'Copying…', done: 'Copied!', error: 'Try again' }[copyStatus];
 
   const renderStatusIcon = (status: ActionStatus, IdleIcon: React.ComponentType<{ size?: number }>) => {
-    if (status === 'working') return <FiLoader size={16} className={styles.spin} />;
-    if (status === 'done') return <FiCheck size={16} />;
-    if (status === 'error') return <FiAlertCircle size={16} />;
+    if (status === 'working') {
+      return <FiLoader size={16} className={styles.spin} />;
+    }
+    if (status === 'done') {
+      return <FiCheck size={16} />;
+    }
+    if (status === 'error') {
+      return <FiAlertCircle size={16} />;
+    }
     return <IdleIcon size={16} />;
   };
 

--- a/src/components/Quiz/ShareResultModal.tsx
+++ b/src/components/Quiz/ShareResultModal.tsx
@@ -30,8 +30,14 @@ export interface ShareResultModalProps {
 type ActionStatus = 'idle' | 'working' | 'done' | 'error';
 const RESET_DELAY_MS = 2500;
 
+/**
+ * Generates a slug for the share image
+ */
 const getShareSlug = (value: string): string => slugify(value, 'quiz-result');
 
+/**
+ * Header component for the modal
+ */
 const ModalHeader = ({ onClose }: { onClose: () => void }) => (
   <div className={styles.header}>
     <h2 id="share-result-modal-title" className={styles.title}>
@@ -45,6 +51,25 @@ const ModalHeader = ({ onClose }: { onClose: () => void }) => (
     >
       <FiX size={18} />
     </button>
+  </div>
+);
+
+/**
+ * Wrapper component for the modal to reduce JSX nesting depth
+ */
+const ModalWrapper = ({ onClose, modalRef, children }: { onClose: () => void; modalRef: React.RefObject<HTMLDivElement>; children: React.ReactNode }) => (
+  <div onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') onClose(); }} role="presentation" className={styles.overlay}>
+    <div
+      ref={modalRef}
+      onClick={e => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="share-result-modal-title"
+      className={styles.modal}
+    >
+      {children}
+    </div>
   </div>
 );
 
@@ -132,10 +157,9 @@ const ShareResultModal = ({
         total,
         siteName,
       );
-      // skipcq: JS-0323
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const ClipboardItemCtor = typeof window !== 'undefined'
-        ? (window as any).ClipboardItem
+        ? (window as any).ClipboardItem // skipcq: JS-0323
         : undefined;
 
       if (navigator.clipboard && ClipboardItemCtor) {
@@ -213,17 +237,8 @@ const ShareResultModal = ({
   };
 
   return (
-    <div onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') onClose(); }} role="presentation" className={styles.overlay}>
-      <div
-        ref={modalRef}
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="share-result-modal-title"
-        className={styles.modal}
-      >
-        <ModalHeader onClose={onClose} />
+    <ModalWrapper onClose={onClose} modalRef={modalRef}>
+      <ModalHeader onClose={onClose} />
 
         <div className={styles.preview}>
           <ShareResultCard
@@ -277,8 +292,7 @@ const ShareResultModal = ({
               {errorMessage}
             </p>
         )}
-      </div>
-    </div>
+    </ModalWrapper>
   );
 };
 

--- a/src/components/Quiz/ShareResultModal.tsx
+++ b/src/components/Quiz/ShareResultModal.tsx
@@ -1,13 +1,20 @@
-import React, { useCallback, useRef, useState, useEffect } from 'react';
-import clsx from 'clsx';
-import { FiDownload, FiImage, FiCheck, FiAlertCircle, FiLoader, FiX } from 'react-icons/fi';
-import { FaXTwitter } from 'react-icons/fa6';
-import { FaLinkedin } from 'react-icons/fa';
-import { useFocusTrap } from '../../hooks/useFocusTrap';
-import ShareResultCard from './ShareResultCard';
-import { renderShareCardToPngBlob } from '../../utils/shareResultImage';
-import { slugify } from '../../utils/slugUtils';
-import styles from './ShareResultModal.module.css';
+import React, { useCallback, useRef, useState, useEffect } from "react";
+import clsx from "clsx";
+import {
+  FiDownload,
+  FiImage,
+  FiCheck,
+  FiAlertCircle,
+  FiLoader,
+  FiX
+} from "react-icons/fi";
+import { FaXTwitter } from "react-icons/fa6";
+import { FaLinkedin } from "react-icons/fa";
+import { useFocusTrap } from "../../hooks/useFocusTrap";
+import ShareResultCard from "./ShareResultCard";
+import { renderShareCardToPngBlob } from "../../utils/shareResultImage";
+import { slugify } from "../../utils/slugUtils";
+import styles from "./ShareResultModal.module.css";
 
 export interface ShareResultModalProps {
   isOpen: boolean;
@@ -18,11 +25,11 @@ export interface ShareResultModalProps {
   siteName?: string;
 }
 
-type ActionStatus = 'idle' | 'working' | 'done' | 'error';
+type ActionStatus = "idle" | "working" | "done" | "error";
 const RESET_DELAY_MS = 2500;
 
 function getShareSlug(value: string): string {
-  return slugify(value, 'quiz-result');
+  return slugify(value, "quiz-result");
 }
 
 export default function ShareResultModal({
@@ -31,29 +38,29 @@ export default function ShareResultModal({
   topic,
   score,
   total,
-  siteName = 'Algo',
+  siteName = "Algo"
 }: ShareResultModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   useFocusTrap(modalRef, { isOpen, onClose });
 
-  const [downloadStatus, setDownloadStatus] = useState<ActionStatus>('idle');
-  const [copyStatus, setCopyStatus] = useState<ActionStatus>('idle');
-  const [errorMessage, setErrorMessage] = useState('');
+  const [downloadStatus, setDownloadStatus] = useState<ActionStatus>("idle");
+  const [copyStatus, setCopyStatus] = useState<ActionStatus>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
 
   // Reset all action state when the modal opens so stale errors from a
   // previous session are never visible before the user takes any action.
   useEffect(() => {
     if (isOpen) {
-      setDownloadStatus('idle');
-      setCopyStatus('idle');
-      setErrorMessage('');
+      setDownloadStatus("idle");
+      setCopyStatus("idle");
+      setErrorMessage("");
     }
   }, [isOpen, setDownloadStatus, setCopyStatus, setErrorMessage]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
-    if (downloadStatus === 'done' || downloadStatus === 'error') {
-      timer = setTimeout(() => setDownloadStatus('idle'), RESET_DELAY_MS);
+    if (downloadStatus === "done" || downloadStatus === "error") {
+      timer = setTimeout(() => setDownloadStatus("idle"), RESET_DELAY_MS);
     }
     return () => {
       if (timer) clearTimeout(timer);
@@ -62,8 +69,8 @@ export default function ShareResultModal({
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
-    if (copyStatus === 'done' || copyStatus === 'error') {
-      timer = setTimeout(() => setCopyStatus('idle'), RESET_DELAY_MS);
+    if (copyStatus === "done" || copyStatus === "error") {
+      timer = setTimeout(() => setCopyStatus("idle"), RESET_DELAY_MS);
     }
     return () => {
       if (timer) clearTimeout(timer);
@@ -71,67 +78,85 @@ export default function ShareResultModal({
   }, [copyStatus, setCopyStatus]);
 
   const shareText = `I scored ${score}/${total} on the ${topic} quiz on ${siteName}! 🎯`;
-  const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
+  const shareUrl = typeof window !== "undefined" ? window.location.href : "";
 
   const handleDownload = useCallback(async () => {
-    setDownloadStatus('working');
-    setErrorMessage('');
+    setDownloadStatus("working");
+    setErrorMessage("");
     try {
-      const blob = await renderShareCardToPngBlob(topic, score, total, siteName);
+      const blob = await renderShareCardToPngBlob(
+        topic,
+        score,
+        total,
+        siteName
+      );
       const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
+      const link = document.createElement("a");
       link.href = url;
       link.download = `${getShareSlug(topic)}-quiz-result.png`;
       link.click();
       URL.revokeObjectURL(url);
-      setDownloadStatus('done');
+      setDownloadStatus("done");
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : 'Download failed.');
-      setDownloadStatus('error');
+      setErrorMessage(err instanceof Error ? err.message : "Download failed.");
+      setDownloadStatus("error");
     }
   }, [topic, score, total, siteName, setDownloadStatus, setErrorMessage]);
 
   const handleCopyImage = useCallback(async () => {
-    setCopyStatus('working');
-    setErrorMessage('');
+    setCopyStatus("working");
+    setErrorMessage("");
     try {
-      const blob = await renderShareCardToPngBlob(topic, score, total, siteName);
-      const ClipboardItemCtor = typeof window !== 'undefined' ? (window as any).ClipboardItem : undefined;
+      const blob = await renderShareCardToPngBlob(
+        topic,
+        score,
+        total,
+        siteName
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const ClipboardItemCtor =
+        typeof window !== "undefined"
+          ? (window as any).ClipboardItem
+          : undefined;
 
       if (navigator.clipboard && ClipboardItemCtor) {
-        await navigator.clipboard.write([new ClipboardItemCtor({ 'image/png': blob })]);
+        await navigator.clipboard.write([
+          new ClipboardItemCtor({ "image/png": blob })
+        ]);
       } else {
         // Clipboard image writes aren't supported everywhere (e.g. Firefox) —
         // fall back to a direct PNG download so the action still succeeds.
         const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
+        const link = document.createElement("a");
         link.href = url;
         link.download = `${getShareSlug(topic)}-quiz-result.png`;
         link.click();
         URL.revokeObjectURL(url);
       }
-      setCopyStatus('done');
+      setCopyStatus("done");
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : 'Copy failed.');
-      setCopyStatus('error');
+      setErrorMessage(err instanceof Error ? err.message : "Copy failed.");
+      setCopyStatus("error");
     }
   }, [topic, score, total, siteName, setCopyStatus, setErrorMessage]);
 
   const openShareWindow = (url: string) => {
-    window.open(url, '_blank', 'noopener,noreferrer,width=600,height=500');
+    window.open(url, "_blank", "noopener,noreferrer,width=600,height=500");
   };
 
   const handleShareTwitter = () => {
-    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(
-      shareUrl,
-    )}`;
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      shareText
+    )}&url=${encodeURIComponent(shareUrl)}`;
     openShareWindow(url);
   };
 
   const handleShareLinkedIn = () => {
     // LinkedIn's share endpoint only accepts a URL — it doesn't support
     // prefilled post text, so the caption is left for the user to add.
-    const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`;
+    const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+      shareUrl
+    )}`;
     openShareWindow(url);
   };
 
@@ -139,29 +164,41 @@ export default function ShareResultModal({
     return null;
   }
 
-  const downloadLabel = { idle: 'Download PNG', working: 'Preparing…', done: 'Downloaded!', error: 'Try again' }[
-    downloadStatus
-  ];
-  const copyLabel = { idle: 'Copy image', working: 'Copying…', done: 'Copied!', error: 'Try again' }[copyStatus];
+  const downloadLabel = {
+    idle: "Download PNG",
+    working: "Preparing…",
+    done: "Downloaded!",
+    error: "Try again"
+  }[downloadStatus];
+  const copyLabel = {
+    idle: "Copy image",
+    working: "Copying…",
+    done: "Copied!",
+    error: "Try again"
+  }[copyStatus];
 
-  const renderStatusIcon = (status: ActionStatus, IdleIcon: React.ComponentType<{ size?: number }>) => {
-    if (status === 'working') {
+  const renderStatusIcon = (
+    status: ActionStatus,
+    IdleIcon: React.ComponentType<{ size?: number }>
+  ) => {
+    if (status === "working") {
       return <FiLoader size={16} className={styles.spin} />;
     }
-    if (status === 'done') {
+    if (status === "done") {
       return <FiCheck size={16} />;
     }
-    if (status === 'error') {
+    if (status === "error") {
       return <FiAlertCircle size={16} />;
     }
     return <IdleIcon size={16} />;
   };
 
   return (
-    <div onClick={onClose} className={styles.overlay}>
+    <div onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') onClose(); }} role="presentation" className={styles.overlay}>
       <div
         ref={modalRef}
-        onClick={(e) => e.stopPropagation()}
+        onClick={e => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby="share-result-modal-title"
@@ -171,39 +208,68 @@ export default function ShareResultModal({
           <h2 id="share-result-modal-title" className={styles.title}>
             Share your result
           </h2>
-          <button type="button" onClick={onClose} aria-label="Close share dialog" className={styles.closeButton}>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close share dialog"
+            className={styles.closeButton}
+          >
             <FiX size={18} />
           </button>
         </div>
 
         <div className={styles.preview}>
-          <ShareResultCard topic={topic} score={score} total={total} siteName={siteName} />
+          <ShareResultCard
+            topic={topic}
+            score={score}
+            total={total}
+            siteName={siteName}
+          />
         </div>
 
         <div className={styles.actions}>
-          <button type="button" onClick={handleDownload} disabled={downloadStatus === 'working'} className={styles.button}>
+          <button
+            type="button"
+            onClick={handleDownload}
+            disabled={downloadStatus === "working"}
+            className={styles.button}
+          >
             {renderStatusIcon(downloadStatus, FiDownload)}
             <span>{downloadLabel}</span>
           </button>
-          <button type="button" onClick={handleCopyImage} disabled={copyStatus === 'working'} className={styles.button}>
+          <button
+            type="button"
+            onClick={handleCopyImage}
+            disabled={copyStatus === "working"}
+            className={styles.button}
+          >
             {renderStatusIcon(copyStatus, FiImage)}
             <span>{copyLabel}</span>
           </button>
-          <button type="button" onClick={handleShareTwitter} className={clsx(styles.button, styles.twitterButton)}>
+          <button
+            type="button"
+            onClick={handleShareTwitter}
+            className={clsx(styles.button, styles.twitterButton)}
+          >
             <FaXTwitter size={16} />
             <span>Share on X</span>
           </button>
-          <button type="button" onClick={handleShareLinkedIn} className={clsx(styles.button, styles.linkedinButton)}>
+          <button
+            type="button"
+            onClick={handleShareLinkedIn}
+            className={clsx(styles.button, styles.linkedinButton)}
+          >
             <FaLinkedin size={16} />
             <span>Share on LinkedIn</span>
           </button>
         </div>
 
-        {errorMessage && (downloadStatus === 'error' || copyStatus === 'error') && (
-          <p className={styles.errorText} role="status">
-            {errorMessage}
-          </p>
-        )}
+        {errorMessage &&
+          (downloadStatus === "error" || copyStatus === "error") && (
+            <p className={styles.errorText} role="status">
+              {errorMessage}
+            </p>
+          )}
       </div>
     </div>
   );

--- a/src/components/Quiz/ShareResultModal.tsx
+++ b/src/components/Quiz/ShareResultModal.tsx
@@ -1,20 +1,22 @@
-import React, { useCallback, useRef, useState, useEffect } from "react";
-import clsx from "clsx";
+import React, {
+  useCallback, useRef, useState, useEffect,
+} from 'react';
+import clsx from 'clsx';
 import {
   FiDownload,
   FiImage,
   FiCheck,
   FiAlertCircle,
   FiLoader,
-  FiX
-} from "react-icons/fi";
-import { FaXTwitter } from "react-icons/fa6";
-import { FaLinkedin } from "react-icons/fa";
-import { useFocusTrap } from "../../hooks/useFocusTrap";
-import ShareResultCard from "./ShareResultCard";
-import { renderShareCardToPngBlob } from "../../utils/shareResultImage";
-import { slugify } from "../../utils/slugUtils";
-import styles from "./ShareResultModal.module.css";
+  FiX,
+} from 'react-icons/fi';
+import { FaXTwitter } from 'react-icons/fa6';
+import { FaLinkedin } from 'react-icons/fa';
+import { useFocusTrap } from '../../hooks/useFocusTrap';
+import ShareResultCard from './ShareResultCard';
+import { renderShareCardToPngBlob } from '../../utils/shareResultImage';
+import { slugify } from '../../utils/slugUtils';
+import styles from './ShareResultModal.module.css';
 
 export interface ShareResultModalProps {
   isOpen: boolean;
@@ -25,42 +27,59 @@ export interface ShareResultModalProps {
   siteName?: string;
 }
 
-type ActionStatus = "idle" | "working" | "done" | "error";
+type ActionStatus = 'idle' | 'working' | 'done' | 'error';
 const RESET_DELAY_MS = 2500;
 
-function getShareSlug(value: string): string {
-  return slugify(value, "quiz-result");
-}
+const getShareSlug = (value: string): string => slugify(value, 'quiz-result');
 
-export default function ShareResultModal({
+const ModalHeader = ({ onClose }: { onClose: () => void }) => (
+  <div className={styles.header}>
+    <h2 id="share-result-modal-title" className={styles.title}>
+      Share your result
+    </h2>
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label="Close share dialog"
+      className={styles.closeButton}
+    >
+      <FiX size={18} />
+    </button>
+  </div>
+);
+
+/**
+ * Modal to share quiz results
+ */
+const ShareResultModal = ({
   isOpen,
   onClose,
   topic,
   score,
   total,
-  siteName = "Algo"
-}: ShareResultModalProps) {
+  siteName = 'Algo',
+}: ShareResultModalProps) => {
   const modalRef = useRef<HTMLDivElement>(null);
   useFocusTrap(modalRef, { isOpen, onClose });
 
-  const [downloadStatus, setDownloadStatus] = useState<ActionStatus>("idle");
-  const [copyStatus, setCopyStatus] = useState<ActionStatus>("idle");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [downloadStatus, setDownloadStatus] = useState<ActionStatus>('idle');
+  const [copyStatus, setCopyStatus] = useState<ActionStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
 
   // Reset all action state when the modal opens so stale errors from a
   // previous session are never visible before the user takes any action.
   useEffect(() => {
     if (isOpen) {
-      setDownloadStatus("idle");
-      setCopyStatus("idle");
-      setErrorMessage("");
+      setDownloadStatus('idle');
+      setCopyStatus('idle');
+      setErrorMessage('');
     }
   }, [isOpen, setDownloadStatus, setCopyStatus, setErrorMessage]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
-    if (downloadStatus === "done" || downloadStatus === "error") {
-      timer = setTimeout(() => setDownloadStatus("idle"), RESET_DELAY_MS);
+    if (downloadStatus === 'done' || downloadStatus === 'error') {
+      timer = setTimeout(() => setDownloadStatus('idle'), RESET_DELAY_MS);
     }
     return () => {
       if (timer) clearTimeout(timer);
@@ -69,8 +88,8 @@ export default function ShareResultModal({
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
-    if (copyStatus === "done" || copyStatus === "error") {
-      timer = setTimeout(() => setCopyStatus("idle"), RESET_DELAY_MS);
+    if (copyStatus === 'done' || copyStatus === 'error') {
+      timer = setTimeout(() => setCopyStatus('idle'), RESET_DELAY_MS);
     }
     return () => {
       if (timer) clearTimeout(timer);
@@ -78,75 +97,75 @@ export default function ShareResultModal({
   }, [copyStatus, setCopyStatus]);
 
   const shareText = `I scored ${score}/${total} on the ${topic} quiz on ${siteName}! 🎯`;
-  const shareUrl = typeof window !== "undefined" ? window.location.href : "";
+  const shareUrl = typeof window !== 'undefined' ? window.location.href : '';
 
   const handleDownload = useCallback(async () => {
-    setDownloadStatus("working");
-    setErrorMessage("");
+    setDownloadStatus('working');
+    setErrorMessage('');
     try {
       const blob = await renderShareCardToPngBlob(
         topic,
         score,
         total,
-        siteName
+        siteName,
       );
       const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
+      const link = document.createElement('a');
       link.href = url;
       link.download = `${getShareSlug(topic)}-quiz-result.png`;
       link.click();
       URL.revokeObjectURL(url);
-      setDownloadStatus("done");
+      setDownloadStatus('done');
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : "Download failed.");
-      setDownloadStatus("error");
+      setErrorMessage(err instanceof Error ? err.message : 'Download failed.');
+      setDownloadStatus('error');
     }
   }, [topic, score, total, siteName, setDownloadStatus, setErrorMessage]);
 
   const handleCopyImage = useCallback(async () => {
-    setCopyStatus("working");
-    setErrorMessage("");
+    setCopyStatus('working');
+    setErrorMessage('');
     try {
       const blob = await renderShareCardToPngBlob(
         topic,
         score,
         total,
-        siteName
+        siteName,
       );
+      // skipcq: JS-0323
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const ClipboardItemCtor =
-        typeof window !== "undefined"
-          ? (window as any).ClipboardItem
-          : undefined;
+      const ClipboardItemCtor = typeof window !== 'undefined'
+        ? (window as any).ClipboardItem
+        : undefined;
 
       if (navigator.clipboard && ClipboardItemCtor) {
         await navigator.clipboard.write([
-          new ClipboardItemCtor({ "image/png": blob })
+          new ClipboardItemCtor({ 'image/png': blob }),
         ]);
       } else {
         // Clipboard image writes aren't supported everywhere (e.g. Firefox) —
         // fall back to a direct PNG download so the action still succeeds.
         const url = URL.createObjectURL(blob);
-        const link = document.createElement("a");
+        const link = document.createElement('a');
         link.href = url;
         link.download = `${getShareSlug(topic)}-quiz-result.png`;
         link.click();
         URL.revokeObjectURL(url);
       }
-      setCopyStatus("done");
+      setCopyStatus('done');
     } catch (err) {
-      setErrorMessage(err instanceof Error ? err.message : "Copy failed.");
-      setCopyStatus("error");
+      setErrorMessage(err instanceof Error ? err.message : 'Copy failed.');
+      setCopyStatus('error');
     }
   }, [topic, score, total, siteName, setCopyStatus, setErrorMessage]);
 
   const openShareWindow = (url: string) => {
-    window.open(url, "_blank", "noopener,noreferrer,width=600,height=500");
+    window.open(url, '_blank', 'noopener,noreferrer,width=600,height=500');
   };
 
   const handleShareTwitter = () => {
     const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-      shareText
+      shareText,
     )}&url=${encodeURIComponent(shareUrl)}`;
     openShareWindow(url);
   };
@@ -155,7 +174,7 @@ export default function ShareResultModal({
     // LinkedIn's share endpoint only accepts a URL — it doesn't support
     // prefilled post text, so the caption is left for the user to add.
     const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
-      shareUrl
+      shareUrl,
     )}`;
     openShareWindow(url);
   };
@@ -165,29 +184,29 @@ export default function ShareResultModal({
   }
 
   const downloadLabel = {
-    idle: "Download PNG",
-    working: "Preparing…",
-    done: "Downloaded!",
-    error: "Try again"
+    idle: 'Download PNG',
+    working: 'Preparing…',
+    done: 'Downloaded!',
+    error: 'Try again',
   }[downloadStatus];
   const copyLabel = {
-    idle: "Copy image",
-    working: "Copying…",
-    done: "Copied!",
-    error: "Try again"
+    idle: 'Copy image',
+    working: 'Copying…',
+    done: 'Copied!',
+    error: 'Try again',
   }[copyStatus];
 
   const renderStatusIcon = (
     status: ActionStatus,
-    IdleIcon: React.ComponentType<{ size?: number }>
+    IdleIcon: React.ComponentType<{ size?: number }>,
   ) => {
-    if (status === "working") {
+    if (status === 'working') {
       return <FiLoader size={16} className={styles.spin} />;
     }
-    if (status === "done") {
+    if (status === 'done') {
       return <FiCheck size={16} />;
     }
-    if (status === "error") {
+    if (status === 'error') {
       return <FiAlertCircle size={16} />;
     }
     return <IdleIcon size={16} />;
@@ -197,26 +216,14 @@ export default function ShareResultModal({
     <div onClick={onClose} onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter' || e.key === ' ') onClose(); }} role="presentation" className={styles.overlay}>
       <div
         ref={modalRef}
-        onClick={e => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby="share-result-modal-title"
         className={styles.modal}
       >
-        <div className={styles.header}>
-          <h2 id="share-result-modal-title" className={styles.title}>
-            Share your result
-          </h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close share dialog"
-            className={styles.closeButton}
-          >
-            <FiX size={18} />
-          </button>
-        </div>
+        <ModalHeader onClose={onClose} />
 
         <div className={styles.preview}>
           <ShareResultCard
@@ -231,7 +238,7 @@ export default function ShareResultModal({
           <button
             type="button"
             onClick={handleDownload}
-            disabled={downloadStatus === "working"}
+            disabled={downloadStatus === 'working'}
             className={styles.button}
           >
             {renderStatusIcon(downloadStatus, FiDownload)}
@@ -240,7 +247,7 @@ export default function ShareResultModal({
           <button
             type="button"
             onClick={handleCopyImage}
-            disabled={copyStatus === "working"}
+            disabled={copyStatus === 'working'}
             className={styles.button}
           >
             {renderStatusIcon(copyStatus, FiImage)}
@@ -264,13 +271,15 @@ export default function ShareResultModal({
           </button>
         </div>
 
-        {errorMessage &&
-          (downloadStatus === "error" || copyStatus === "error") && (
+        {errorMessage
+          && (downloadStatus === 'error' || copyStatus === 'error') && (
             <p className={styles.errorText} role="status">
               {errorMessage}
             </p>
-          )}
+        )}
       </div>
     </div>
   );
-}
+};
+
+export default ShareResultModal;


### PR DESCRIPTION
## Description
Fixes #3839 

This PR resolves an issue in `ShareResultModal` where the `errorMessage` state was not cleared when the modal was closed and reopened, resulting in stale error messages being shown to the user on subsequent sessions.

### Changes Made
- Added state resets (`setErrorMessage('')`, `setDownloadStatus('idle')`, `setCopyStatus('idle')`) within the `isOpen` transition effect to guarantee a clean slate on mount.
- Refactored `downloadStatus` and `copyStatus` timeout logic to use idiomatic `useEffect` blocks instead of `useRef`, fixing a strict React Hook `exhaustive-deps` warning and a DeepSource `JS-0022` dead-code violation.
- Ensured all arrow functions in `useEffect` strictly satisfy the ESLint `consistent-return` rule.
- Applied Airbnb style guide enforcements (e.g. wrapping control statements in curly braces) and removed redundant `console.error` logs.