### PR TITLE
fix: use exact matching for sidebar completion status

### DIFF
--- a/src/__tests__/components/SidebarUpdater.test.tsx
+++ b/src/__tests__/components/SidebarUpdater.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for the SidebarUpdater completion badge matching.
+ *
+ * Regression coverage for: sidebar completion checkmarks previously used fuzzy
+ * substring title matching, so completing "Two Sum" could badge "Two Sum II"
+ * (and vice-versa). Matching now uses the sidebar link href -> doc topicId.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import SidebarUpdater from '../../components/ProgressTracker/SidebarUpdater';
+
+jest.mock('../../utils/safeStorage', () => {
+  const actual = jest.requireActual('../../utils/safeStorage');
+  return {
+    ...actual,
+    syncAlgoProgress: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+/* ---------- localStorage mock ---------- */
+const store: Record<string, string> = {};
+const mockLocalStorage: Storage = {
+  getItem: (k: string) => store[k] ?? null,
+  setItem: (k: string, v: string) => { store[k] = v; },
+  removeItem: (k: string) => { delete store[k]; },
+  clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+  get length() { return Object.keys(store).length; },
+  key: (i: number) => Object.keys(store)[i] ?? null,
+};
+
+Object.defineProperty(window, 'localStorage', { value: mockLocalStorage, writable: true });
+
+/* ---------- helpers ---------- */
+
+function addMenuLink(href: string, label: string): HTMLElement {
+  const link = document.createElement('a');
+  link.className = 'menu__link';
+  link.href = href;
+  link.textContent = label;
+  document.body.appendChild(link);
+  return link;
+}
+
+function removeMenuLinks() {
+  document.querySelectorAll('.menu__link').forEach((el) => el.remove());
+}
+
+function badgeCount(link: HTMLElement): number {
+  return link.querySelectorAll('.completion-badge').length;
+}
+
+async function renderAndSettle() {
+  render(<SidebarUpdater />);
+  // Flush the promise chain (syncAlgoProgress.then(load))…
+  await act(async () => {});
+  // …then run the deferred badge-painting timeout.
+  await act(async () => {
+    jest.advanceTimersByTime(200);
+  });
+}
+
+describe('SidebarUpdater', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockLocalStorage.clear();
+    removeMenuLinks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('badges the exact sidebar link for a completed doc', async () => {
+    store['algo_progress'] = JSON.stringify({
+      'dsa-problems-easy-two-sum-problem': true,
+      'dsa-problems-easy-two-sum-problem_title': 'Two Sum',
+    });
+
+    const twoSum = addMenuLink('/algo/docs/dsa-problems/easy/two-sum-problem', 'Two Sum');
+    const twoSumII = addMenuLink('/algo/docs/dsa-problems/medium/two-sum-ii', 'Two Sum II');
+
+    await renderAndSettle();
+
+    expect(badgeCount(twoSum)).toBe(1);
+    expect(badgeCount(twoSumII)).toBe(0);
+  });
+
+  it('does not badge near-duplicate links (Two Sum II / Subsets II / Path Sum III)', async () => {
+    store['algo_progress'] = JSON.stringify({
+      'dsa-problems-medium-subsets-ii': true,
+      'dsa-problems-medium-subsets-ii_title': 'Subsets II',
+      'dsa-problems-easy-path-sum': true,
+      'dsa-problems-easy-path-sum_title': 'Path Sum',
+      'dsa-problems-hard-path-sum-iii': true,
+      'dsa-problems-hard-path-sum-iii_title': 'Path Sum III',
+    });
+
+    const subsetsII = addMenuLink('/algo/docs/dsa-problems/medium/subsets-ii', 'Subsets II');
+    const subsets = addMenuLink('/algo/docs/dsa-problems/medium/subsets', 'Subsets');
+    const pathSum = addMenuLink('/algo/docs/dsa-problems/easy/path-sum', 'Path Sum');
+    const pathSumIII = addMenuLink('/algo/docs/dsa-problems/hard/path-sum-iii', 'Path Sum III');
+
+    await renderAndSettle();
+
+    expect(badgeCount(subsetsII)).toBe(1);
+    expect(badgeCount(subsets)).toBe(0);
+    expect(badgeCount(pathSum)).toBe(1);
+    expect(badgeCount(pathSumIII)).toBe(1);
+  });
+
+  it('badges links whose sidebar_label differs from the stored title via URL', async () => {
+    store['algo_progress'] = JSON.stringify({
+      'basic-data-structures-array-arrays-in-dsa': true,
+      'basic-data-structures-array-arrays-in-dsa_title': 'Arrays in Data Structures and Algorithms',
+    });
+
+    const arrays = addMenuLink('/algo/docs/basic-data-structures/array/arrays-in-dsa', 'Arrays');
+
+    await renderAndSettle();
+
+    expect(badgeCount(arrays)).toBe(1);
+  });
+
+  it('does not badge a link whose href does not match any completed doc', async () => {
+    store['algo_progress'] = JSON.stringify({
+      'graph-11': true,
+      'graph-11_title': 'Graph Challenge',
+    });
+
+    const unrelated = addMenuLink('/algo/docs/arrays/intro', 'Arrays Intro');
+
+    await renderAndSettle();
+
+    expect(badgeCount(unrelated)).toBe(0);
+  });
+
+  it('handles trailing slashes and base-url variations', async () => {
+    store['algo_progress'] = JSON.stringify({
+      'algorithms-sorting-quick-sort': true,
+      'algorithms-sorting-quick-sort_title': 'Quick Sort',
+    });
+
+    const trailing = addMenuLink('/algo/docs/algorithms/sorting/quick-sort/', 'Quick Sort');
+
+    await renderAndSettle();
+
+    expect(badgeCount(trailing)).toBe(1);
+  });
+
+  it('falls back to exact normalized title equality for legacy keys', async () => {
+    // Legacy entry created from a title-derived key rather than the doc id.
+    store['algo_progress'] = JSON.stringify({
+      'two-sum': true,
+      'two-sum_title': 'Two Sum',
+    });
+
+    const twoSum = addMenuLink('/algo/docs/dsa-problems/easy/two-sum-problem', 'Two Sum');
+    const twoSumII = addMenuLink('/algo/docs/dsa-problems/medium/two-sum-ii', 'Two Sum II');
+
+    await renderAndSettle();
+
+    expect(badgeCount(twoSum)).toBe(1);
+    expect(badgeCount(twoSumII)).toBe(0);
+  });
+});

--- a/src/__tests__/components/SidebarUpdater.test.tsx
+++ b/src/__tests__/components/SidebarUpdater.test.tsx
@@ -13,56 +13,56 @@ jest.mock('../../utils/safeStorage', () => {
   const actual = jest.requireActual('../../utils/safeStorage');
   return {
     ...actual,
-    syncAlgoProgress: jest.fn().mockResolvedValue(undefined),
+    syncAlgoProgress: jest.fn(() => Promise.resolve()),
   };
 });
 
 /* ---------- localStorage mock ---------- */
-const store: Record<string, string> = {};
+const store = new Map<string, string>();
 const mockLocalStorage: Storage = {
-  getItem: (k: string) => store[k] ?? null,
-  setItem: (k: string, v: string) => { store[k] = v; },
-  removeItem: (k: string) => { delete store[k]; },
-  clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
-  get length() { return Object.keys(store).length; },
-  key: (i: number) => Object.keys(store)[i] ?? null,
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => { store.set(k, v); },
+  removeItem: (k: string) => { store.delete(k); },
+  clear: () => { store.clear(); },
+  get length() { return store.size; },
+  key: (i: number) => Array.from(store.keys())[i] ?? null,
 };
 
 Object.defineProperty(window, 'localStorage', { value: mockLocalStorage, writable: true });
 
-/* ---------- helpers ---------- */
-
-function addMenuLink(href: string, label: string): HTMLElement {
-  const link = document.createElement('a');
-  link.className = 'menu__link';
-  link.href = href;
-  link.textContent = label;
-  document.body.appendChild(link);
-  return link;
-}
-
-function removeMenuLinks() {
-  document.querySelectorAll('.menu__link').forEach((el) => el.remove());
-}
-
-function badgeCount(link: HTMLElement): number {
-  return link.querySelectorAll('.completion-badge').length;
-}
-
-async function renderAndSettle() {
-  render(<SidebarUpdater />);
-  // Flush the promise chain (syncAlgoProgress.then(load))…
-  await act(async () => {});
-  // …then run the deferred badge-painting timeout.
-  await act(async () => {
-    jest.advanceTimersByTime(200);
-  });
-}
-
 describe('SidebarUpdater', () => {
+  const addMenuLink = (href: string, label: string): HTMLElement => {
+    const link = document.createElement('a');
+    link.className = 'menu__link';
+    link.href = href;
+    link.textContent = label;
+    document.body.appendChild(link);
+    return link;
+  };
+
+  const removeMenuLinks = () => {
+    document.querySelectorAll('.menu__link').forEach((el) => el.remove());
+  };
+
+  const badgeCount = (link: HTMLElement): number => {
+    return link.querySelectorAll('.completion-badge').length;
+  };
+
+  const renderAndSettle = async () => {
+    render(<SidebarUpdater />);
+    // Flush the promise chain (syncAlgoProgress.then(load)).
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Then run the deferred badge-painting timeout.
+    await act(() => {
+      jest.advanceTimersByTime(200);
+    });
+  };
+
   beforeEach(() => {
     jest.useFakeTimers();
-    mockLocalStorage.clear();
+    store.clear();
     removeMenuLinks();
   });
 
@@ -71,10 +71,10 @@ describe('SidebarUpdater', () => {
   });
 
   it('badges the exact sidebar link for a completed doc', async () => {
-    store['algo_progress'] = JSON.stringify({
+    store.set('algo_progress', JSON.stringify({
       'dsa-problems-easy-two-sum-problem': true,
       'dsa-problems-easy-two-sum-problem_title': 'Two Sum',
-    });
+    }));
 
     const twoSum = addMenuLink('/algo/docs/dsa-problems/easy/two-sum-problem', 'Two Sum');
     const twoSumII = addMenuLink('/algo/docs/dsa-problems/medium/two-sum-ii', 'Two Sum II');
@@ -86,14 +86,14 @@ describe('SidebarUpdater', () => {
   });
 
   it('does not badge near-duplicate links (Two Sum II / Subsets II / Path Sum III)', async () => {
-    store['algo_progress'] = JSON.stringify({
+    store.set('algo_progress', JSON.stringify({
       'dsa-problems-medium-subsets-ii': true,
       'dsa-problems-medium-subsets-ii_title': 'Subsets II',
       'dsa-problems-easy-path-sum': true,
       'dsa-problems-easy-path-sum_title': 'Path Sum',
       'dsa-problems-hard-path-sum-iii': true,
       'dsa-problems-hard-path-sum-iii_title': 'Path Sum III',
-    });
+    }));
 
     const subsetsII = addMenuLink('/algo/docs/dsa-problems/medium/subsets-ii', 'Subsets II');
     const subsets = addMenuLink('/algo/docs/dsa-problems/medium/subsets', 'Subsets');
@@ -109,10 +109,10 @@ describe('SidebarUpdater', () => {
   });
 
   it('badges links whose sidebar_label differs from the stored title via URL', async () => {
-    store['algo_progress'] = JSON.stringify({
+    store.set('algo_progress', JSON.stringify({
       'basic-data-structures-array-arrays-in-dsa': true,
       'basic-data-structures-array-arrays-in-dsa_title': 'Arrays in Data Structures and Algorithms',
-    });
+    }));
 
     const arrays = addMenuLink('/algo/docs/basic-data-structures/array/arrays-in-dsa', 'Arrays');
 
@@ -122,10 +122,10 @@ describe('SidebarUpdater', () => {
   });
 
   it('does not badge a link whose href does not match any completed doc', async () => {
-    store['algo_progress'] = JSON.stringify({
+    store.set('algo_progress', JSON.stringify({
       'graph-11': true,
       'graph-11_title': 'Graph Challenge',
-    });
+    }));
 
     const unrelated = addMenuLink('/algo/docs/arrays/intro', 'Arrays Intro');
 
@@ -135,10 +135,10 @@ describe('SidebarUpdater', () => {
   });
 
   it('handles trailing slashes and base-url variations', async () => {
-    store['algo_progress'] = JSON.stringify({
+    store.set('algo_progress', JSON.stringify({
       'algorithms-sorting-quick-sort': true,
       'algorithms-sorting-quick-sort_title': 'Quick Sort',
-    });
+    }));
 
     const trailing = addMenuLink('/algo/docs/algorithms/sorting/quick-sort/', 'Quick Sort');
 
@@ -149,10 +149,10 @@ describe('SidebarUpdater', () => {
 
   it('falls back to exact normalized title equality for legacy keys', async () => {
     // Legacy entry created from a title-derived key rather than the doc id.
-    store['algo_progress'] = JSON.stringify({
+    store.set('algo_progress', JSON.stringify({
       'two-sum': true,
       'two-sum_title': 'Two Sum',
-    });
+    }));
 
     const twoSum = addMenuLink('/algo/docs/dsa-problems/easy/two-sum-problem', 'Two Sum');
     const twoSumII = addMenuLink('/algo/docs/dsa-problems/medium/two-sum-ii', 'Two Sum II');

--- a/src/components/ProgressTracker/SidebarUpdater.tsx
+++ b/src/components/ProgressTracker/SidebarUpdater.tsx
@@ -6,6 +6,7 @@ interface ProgressData {
   [key: string]: boolean | string;
 }
 
+/** Normalizes sidebar link text / stored titles for exact comparison. */
 const normalizeLabel = (text: string): string => text.toLowerCase().replace(/\s+/g, ' ').trim();
 
 /**
@@ -59,6 +60,7 @@ const SidebarUpdater: React.FC = () => {
       }
 
       const matchedKeys = new Set<string>();
+      /** Appends a completion badge to a sidebar link (idempotent). */
       const addBadge = (link: HTMLElement) => {
         if (link.querySelector('.completion-badge')) return;
         const badge = document.createElement('span');

--- a/src/components/ProgressTracker/SidebarUpdater.tsx
+++ b/src/components/ProgressTracker/SidebarUpdater.tsx
@@ -6,6 +6,24 @@ interface ProgressData {
   [key: string]: boolean | string;
 }
 
+const normalizeLabel = (text: string): string => text.toLowerCase().replace(/\s+/g, ' ').trim();
+
+/**
+ * Derives the doc topicId (e.g. "dsa-problems-easy-two-sum-problem") that a
+ * sidebar link's href maps to, or null for non-doc links.
+ *
+ * Sidebar hrefs look like "/algo/docs/dsa-problems/easy/two-sum-problem" and
+ * progress keys are built from the doc id with "/" replaced by "-", so the two
+ * can be matched exactly — no fuzzy title matching required.
+ */
+const docTopicIdFromHref = (href: string | null): string | null => {
+  if (!href) return null;
+  const segments = href.split('/').filter(Boolean);
+  const docsIndex = segments.indexOf('docs');
+  if (docsIndex === -1) return null;
+  return segments.slice(docsIndex + 1).join('-');
+};
+
 const SidebarUpdater: React.FC = () => {
   const [progress, setProgress] = useState<ProgressData>({});
 
@@ -27,24 +45,53 @@ const SidebarUpdater: React.FC = () => {
 
   useEffect(() => {
     const id = setTimeout(() => {
-      const links = document.querySelectorAll('.menu__link');
-      links.forEach(link => {
-        link.querySelector('.completion-badge')?.remove();
-        const linkText = link.textContent?.trim() || '';
-        for (const [key, val] of Object.entries(progress)) {
-          if (!key.endsWith('_title') && val === true) {
-            const title = progress[`${key}_title`] as string;
-            if (title && (linkText.includes(title) || title.includes(linkText))) {
-              const badge = document.createElement('span');
-              badge.className = 'completion-badge';
-              badge.textContent = '✓';
-              badge.style.cssText = 'margin-left:6px;opacity:0.85;';
-              link.appendChild(badge);
-              break;
-            }
-          }
+      const links = Array.from(document.querySelectorAll<HTMLElement>('.menu__link'));
+
+      // Clear any stale badges first.
+      links.forEach(link => link.querySelector('.completion-badge')?.remove());
+
+      const completed: Array<{ key: string; title: string }> = [];
+      for (const [key, val] of Object.entries(progress)) {
+        if (val === true && !key.endsWith('_title') && !key.endsWith('_updatedAt') && !key.endsWith('_url')) {
+          const title = typeof progress[`${key}_title`] === 'string' ? (progress[`${key}_title`] as string) : '';
+          completed.push({ key, title: title.trim() });
         }
-      });
+      }
+
+      const matchedKeys = new Set<string>();
+      const addBadge = (link: HTMLElement) => {
+        if (link.querySelector('.completion-badge')) return;
+        const badge = document.createElement('span');
+        badge.className = 'completion-badge';
+        badge.textContent = '✓';
+        badge.style.cssText = 'margin-left:6px;opacity:0.85;';
+        link.appendChild(badge);
+      };
+
+      // Primary: exact href-to-topicId match. Unambiguous even for
+      // near-duplicate titles like "Two Sum" / "Two Sum II".
+      for (const link of links) {
+        const docTopicId = docTopicIdFromHref(link.getAttribute('href'));
+        if (!docTopicId) continue;
+        const entry = completed.find(item => item.key === docTopicId);
+        if (entry) {
+          matchedKeys.add(entry.key);
+          addBadge(link);
+        }
+      }
+
+      // Fallback for legacy entries whose stored key is not the doc id (e.g.
+      // keys derived from the page title instead of the path). Only exact
+      // normalized title equality is allowed so near-duplicates never badge the
+      // wrong link.
+      for (const entry of completed) {
+        if (matchedKeys.has(entry.key) || !entry.title) continue;
+        const link = links.find(l =>
+          !l.querySelector('.completion-badge') &&
+          normalizeLabel(l.textContent ?? '') === normalizeLabel(entry.title)
+        );
+        if (link) addBadge(link);
+      }
     }, 150);
     return () => clearTimeout(id);
   }, [progress]);


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes an issue where sidebar completion checkmarks could be assigned to the wrong DSA problem because SidebarUpdater.tsx uses fuzzy substring matching to determine whether a problem has been completed.

The current logic uses:

linkText.includes(title) || title.includes(linkText)

This is unreliable for problems with similar names, such as:

Two Sum / Two Sum II
Subsets / Subsets II
Path Sum / Path Sum II
Path Sum / Path Sum III

For example, completing Two Sum II can incorrectly cause the Two Sum sidebar entry to appear as completed.

Fixes #3862 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
