### PR TITLE
fix: explicitly annotate node variables with NodeData to resolve TS7022

### DIFF
--- a/src/components/Visualizing/TreeSandbox.tsx
+++ b/src/components/Visualizing/TreeSandbox.tsx
@@ -102,12 +102,12 @@ export default function TreeSandbox() {
 
   const getBalanceFactor = (nodeId: string | null, map: TreeMap): number => {
     if (!nodeId || !map[nodeId]) return 0;
-    const node = map[nodeId];
+    const node: NodeData = map[nodeId];
     return getHeight(node.leftId, map) - getHeight(node.rightId, map);
   };
 
   const updateHeight = (nodeId: string, map: TreeMap) => {
-    const node = map[nodeId];
+    const node: NodeData = map[nodeId];
     node.height = Math.max(getHeight(node.leftId, map), getHeight(node.rightId, map)) + 1;
   };
 
@@ -127,7 +127,7 @@ export default function TreeSandbox() {
       xMin: number,
       xMax: number
     ) => {
-      const node = map[nodeId];
+      const node: NodeData = map[nodeId];
       if (!node) return;
 
       const x = (xMin + xMax) / 2;
@@ -223,7 +223,7 @@ export default function TreeSandbox() {
     );
 
     while (currId) {
-      const node = treeMap[currId];
+      const node: NodeData = treeMap[currId];
       path.push(currId);
 
       if (node.key === key) {
@@ -360,7 +360,7 @@ export default function TreeSandbox() {
         return newNode.id;
       }
 
-      const node = tempMap[nodeId];
+      const node: NodeData = tempMap[nodeId];
       pushStep(
         insertSteps,
         tempMap,
@@ -733,7 +733,7 @@ export default function TreeSandbox() {
     ): string | null => {
       if (!nodeId) return null;
 
-      const node = tempMap[nodeId];
+      const node: NodeData = tempMap[nodeId];
       pushStep(
         deleteSteps,
         tempMap,
@@ -1011,7 +1011,7 @@ export default function TreeSandbox() {
     if (type === "pre") {
       const traverse = (nodeId: string | null) => {
         if (!nodeId) return;
-        const node = treeMap[nodeId];
+        const node: NodeData = treeMap[nodeId];
         visitedKeys.push(node.key);
         pushStep(
           traversalSteps,
@@ -1034,7 +1034,7 @@ export default function TreeSandbox() {
     } else if (type === "in") {
       const traverse = (nodeId: string | null) => {
         if (!nodeId) return;
-        const node = treeMap[nodeId];
+        const node: NodeData = treeMap[nodeId];
         traverse(node.leftId);
         visitedKeys.push(node.key);
         pushStep(
@@ -1057,7 +1057,7 @@ export default function TreeSandbox() {
     } else if (type === "post") {
       const traverse = (nodeId: string | null) => {
         if (!nodeId) return;
-        const node = treeMap[nodeId];
+        const node: NodeData = treeMap[nodeId];
         traverse(node.leftId);
         traverse(node.rightId);
         visitedKeys.push(node.key);
@@ -1081,7 +1081,7 @@ export default function TreeSandbox() {
       const queue: string[] = [rootId];
       while (queue.length > 0) {
         const currId = queue.shift()!;
-        const node = treeMap[currId];
+        const node: NodeData = treeMap[currId];
         visitedKeys.push(node.key);
 
         pushStep(


### PR DESCRIPTION
Fix #3857

## Description

This PR resolves the TS7022 error in src/components/Visualizing/TreeSandbox.tsx where TypeScript was failing to implicitly infer the type of the node variable because of the recursive nature of the variables being assigned within the tree traversals.

## Explicit 

NodeData type annotations have been added to all node initializations across the file, resolving the inference issue and ensuring that the component successfully passes strict TypeScript compilation checks.

## Changes Made

- Added NodeData type annotations to node declarations in search, insertion, traversal, and deletion simulation steps.
- Ensured npm run build / npx tsc passes cleanly without the TS7022 warning.