### PR TITLE
fix: add aria-label to DailyChallengeWidget toggle button for screen reader accessibility

### DIFF
--- a/src/__tests__/components/DailyChallengeWidget.test.tsx
+++ b/src/__tests__/components/DailyChallengeWidget.test.tsx
@@ -29,7 +29,7 @@ describe("DailyChallengeWidget", () => {
     expect(
       await screen.findByRole("button", { name: "Mark as solved" })
     ).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Solved" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Mark as unsolved" })).not.toBeInTheDocument();
   });
 
   test("marking solved persists a date-scoped status", async () => {
@@ -37,7 +37,7 @@ describe("DailyChallengeWidget", () => {
     const button = await screen.findByRole("button", { name: "Mark as solved" });
     fireEvent.click(button);
 
-    expect(screen.getByRole("button", { name: "Solved" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark as unsolved" })).toBeInTheDocument();
 
     const raw = localStorage.getItem(STORAGE_KEY);
     expect(raw).not.toBeNull();
@@ -53,7 +53,7 @@ describe("DailyChallengeWidget", () => {
     );
 
     render(<DailyChallengeWidget />);
-    expect(await screen.findByRole("button", { name: "Solved" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Mark as unsolved" })).toBeInTheDocument();
   });
 
   test("a solved status from a previous day does not leak into today", async () => {

--- a/src/components/DailyChallengeWidget.tsx
+++ b/src/components/DailyChallengeWidget.tsx
@@ -82,6 +82,7 @@ const DailyChallengeWidget: React.FC = () => {
         <button
           type="button"
           onClick={toggleStatus}
+          aria-label={status === "solved" ? "Mark as unsolved" : "Mark as solved"}
           className={`inline-flex shrink-0 items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
             status === "solved"
               ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"


### PR DESCRIPTION
fix #3873 

**Problem**
The "Mark as solved" toggle button had no aria-label. When solved, it
rendered the text "Solved" - screen readers announced the current state
instead of the action, giving keyboard/AT users no indication that clicking
would un-mark the challenge.

**Fix**
Added aria-label={status === "solved" ? "Mark as unsolved" : "Mark as solved"}
to the button. Assistive technologies now always announce the action the
button performs, not the current state.

Updated the DailyChallengeWidget tests to query by the aria-label values
("Mark as unsolved" / "Mark as solved") since aria-label takes precedence
over visible text as the accessible name.

**Testing**
All 5 DailyChallengeWidget tests pass. tsc --noEmit confirms no errors.
