### PR TITLE
fix: await act with microtask drain in renderAndSettle to fix fragile timer/async interleaving

### DIFF
--- a/src/__tests__/components/SidebarUpdater.test.tsx
+++ b/src/__tests__/components/SidebarUpdater.test.tsx
@@ -54,9 +54,11 @@ describe('SidebarUpdater', () => {
     await act(async () => {
       await Promise.resolve();
     });
-    // Then run the deferred badge-painting timeout.
-    await act(() => {
+    // Drain microtasks and advance timers together so the deferred
+    // badge-painting setTimeout fires reliably regardless of Node/Jest version.
+    await act(async () => {
       jest.advanceTimersByTime(200);
+      await Promise.resolve();
     });
   };
 


### PR DESCRIPTION
fix #3886

**Problem**
SidebarUpdater schedules setTimeout(paintBadges, 150) inside a .then() on
a mocked promise. The test flushed the promise with await Promise.resolve(),
then called act(() => jest.advanceTimersByTime(200)) - a non-async act with
no microtask drain. This ordering is not guaranteed to correctly interleave
fake timers with the async microtask queue. The tests passed currently but
could silently fail under different Node or Jest versions.

**Fix**
Changed the second act() call in renderAndSettle from synchronous to async,
adding await Promise.resolve() inside it to drain the microtask queue after
advancing the timers:

  await act(async () => {
    jest.advanceTimersByTime(200);
    await Promise.resolve();
  });

This guarantees the .then() callback fully resolves before the timer fires,
making the test deterministic across runtime versions.

