### PR TITLE
fix: remove console.error and redundant try/catch in practice page useEffect

### DIFF
--- a/src/pages/practice/index.tsx
+++ b/src/pages/practice/index.tsx
@@ -394,12 +394,10 @@ const Practice: React.FC = () => {
   const [solved, setSolved] = useState<Set<string>>(new Set());
 
   // Mount logic to safely bootstrap standard LocalStorage states in dynamic SSR
+  // safeJsonParse handles malformed JSON internally and returns the fallback
+  // value, so no try/catch is needed here.
   useEffect(() => {
-    try {
-      setSolved(new Set(safeJsonParse<string[]>("leetcode_solved", [])));
-    } catch (e) {
-      console.error("Failed parsing problem registry context state data:", e);
-    }
+    setSolved(new Set(safeJsonParse<string[]>("leetcode_solved", [])));
   }, []);
 
   const toggleSolved = (key: string) => {


### PR DESCRIPTION
fix #3870 

**Problem**
The useEffect bootstrapping solved state wrapped safeJsonParse in a try/catch
and called console.error() on failure. DeepSource flags console.* calls in
production code as a blocking hygiene issue, causing the CI check to fail.

**Fix**
Removed the try/catch and console.error entirely. safeJsonParse already handles
malformed JSON internally and returns the [] fallback - the outer try/catch was
redundant and setSolved(new Set([])) is a safe graceful degradation.

**Testing**
No console.* calls remain in practice/index.tsx. tsc --noEmit confirms no errors.
