### PR TITLE
fix(AlgorithmRelationshipMap): define isolatedCx and isolatedCy and compute isolated state

### DIFF
--- a/src/components/AlgorithmRelationshipMap/layout.ts
+++ b/src/components/AlgorithmRelationshipMap/layout.ts
@@ -62,12 +62,23 @@ export function computeForceLayout(
   const centerY = height / 2;
   const radius = Math.min(width, height) * 0.3;
 
+  const isolatedCy = height * ISOLATED_STRIP_Y_FRACTION;
+  const isolatedCx = width / 2;
+
+  const degree = new Map<string, number>();
+  for (const n of nodes) degree.set(n.id, 0);
+  for (const e of edges) {
+    degree.set(e.source, (degree.get(e.source) || 0) + 1);
+    degree.set(e.target, (degree.get(e.target) || 0) + 1);
+  }
+
   const simNodes: PositionedNode[] = nodes.map((n, index) => {
     const angle = (index / Math.max(nodes.length, 1)) * Math.PI * 2;
     return {
       id: n.id,
       x: centerX + Math.cos(angle) * radius,
       y: centerY + Math.sin(angle) * radius,
+      isolated: degree.get(n.id) === 0,
     };
   });
 


### PR DESCRIPTION
fix #3837 

Description
This PR resolves [#3837] by defining the missing layout configuration variables that caused ReferenceError: isolatedCy is not defined to be thrown at runtime.

Changes
Defined isolatedCy using the existing ISOLATED_STRIP_Y_FRACTION and the canvas height.
Defined isolatedCx as the horizontal centre (width / 2).
Implemented the missing per-node degree computation to accurately populate the isolated flag on PositionedNode, which correctly activates the targeted forces for nodes with no edges, matching the implementation plan in the codebase comments.

Verification
The D3 force simulation can now compute the layout synchronously without crashing, and isolated algorithm nodes are successfully pushed down into their dedicated lower horizontal strip as intended.