### PR TITLE
fix: reset daily challenge solved status by date

### DIFF
--- a/src/__tests__/components/DailyChallengeWidget.test.tsx
+++ b/src/__tests__/components/DailyChallengeWidget.test.tsx
@@ -39,7 +39,9 @@ describe("DailyChallengeWidget", () => {
 
     expect(screen.getByRole("button", { name: "Solved" })).toBeInTheDocument();
 
-    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    const raw = localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(String(raw));
     expect(stored.date).toBe(dateKeyFor(new Date()));
     expect(stored.status).toBe("solved");
   });

--- a/src/__tests__/components/DailyChallengeWidget.test.tsx
+++ b/src/__tests__/components/DailyChallengeWidget.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen, fireEvent } from "../testUtils";
+import DailyChallengeWidget from "../../components/DailyChallengeWidget";
+
+const STORAGE_KEY = "daily_challenge_status";
+
+/** Returns a local "YYYY-MM-DD" key for the given date. */
+const dateKeyFor = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/** Returns a date shifted `n` days before today. */
+const daysAgo = (n: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() - n);
+  return date;
+};
+
+describe("DailyChallengeWidget", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test("starts unsolved when nothing is stored", async () => {
+    render(<DailyChallengeWidget />);
+    expect(
+      await screen.findByRole("button", { name: "Mark as solved" })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Solved" })).not.toBeInTheDocument();
+  });
+
+  test("marking solved persists a date-scoped status", async () => {
+    render(<DailyChallengeWidget />);
+    const button = await screen.findByRole("button", { name: "Mark as solved" });
+    fireEvent.click(button);
+
+    expect(screen.getByRole("button", { name: "Solved" })).toBeInTheDocument();
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored.date).toBe(dateKeyFor(new Date()));
+    expect(stored.status).toBe("solved");
+  });
+
+  test("rehydrates the solved status for today only", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ date: dateKeyFor(new Date()), status: "solved" })
+    );
+
+    render(<DailyChallengeWidget />);
+    expect(await screen.findByRole("button", { name: "Solved" })).toBeInTheDocument();
+  });
+
+  test("a solved status from a previous day does not leak into today", async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ date: dateKeyFor(daysAgo(1)), status: "solved" })
+    );
+
+    render(<DailyChallengeWidget />);
+    expect(
+      await screen.findByRole("button", { name: "Mark as solved" })
+    ).toBeInTheDocument();
+  });
+
+  test("legacy plain solved string is treated as stale", async () => {
+    localStorage.setItem(STORAGE_KEY, "solved");
+
+    render(<DailyChallengeWidget />);
+    expect(
+      await screen.findByRole("button", { name: "Mark as solved" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/DailyChallengeWidget.tsx
+++ b/src/components/DailyChallengeWidget.tsx
@@ -2,10 +2,27 @@ import React, { useEffect, useMemo, useState } from "react";
 import Link from "@docusaurus/Link";
 import { FiCheckCircle, FiClock, FiTag, FiTarget } from "react-icons/fi";
 import { getDailyChallenge } from "../data/dailyChallenge";
+import { safeGetItem, safeSetItem } from "../utils/safeStorage";
 
 const STORAGE_KEY = "daily_challenge_status";
 
 type ChallengeStatus = "solved" | "unsolved";
+
+interface StoredStatus {
+  date: string;
+  status: ChallengeStatus;
+}
+
+/**
+ * Returns a local "YYYY-MM-DD" key matching the calendar day used by
+ * getDailyChallenge() so the solved flag rotates with the daily challenge.
+ */
+const dateKeyFor = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
 
 const DailyChallengeWidget: React.FC = () => {
   const [status, setStatus] = useState<ChallengeStatus>("unsolved");
@@ -19,24 +36,32 @@ const DailyChallengeWidget: React.FC = () => {
       return;
     }
 
-    try {
-      const saved = window.localStorage.getItem(STORAGE_KEY);
-      if (saved === "solved") {
-        setStatus("solved");
+    const raw = safeGetItem(STORAGE_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as StoredStatus;
+        if (parsed.date === dateKeyFor(new Date()) && parsed.status === "solved") {
+          setStatus("solved");
+        }
+      } catch {
+        // Legacy plain "solved" value predates date-scoped storage and is stale.
       }
-    } catch {
-      // Ignore storage access issues.
     }
   }, []);
 
+  /**
+   * Flips the solved state for today's challenge and persists it keyed by
+   * the current date so it never leaks into future daily challenges.
+   */
   const toggleStatus = () => {
     if (typeof window === "undefined") {
       return;
     }
 
     const nextStatus = status === "solved" ? "unsolved" : "solved";
+    const stored: StoredStatus = { date: dateKeyFor(new Date()), status: nextStatus };
     setStatus(nextStatus);
-    window.localStorage.setItem(STORAGE_KEY, nextStatus);
+    safeSetItem(STORAGE_KEY, JSON.stringify(stored));
   };
 
   if (!mounted) {


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes an issue where the Daily Challenge solved state persisted across different days.

DailyChallengeWidget.tsx currently stores the completion state under a single static localStorage key:

daily_challenge_status

Meanwhile, getDailyChallenge() rotates the challenge based on the day of the year.

Because the stored completion state is not associated with a specific date or challenge, solving one day's challenge causes subsequent challenges to incorrectly appear as solved.

Fixes #3864 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
