### PR TITLE
fix: replace alert() with inline status message and convert to const arrow to resolve DeepSource JS-0067/JS-D1001

### DIFF
--- a/src/components/Visualizing/TreeSandbox.tsx
+++ b/src/components/Visualizing/TreeSandbox.tsx
@@ -56,6 +56,91 @@ interface RotationRecipe {
   description: string;
 }
 
+// ── Pure tree utility functions (module-level, no React state) ──────────────
+
+/** Creates a new tree node with a random stable id. */
+const createNode = (key: number): NodeData => {
+  const id = Math.random().toString(36).substring(2, 9);
+  return { key, id, leftId: null, rightId: null, height: 1 };
+};
+
+/** Deep-clones a TreeMap so simulation steps don't share references. */
+const cloneTreeMap = (map: TreeMap): TreeMap => {
+  const newMap: TreeMap = {};
+  for (const key in map) {
+    newMap[key] = { ...map[key] };
+  }
+  return newMap;
+};
+
+const getHeight = (nodeId: string | null, map: TreeMap): number => {
+  if (!nodeId || !map[nodeId]) return 0;
+  return map[nodeId].height;
+};
+
+const getBalanceFactor = (nodeId: string | null, map: TreeMap): number => {
+  if (!nodeId || !map[nodeId]) return 0;
+  const node: NodeData = map[nodeId];
+  return getHeight(node.leftId, map) - getHeight(node.rightId, map);
+};
+
+const updateHeight = (nodeId: string, map: TreeMap): void => {
+  const node: NodeData = map[nodeId];
+  node.height = Math.max(getHeight(node.leftId, map), getHeight(node.rightId, map)) + 1;
+};
+
+/** Appends a snapshot of the current tree state to the simulation step list. */
+const pushStep = (
+  stepList: SimulationStep[],
+  currentMap: TreeMap,
+  currentRoot: string | null,
+  highlighted: string[],
+  success: string[],
+  warning: string[],
+  rotation: string[],
+  explanation: string,
+  visited: number[] = [],
+  actionKey?: number
+): void => {
+  stepList.push({
+    tree: cloneTreeMap(currentMap),
+    rootId: currentRoot,
+    highlightedIds: [...highlighted],
+    successIds: [...success],
+    warningIds: [...warning],
+    rotationIds: [...rotation],
+    explanation,
+    visitedKeys: [...visited],
+    actionNodeKey: actionKey,
+  });
+};
+
+/** AVL right rotation around zId; returns the new subtree root id. */
+const rotateRight = (zId: string, map: TreeMap): string => {
+  const z = map[zId];
+  const yId = z.leftId!;
+  const y = map[yId];
+  const T3Id = y.rightId;
+  y.rightId = zId;
+  z.leftId = T3Id;
+  updateHeight(zId, map);
+  updateHeight(yId, map);
+  return yId;
+};
+
+/** AVL left rotation around zId; returns the new subtree root id. */
+const rotateLeft = (zId: string, map: TreeMap): string => {
+  const z = map[zId];
+  const yId = z.rightId!;
+  const y = map[yId];
+  const T2Id = y.leftId;
+  y.leftId = zId;
+  z.rightId = T2Id;
+  updateHeight(zId, map);
+  updateHeight(yId, map);
+  return yId;
+};
+
 /**
  * Interactive BST and AVL self-balancing tree sandbox. Supports insert,
  * search, delete, and traversal operations with step-by-step animation,
@@ -83,46 +168,11 @@ const TreeSandbox = (): React.ReactElement => {
   // Inline status message replaces alert() — auto-clears after 3 s
   const [statusMessage, setStatusMessage] = useState<{ text: string; type: "error" | "info" } | null>(null);
   const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  /** Displays an inline status banner that auto-dismisses after 3 seconds. */
   const showStatus = (text: string, type: "error" | "info" = "error") => {
     if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
     setStatusMessage({ text, type });
     statusTimerRef.current = setTimeout(() => setStatusMessage(null), 3000);
-  };
-
-  // Node helper functions
-  const createNode = (key: number): NodeData => {
-    const id = Math.random().toString(36).substring(2, 9);
-    return {
-      key,
-      id,
-      leftId: null,
-      rightId: null,
-      height: 1
-    };
-  };
-
-  const cloneTreeMap = (map: TreeMap): TreeMap => {
-    const newMap: TreeMap = {};
-    for (const key in map) {
-      newMap[key] = { ...map[key] };
-    }
-    return newMap;
-  };
-
-  const getHeight = (nodeId: string | null, map: TreeMap): number => {
-    if (!nodeId || !map[nodeId]) return 0;
-    return map[nodeId].height;
-  };
-
-  const getBalanceFactor = (nodeId: string | null, map: TreeMap): number => {
-    if (!nodeId || !map[nodeId]) return 0;
-    const node: NodeData = map[nodeId];
-    return getHeight(node.leftId, map) - getHeight(node.rightId, map);
-  };
-
-  const updateHeight = (nodeId: string, map: TreeMap) => {
-    const node: NodeData = map[nodeId];
-    node.height = Math.max(getHeight(node.leftId, map), getHeight(node.rightId, map)) + 1;
   };
 
   // Generate layouts dynamically based on SVG size
@@ -180,32 +230,6 @@ const TreeSandbox = (): React.ReactElement => {
       if (timerRef.current) clearInterval(timerRef.current);
     };
   }, [isPlaying, steps.length, playSpeed]);
-
-  // Apply a Simulation Step sequence
-  const pushStep = (
-    stepList: SimulationStep[],
-    currentMap: TreeMap,
-    currentRoot: string | null,
-    highlighted: string[],
-    success: string[],
-    warning: string[],
-    rotation: string[],
-    explanation: string,
-    visited: number[] = [],
-    actionKey?: number
-  ) => {
-    stepList.push({
-      tree: cloneTreeMap(currentMap),
-      rootId: currentRoot,
-      highlightedIds: [...highlighted],
-      successIds: [...success],
-      warningIds: [...warning],
-      rotationIds: [...rotation],
-      explanation,
-      visitedKeys: [...visited],
-      actionNodeKey: actionKey
-    });
-  };
 
   // --- INTERACTION: SEARCH ---
   const triggerSearch = (key: number) => {
@@ -659,41 +683,6 @@ const TreeSandbox = (): React.ReactElement => {
     const finalStep = insertSteps[insertSteps.length - 1];
     setTreeMap(finalStep.tree);
     setRootId(finalStep.rootId);
-  };
-
-  // AVL ROTATIONS CORE MATH
-  const rotateRight = (zId: string, map: TreeMap): string => {
-    const z = map[zId];
-    const yId = z.leftId!;
-    const y = map[yId];
-    const T3Id = y.rightId;
-
-    // Perform rotation
-    y.rightId = zId;
-    z.leftId = T3Id;
-
-    // Update heights
-    updateHeight(zId, map);
-    updateHeight(yId, map);
-
-    return yId;
-  };
-
-  const rotateLeft = (zId: string, map: TreeMap): string => {
-    const z = map[zId];
-    const yId = z.rightId!;
-    const y = map[yId];
-    const T2Id = y.leftId;
-
-    // Perform rotation
-    y.leftId = zId;
-    z.rightId = T2Id;
-
-    // Update heights
-    updateHeight(zId, map);
-    updateHeight(yId, map);
-
-    return yId;
   };
 
   // --- INTERACTION: DELETE ---

--- a/src/components/Visualizing/TreeSandbox.tsx
+++ b/src/components/Visualizing/TreeSandbox.tsx
@@ -56,7 +56,12 @@ interface RotationRecipe {
   description: string;
 }
 
-export default function TreeSandbox() {
+/**
+ * Interactive BST and AVL self-balancing tree sandbox. Supports insert,
+ * search, delete, and traversal operations with step-by-step animation,
+ * balance-factor overlays, and preset AVL rotation tutorials.
+ */
+const TreeSandbox = (): React.ReactElement => {
   const { colorMode } = useColorMode();
   const isDark = colorMode === "dark";
 
@@ -74,6 +79,15 @@ export default function TreeSandbox() {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [playSpeed, setPlaySpeed] = useState<number>(1000); // ms delay
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Inline status message replaces alert() — auto-clears after 3 s
+  const [statusMessage, setStatusMessage] = useState<{ text: string; type: "error" | "info" } | null>(null);
+  const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const showStatus = (text: string, type: "error" | "info" = "error") => {
+    if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+    setStatusMessage({ text, type });
+    statusTimerRef.current = setTimeout(() => setStatusMessage(null), 3000);
+  };
 
   // Node helper functions
   const createNode = (key: number): NodeData => {
@@ -197,7 +211,7 @@ export default function TreeSandbox() {
   const triggerSearch = (key: number) => {
     setIsPlaying(false);
     if (isNaN(key) || key < 1 || key > 99) {
-      alert(translate({ message: "Please enter a valid integer between 1 and 99." }));
+      showStatus(translate({ message: "Please enter a valid integer between 1 and 99." }));
       return;
     }
     if (!rootId) return;
@@ -296,14 +310,14 @@ export default function TreeSandbox() {
   const triggerInsert = (key: number) => {
     setIsPlaying(false);
     if (isNaN(key) || key < 1 || key > 99) {
-      alert(translate({ message: "Please enter a valid integer between 1 and 99." }));
+      showStatus(translate({ message: "Please enter a valid integer between 1 and 99." }));
       return;
     }
 
     // Prevent duplicate entries
     const exists = Object.values(treeMap).some((n) => n.key === key);
     if (exists) {
-      alert(translate({ message: "Key {key} already exists in the tree!" }, { key }));
+      showStatus(translate({ message: "Key {key} already exists in the tree!" }, { key }));
       return;
     }
 
@@ -686,13 +700,13 @@ export default function TreeSandbox() {
   const triggerDelete = (key: number) => {
     setIsPlaying(false);
     if (isNaN(key) || key < 1 || key > 99) {
-      alert(translate({ message: "Please enter a valid integer between 1 and 99." }));
+      showStatus(translate({ message: "Please enter a valid integer between 1 and 99." }));
       return;
     }
 
     const exists = Object.values(treeMap).some((n) => n.key === key);
     if (!exists) {
-      alert(translate({ message: "Key {key} does not exist in the tree!" }, { key }));
+      showStatus(translate({ message: "Key {key} does not exist in the tree!" }, { key }));
       return;
     }
 
@@ -1161,10 +1175,10 @@ export default function TreeSandbox() {
 
     // Prompt user to trigger insertion of 3rd key
     setInputKey(recipe.keys[2].toString());
-    alert(translate(
+    showStatus(translate(
       { message: "Recipe loaded! Click 'Insert' to add key {key} and watch the AVL {type} rotation rebalancing animation!" },
       { key: recipe.keys[2], type: recipe.type }
-    ));
+    ), "info");
   };
 
   const loadRandomTree = () => {
@@ -1263,7 +1277,23 @@ export default function TreeSandbox() {
 
   return (
     <div style={{ padding: "8px", fontFamily: "var(--ifm-font-family-base)", color: "var(--ifm-font-color-base)" }}>
-      
+
+      {/* Inline status message — replaces alert() */}
+      {statusMessage && (
+        <div style={{
+          marginBottom: "12px",
+          padding: "10px 16px",
+          borderRadius: "10px",
+          fontWeight: 600,
+          fontSize: "0.875rem",
+          background: statusMessage.type === "error" ? "#fee2e2" : "#eff6ff",
+          color: statusMessage.type === "error" ? "#b91c1c" : "#1d4ed8",
+          border: `1px solid ${statusMessage.type === "error" ? "#fca5a5" : "#93c5fd"}`,
+        }}>
+          {statusMessage.text}
+        </div>
+      )}
+
       {/* HEADER */}
       <div style={{ textAlign: "center", marginBottom: "24px" }}>
         <div style={{ display: "inline-flex", alignItems: "center", gap: "8px", padding: "6px 14px", background: "rgba(99, 102, 241, 0.1)", borderRadius: "30px", marginBottom: "8px" }}>
@@ -1928,4 +1958,6 @@ export default function TreeSandbox() {
       </div>
     </div>
   );
-}
+};
+
+export default TreeSandbox;


### PR DESCRIPTION
fix #3882

**Problem**
TreeSandbox had three DeepSource blocking issues:
1. Six alert() calls (validation errors + recipe confirmation) - freezes the UI and fails DeepSource hygiene check
2. export default function declaration - triggers JS-0067 (unexpected function in global scope)
3. Missing JSDoc on the component - triggers JS-D1001

**Fix**
- Added statusMessage state ({ text, type: 'error' | 'info' }) with a 3s auto-clear timer (stored in statusTimerRef for cleanup safety)
- Replaced all 6 alert() calls with showStatus(...) - errors shown in red, info in blue, rendered as an inline banner above the header
- Converted export default function TreeSandbox() to a const arrow function with a separate export default TreeSandbox
- Added JSDoc block above the component declaration

**Testing**
No alert() calls remain. tsc --noEmit confirms no errors in TreeSandbox.tsx.
