### PR TITLE
fix: replace alert with inline success state for marking challenge solved across layouts

### DIFF
--- a/src/components/DPChallengeLayout.tsx
+++ b/src/components/DPChallengeLayout.tsx
@@ -23,6 +23,9 @@ const DIFF_COLORS = {
 
 interface Props { challenge: DPChallenge; }
 
+/**
+ * Main layout component for DPChallengeLayout.
+ */
 const DPChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });

--- a/src/components/DPChallengeLayout.tsx
+++ b/src/components/DPChallengeLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import Layout from "@theme/Layout";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
@@ -37,8 +37,19 @@ export default function DPChallengeLayout({ challenge }: Props) {
   const [showSolution, setShowSolution] = useState(false);
   const [running, setRunning] = useState(false);
   const [activeTab, setActiveTab] = useState<"problem" | "solution" | "pseudocode" | "real-world">("problem");
+  const [solvedFlash, setSolvedFlash] = useState(false);
   const { runJudge } = useChallengeJudge(challenge);
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (solvedFlash) {
+      timer = setTimeout(() => setSolvedFlash(false), 3000);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [solvedFlash, setSolvedFlash]);
 
   const runCode = useCallback(async () => {
     setRunning(true);
@@ -75,12 +86,12 @@ export default function DPChallengeLayout({ challenge }: Props) {
   onClick={() => {
     if (!canMarkSolved) return;
     markChallengeSolved(challenge.id, challenge.title);
-    alert("Marked as solved!");
+    setSolvedFlash(true);
   }}
   disabled={!canMarkSolved}
   className={`ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors ${canMarkSolved ? "hover:bg-emerald-500/20 cursor-pointer" : "opacity-60 cursor-not-allowed"}`}
 >
-  <FaCheck /> Mark as Solved ✅
+  <FaCheck /> {solvedFlash ? "Solved!" : "Mark as Solved ✅"}
 </button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}

--- a/src/components/DPChallengeLayout.tsx
+++ b/src/components/DPChallengeLayout.tsx
@@ -23,7 +23,7 @@ const DIFF_COLORS = {
 
 interface Props { challenge: DPChallenge; }
 
-export default function DPChallengeLayout({ challenge }: Props) {
+const DPChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });
   const code = codeMap[activeLanguage] ?? challenge.starterCodes?.[activeLanguage] ?? "";
@@ -386,3 +386,5 @@ export default function DPChallengeLayout({ challenge }: Props) {
     </Layout>
   );
 }
+
+export default DPChallengeLayout;

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -407,6 +407,9 @@ interface Props { challenge: GraphChallenge; }
 
 // ─── Main layout ──────────────────────────────────────────────────────────────
 // skipcq: JS-R1005
+/**
+ * Main layout component for GraphChallengeLayout.
+ */
 const GraphChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -421,9 +421,20 @@ export default function GraphChallengeLayout({ challenge }: Props) {
   const [running, setRunning]       = useState(false);
   const [activeTab, setActiveTab]   = useState<"problem" | "visualize" | "solution" | "pseudocode" | "real-world">("problem");
   const { runJudge }                = useChallengeJudge(challenge);
+  const [solvedFlash, setSolvedFlash] = useState(false);
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
 
   const hasDedicated = Boolean(DEDICATED_VISUALIZER[challenge.id]);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (solvedFlash) {
+      timer = setTimeout(() => setSolvedFlash(false), 3000);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [solvedFlash, setSolvedFlash]);
 
   const runCode = useCallback(async () => {
     setRunning(true);
@@ -469,12 +480,12 @@ export default function GraphChallengeLayout({ challenge }: Props) {
   onClick={() => {
     if (!canMarkSolved) return;
     markChallengeSolved(challenge.id, challenge.title);
-    alert("Marked as solved!");
+    setSolvedFlash(true);
   }}
   disabled={!canMarkSolved}
   className={`ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors ${canMarkSolved ? "hover:bg-emerald-500/20 cursor-pointer" : "opacity-60 cursor-not-allowed"}`}
 >
-  <FaCheck /> Mark as Solved ✅
+  <FaCheck /> {solvedFlash ? "Solved!" : "Mark as Solved ✅"}
 </button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -406,10 +406,10 @@ function VisualizeTab({ challenge }: { challenge: GraphChallenge }) {
 interface Props { challenge: GraphChallenge; }
 
 // ─── Main layout ──────────────────────────────────────────────────────────────
-// skipcq: JS-R1005
 /**
  * Main layout component for GraphChallengeLayout.
  */
+// skipcq: JS-R1005
 const GraphChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });

--- a/src/components/GraphChallengeLayout.tsx
+++ b/src/components/GraphChallengeLayout.tsx
@@ -406,7 +406,8 @@ function VisualizeTab({ challenge }: { challenge: GraphChallenge }) {
 interface Props { challenge: GraphChallenge; }
 
 // ─── Main layout ──────────────────────────────────────────────────────────────
-export default function GraphChallengeLayout({ challenge }: Props) {
+// skipcq: JS-R1005
+const GraphChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });
   const code = codeMap[activeLanguage] ?? challenge.starterCodes?.[activeLanguage] ?? "";
@@ -814,4 +815,6 @@ export default function GraphChallengeLayout({ challenge }: Props) {
       </div>
     </Layout>
   );
-}
+};
+
+export default GraphChallengeLayout;

--- a/src/components/GreedyChallengeLayout.tsx
+++ b/src/components/GreedyChallengeLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import Layout from "@theme/Layout";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
@@ -37,8 +37,19 @@ export default function GreedyChallengeLayout({ challenge }: Props) {
   const [showSolution, setShowSolution] = useState(false);
   const [running, setRunning] = useState(false);
   const [activeTab, setActiveTab] = useState<"problem" | "solution" | "pseudocode" | "real-world">("problem");
+  const [solvedFlash, setSolvedFlash] = useState(false);
   const { runJudge } = useChallengeJudge(challenge);
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (solvedFlash) {
+      timer = setTimeout(() => setSolvedFlash(false), 3000);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [solvedFlash, setSolvedFlash]);
 
   const runCode = useCallback(async () => {
     setRunning(true);
@@ -75,12 +86,12 @@ export default function GreedyChallengeLayout({ challenge }: Props) {
   onClick={() => {
     if (!canMarkSolved) return;
     markChallengeSolved(challenge.id, challenge.title);
-    alert("Marked as solved!");
+    setSolvedFlash(true);
   }}
   disabled={!canMarkSolved}
   className={`ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors ${canMarkSolved ? "hover:bg-emerald-500/20 cursor-pointer" : "opacity-60 cursor-not-allowed"}`}
 >
-  <FaCheck /> Mark as Solved ✅
+  <FaCheck /> {solvedFlash ? "Solved!" : "Mark as Solved ✅"}
 </button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}

--- a/src/components/GreedyChallengeLayout.tsx
+++ b/src/components/GreedyChallengeLayout.tsx
@@ -23,6 +23,9 @@ const DIFF_COLORS = {
 
 interface Props { challenge: GreedyChallenge; }
 
+/**
+ * Main layout component for GreedyChallengeLayout.
+ */
 const GreedyChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });

--- a/src/components/GreedyChallengeLayout.tsx
+++ b/src/components/GreedyChallengeLayout.tsx
@@ -23,7 +23,7 @@ const DIFF_COLORS = {
 
 interface Props { challenge: GreedyChallenge; }
 
-export default function GreedyChallengeLayout({ challenge }: Props) {
+const GreedyChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });
   const code = codeMap[activeLanguage] ?? challenge.starterCodes?.[activeLanguage] ?? "";
@@ -387,3 +387,5 @@ export default function GreedyChallengeLayout({ challenge }: Props) {
     </Layout>
   );
 }
+
+export default GreedyChallengeLayout;

--- a/src/components/SortingChallengeLayout.tsx
+++ b/src/components/SortingChallengeLayout.tsx
@@ -23,7 +23,7 @@ const DIFF_COLORS = {
 
 interface Props { challenge: SortingChallenge; }
 
-export default function SortingChallengeLayout({ challenge }: Props) {
+const SortingChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });
   const code = codeMap[activeLanguage] ?? challenge.starterCodes?.[activeLanguage] ?? "";
@@ -387,3 +387,5 @@ export default function SortingChallengeLayout({ challenge }: Props) {
     </Layout>
   );
 }
+
+export default SortingChallengeLayout;

--- a/src/components/SortingChallengeLayout.tsx
+++ b/src/components/SortingChallengeLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import Layout from "@theme/Layout";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
@@ -37,8 +37,19 @@ export default function SortingChallengeLayout({ challenge }: Props) {
   const [showSolution, setShowSolution] = useState(false);
   const [running, setRunning] = useState(false);
   const [activeTab, setActiveTab] = useState<"problem" | "solution" | "pseudocode" | "real-world">("problem");
+  const [solvedFlash, setSolvedFlash] = useState(false);
   const { runJudge } = useChallengeJudge(challenge);
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (solvedFlash) {
+      timer = setTimeout(() => setSolvedFlash(false), 3000);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [solvedFlash, setSolvedFlash]);
 
   const runCode = useCallback(async () => {
     setRunning(true);
@@ -75,12 +86,12 @@ export default function SortingChallengeLayout({ challenge }: Props) {
   onClick={() => {
     if (!canMarkSolved) return;
     markChallengeSolved(challenge.id, challenge.title);
-    alert("Marked as solved!");
+    setSolvedFlash(true);
   }}
   disabled={!canMarkSolved}
   className={`ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors ${canMarkSolved ? "hover:bg-emerald-500/20 cursor-pointer" : "opacity-60 cursor-not-allowed"}`}
 >
-  <FaCheck /> Mark as Solved ✅
+  <FaCheck /> {solvedFlash ? "Solved!" : "Mark as Solved ✅"}
 </button>
           <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[challenge.difficulty]}`}>
             {challenge.difficulty}

--- a/src/components/SortingChallengeLayout.tsx
+++ b/src/components/SortingChallengeLayout.tsx
@@ -23,6 +23,9 @@ const DIFF_COLORS = {
 
 interface Props { challenge: SortingChallenge; }
 
+/**
+ * Main layout component for SortingChallengeLayout.
+ */
 const SortingChallengeLayout = ({ challenge }: Props) => {
   const [activeLanguage, setActiveLanguage] = useState<string>("javascript");
   const [codeMap, setCodeMap] = useState<Record<string, string>>({ javascript: challenge.starterCode });

--- a/src/components/TreeChallenge/ChallengeHeader.tsx
+++ b/src/components/TreeChallenge/ChallengeHeader.tsx
@@ -20,6 +20,9 @@ interface ChallengeHeaderProps {
   judgeResults?: JudgeResult[];
 }
 
+/**
+ * Main layout component for ChallengeHeader.
+ */
 const ChallengeHeader = ({ id, title, difficulty, timeLimit, judgeResults = [] }: ChallengeHeaderProps) => {
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
   const [solvedFlash, setSolvedFlash] = useState(false);

--- a/src/components/TreeChallenge/ChallengeHeader.tsx
+++ b/src/components/TreeChallenge/ChallengeHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import Link from "@docusaurus/Link";
 import { FaArrowLeft, FaChevronRight, FaClock, FaCheck } from "react-icons/fa";
 import { canMarkChallengeSolved } from "../../utils/challengeJudge";
@@ -22,6 +22,17 @@ interface ChallengeHeaderProps {
 
 export default function ChallengeHeader({ id, title, difficulty, timeLimit, judgeResults = [] }: ChallengeHeaderProps) {
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
+  const [solvedFlash, setSolvedFlash] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+    if (solvedFlash) {
+      timer = setTimeout(() => setSolvedFlash(false), 3000);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [solvedFlash, setSolvedFlash]);
 
   return (
     <div className="bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800 px-6 py-3 flex items-center gap-4">
@@ -39,12 +50,12 @@ export default function ChallengeHeader({ id, title, difficulty, timeLimit, judg
   onClick={() => {
     if (!canMarkSolved) return;
     markChallengeSolved(id, title);
-    alert("Marked as solved!");
+    setSolvedFlash(true);
   }}
   disabled={!canMarkSolved}
   className={`ml-auto flex items-center gap-2 px-3 py-1.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border border-emerald-500/20 rounded-lg text-xs font-mono font-bold transition-colors ${canMarkSolved ? "hover:bg-emerald-500/20 cursor-pointer" : "opacity-60 cursor-not-allowed"}`}
 >
-  <FaCheck /> Mark as Solved ✅
+  <FaCheck /> {solvedFlash ? "Solved!" : "Mark as Solved ✅"}
 </button>
       <span className={`px-3 py-1 rounded-full text-xs font-bold border ${DIFF_COLORS[difficulty]}`}>
         {difficulty}

--- a/src/components/TreeChallenge/ChallengeHeader.tsx
+++ b/src/components/TreeChallenge/ChallengeHeader.tsx
@@ -20,7 +20,7 @@ interface ChallengeHeaderProps {
   judgeResults?: JudgeResult[];
 }
 
-export default function ChallengeHeader({ id, title, difficulty, timeLimit, judgeResults = [] }: ChallengeHeaderProps) {
+const ChallengeHeader = ({ id, title, difficulty, timeLimit, judgeResults = [] }: ChallengeHeaderProps) => {
   const canMarkSolved = canMarkChallengeSolved(judgeResults);
   const [solvedFlash, setSolvedFlash] = useState(false);
 
@@ -66,3 +66,4 @@ export default function ChallengeHeader({ id, title, difficulty, timeLimit, judg
     </div>
   );
 }
+export default ChallengeHeader;


### PR DESCRIPTION
Description

fix #3838 

This PR resolves [#3838] by replacing the blocking alert("Marked as solved!") with an inline success state across all challenge layouts.

Instead of a disruptive browser alert, clicking the "Mark as Solved" button now temporarily changes the button text to "✅ Solved!" for 3 seconds before reverting.

Changes
Added solvedFlash state to track temporary success feedback for 3 seconds.
Added useEffect timer to revert solvedFlash back to false automatically, with strict cleanup on unmount to avoid memory leaks or state updates on unmounted components.
Updated onClick handler to trigger setSolvedFlash(true) instead of alert().

Applied changes consistently to all challenge layout components:
DPChallengeLayout.tsx
GraphChallengeLayout.tsx
GreedyChallengeLayout.tsx
SortingChallengeLayout.tsx
TreeChallenge/ChallengeHeader.tsx

Verification
The inline UI feedback provides immediate non-blocking confirmation. The new useEffect pattern ensures no linting issues regarding exhaustive-deps or memory leaks occur.