### PR TITLE
fix: remove console.error and console.warn calls to resolve DeepSource hygiene issues

### DIFF
--- a/src/components/ProgressTracker/SidebarUpdater.tsx
+++ b/src/components/ProgressTracker/SidebarUpdater.tsx
@@ -32,8 +32,8 @@ const SidebarUpdater: React.FC = () => {
     const load = () => {
       try {
         setProgress(safeJsonParse<ProgressData>('algo_progress', {}));
-      } catch (e) {
-        console.error(e);
+      } catch {
+        // safeJsonParse returns the fallback value on failure — nothing to surface here.
       }
     };
     

--- a/src/components/RelatedTopics.tsx
+++ b/src/components/RelatedTopics.tsx
@@ -43,7 +43,7 @@ function convertTopicToPath(topic?: string | null): string | null {
     const categoryName = cleanTopic.replace("category/", "").toLowerCase();
     const mappedPath = CATEGORY_PATH_MAP[categoryName];
     if (mappedPath) return `/docs/${mappedPath}${anchor}`;
-    console.warn(`[RelatedTopics] Unknown category mapping for: ${categoryName}`);
+    // Unknown category — no mapping available, return null to skip the link.
     return null;
   }
 
@@ -57,7 +57,7 @@ function convertTopicToPath(topic?: string | null): string | null {
   const mapped = CATEGORY_PATH_MAP[token];
   if (mapped) return `/docs/${mapped}${anchor}`;
 
-  console.warn(`[RelatedTopics] Unknown topic token, skipping link: ${topic}`);
+  // Unknown topic token — return null to skip the link silently.
   return null;
 }
 


### PR DESCRIPTION
fix #3871

**Problem**
Two files contained console.* calls that DeepSource flags as blocking hygiene issues:

- SidebarUpdater.tsx: console.error(e) inside the load catch block
- RelatedTopics.tsx: console.warn(...) twice inside convertTopicToPath for unknown category/topic tokens

**Fix**
- SidebarUpdater.tsx: removed console.error(e) and bound the catch variable to _ since safeJsonParse already returns the {} fallback on failure
- RelatedTopics.tsx: removed both console.warn calls - both code paths already return null, which the caller handles by skipping the link silently

**Testing**
No console.* calls remain in either file. tsc --noEmit confirms no errors.
