### PR TITLE
fix: use useRef for location.search in URL-sync effect to prevent feedback loop on external navigation

### DIFF
--- a/src/components/ProblemFilterGrid.tsx
+++ b/src/components/ProblemFilterGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useRef } from 'react';
 import { useHistory, useLocation } from '@docusaurus/router';
 import clsx from 'clsx';
 import { Bookmark, Search, X, CheckCircle } from 'lucide-react';
@@ -29,6 +29,15 @@ const DEFAULT_VISIBLE_TAG_COUNT = 14;
 const ProblemFilterGrid = ({ data }: ProblemFilterGridProps) => {
   const location = useLocation();
   const history = useHistory();
+
+  // Keep a ref to the current location.search so the URL-sync effect can read
+  // it without listing it as a dependency — preventing a write-on-read loop
+  // where history.replace triggers location.search to change, re-firing the
+  // effect on every navigation including browser back/forward.
+  const locationSearchRef = useRef(location.search);
+  useEffect(() => {
+    locationSearchRef.current = location.search;
+  }, [location.search]);
 
   const initialParams = useMemo(() => {
     if (typeof window !== 'undefined') {
@@ -74,12 +83,12 @@ const ProblemFilterGrid = ({ data }: ProblemFilterGridProps) => {
     if (showNotYetSolved) params.set('unsolved', 'true');
 
     const newSearch = params.toString();
-    const currentSearch = location.search.replace(/^\?/, '');
+    const currentSearch = locationSearchRef.current.replace(/^\?/, '');
     
     if (newSearch !== currentSearch) {
       history.replace({ search: newSearch ? `?${newSearch}` : '' });
     }
-  }, [query, selectedDifficulties, selectedTags, selectedCompanies, showOnlyBookmarks, showNotYetSolved, history, location.search]);
+  }, [query, selectedDifficulties, selectedTags, selectedCompanies, showOnlyBookmarks, showNotYetSolved, history]);
 
   const { bookmarks, isBookmarked, toggleBookmark } = useBookmarks();
 


### PR DESCRIPTION
fix #3874

**Problem**
The URL-sync useEffect in ProblemFilterGrid listed location.search as a
dependency while also writing to it via history.replace. This caused:
1. Every history.replace changed location.search, re-triggering the effect
   (write-on-read loop, guarded only by string equality).
2. The effect also fired on browser back/forward navigation, potentially
   overwriting the URL the user navigated to with stale filter state.

**Fix**
- Added a locationSearchRef (useRef) that mirrors location.search via a
  separate lightweight useEffect.
- The URL-sync effect now reads locationSearchRef.current instead of
  location.search directly, removing location.search from its dependency
  array.
- The effect now only fires when filter state (query, difficulties, tags,
  companies, bookmarks, unsolved) actually changes - not on external
  navigation.

**Testing**
tsc --noEmit confirms no errors in ProblemFilterGrid.tsx.

