### PR TITLE
fix: sync DSA learning roadmap with unified progress state

### DIFF
--- a/src/__tests__/utils/safeStorage.test.ts
+++ b/src/__tests__/utils/safeStorage.test.ts
@@ -9,6 +9,10 @@ import {
   getUserId,
   extractQuizIdFromStorageKey,
   getAchievementSnapshot,
+  getRoadmapCompletedStages,
+  setRoadmapCompletedStages,
+  ROADMAP_COMPLETED_KEY,
+  LEGACY_ROADMAP_STORAGE_KEY,
   QuizAttemptRecord,
 } from '../../utils/safeStorage';
 
@@ -160,6 +164,63 @@ describe('safeStorage', () => {
     test('falls back to quiz_userId if session is absent', () => {
       localStorage.setItem('quiz_userId', 'usr_fallback');
       expect(getUserId()).toBe('usr_fallback');
+    });
+  });
+
+  describe('roadmap completion reconciliation', () => {
+    test('persists completed stages inside algo_progress and removes the legacy isolated key', () => {
+      localStorage.setItem(LEGACY_ROADMAP_STORAGE_KEY, JSON.stringify([1, 2]));
+
+      setRoadmapCompletedStages([1, 2, 3]);
+
+      const progress = readAlgoProgress();
+      expect(progress[ROADMAP_COMPLETED_KEY]).toEqual([1, 2, 3]);
+      expect(progress.lastActiveAt).toBeDefined();
+      expect(localStorage.getItem(LEGACY_ROADMAP_STORAGE_KEY)).toBeNull();
+    });
+
+    test('getRoadmapCompletedStages migrates legacy isolated data into algo_progress', () => {
+      localStorage.setItem(LEGACY_ROADMAP_STORAGE_KEY, JSON.stringify([1, 2]));
+
+      const stages = getRoadmapCompletedStages();
+
+      expect(stages).toEqual([1, 2]);
+      const progress = readAlgoProgress();
+      expect(progress[ROADMAP_COMPLETED_KEY]).toEqual([1, 2]);
+      expect(localStorage.getItem(LEGACY_ROADMAP_STORAGE_KEY)).toBeNull();
+    });
+
+    test('getRoadmapCompletedStages merges algo_progress and legacy data, dedupes and sorts', () => {
+      localStorage.setItem(LEGACY_ROADMAP_STORAGE_KEY, JSON.stringify([3, 1]));
+      writeAlgoProgress({ [ROADMAP_COMPLETED_KEY]: [2, 1] });
+
+      const stages = getRoadmapCompletedStages();
+
+      expect(stages).toEqual([1, 2, 3]);
+      expect(readAlgoProgress()[ROADMAP_COMPLETED_KEY]).toEqual([1, 2, 3]);
+      expect(localStorage.getItem(LEGACY_ROADMAP_STORAGE_KEY)).toBeNull();
+    });
+
+    test('getRoadmapCompletedStages reads from algo_progress when no legacy data exists', () => {
+      writeAlgoProgress({ [ROADMAP_COMPLETED_KEY]: [4, 2] });
+
+      const stages = getRoadmapCompletedStages();
+
+      expect(stages).toEqual([2, 4]);
+      expect(localStorage.getItem(LEGACY_ROADMAP_STORAGE_KEY)).toBeNull();
+    });
+
+    test('tolerates corrupt legacy data and filters non-number ids', () => {
+      localStorage.setItem(LEGACY_ROADMAP_STORAGE_KEY, '{ invalid json');
+      writeAlgoProgress({ [ROADMAP_COMPLETED_KEY]: [1, 'bad', 2] });
+
+      const stages = getRoadmapCompletedStages();
+
+      expect(stages).toEqual([1, 2]);
+    });
+
+    test('returns an empty array when nothing is stored', () => {
+      expect(getRoadmapCompletedStages()).toEqual([]);
     });
   });
 

--- a/src/components/DSALearningRoadmap/index.tsx
+++ b/src/components/DSALearningRoadmap/index.tsx
@@ -1,5 +1,8 @@
-import React, { useState, useEffect, useMemo } from "react";
-import { safeJsonParse } from "../../utils/safeStorage";
+import React, { useState, useEffect, useMemo, useRef } from "react";
+import {
+  getRoadmapCompletedStages,
+  setRoadmapCompletedStages,
+} from "../../utils/safeStorage";
 import { STAGES } from "../../data/roadmapData";
 import RoadmapStage from "./RoadmapStage";
 
@@ -8,20 +11,22 @@ const DSALearningRoadmap: React.FC = () => {
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set());
   const [completedStages, setCompletedStages] = useState<Set<number>>(new Set());
 
-  // Persist completion state
+  const isFirstRender = useRef(true);
+
+  // Load completion state from the canonical algo_progress store (migrates
+  // any data still in the legacy isolated key into algo_progress).
   useEffect(() => {
-    try {
-      setCompletedStages(new Set(safeJsonParse<number[]>("dsa_learning_roadmap_completed", [])));
-    } catch {}
+    setCompletedStages(new Set(getRoadmapCompletedStages()));
   }, []);
 
+  // Persist completion state inside algo_progress so it stays reconciled
+  // with the rest of the app's progress tracking.
   useEffect(() => {
-    try {
-      localStorage.setItem(
-        "dsa_learning_roadmap_completed",
-        JSON.stringify([...completedStages])
-      );
-    } catch {}
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setRoadmapCompletedStages([...completedStages]);
   }, [completedStages]);
 
   const toggleStage = (id: number) => {

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -176,6 +176,65 @@ export function markChallengeSolved(challengeId: string, title: string): void {
   );
 }
 
+/** Namespace key inside algo_progress that stores the DSA roadmap's completed stage ids. */
+export const ROADMAP_COMPLETED_KEY = 'roadmapStagesCompleted';
+
+/** Legacy isolated localStorage key the roadmap used before being reconciled into algo_progress. */
+export const LEGACY_ROADMAP_STORAGE_KEY = 'dsa_learning_roadmap_completed';
+
+/**
+ * Reads the legacy isolated roadmap key, tolerating missing or corrupt values.
+ */
+const readLegacyRoadmapStages = (): number[] => {
+  const raw = safeGetItem(LEGACY_ROADMAP_STORAGE_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((id): id is number => typeof id === 'number');
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Returns the DSA roadmap's completed stage ids from the canonical
+ * algo_progress store, migrating any data still in the legacy isolated key
+ * so roadmap progress lives with all other app progress.
+ */
+export const getRoadmapCompletedStages = (): number[] => {
+  const progress = readAlgoProgress();
+  const stored = Array.isArray(progress[ROADMAP_COMPLETED_KEY])
+    ? (progress[ROADMAP_COMPLETED_KEY] as unknown[]).filter(
+        (id): id is number => typeof id === 'number'
+      )
+    : [];
+
+  const legacy = readLegacyRoadmapStages();
+  if (legacy.length === 0) {
+    return Array.from(new Set(stored)).sort((a, b) => a - b);
+  }
+
+  const merged = Array.from(new Set([...stored, ...legacy])).sort((a, b) => a - b);
+  const next: AlgoProgressData = { ...progress, [ROADMAP_COMPLETED_KEY]: merged };
+  next.lastActiveAt = new Date().toISOString();
+  writeAlgoProgress(next);
+  safeRemoveItem(LEGACY_ROADMAP_STORAGE_KEY);
+  return merged;
+};
+
+/**
+ * Persists the DSA roadmap's completed stage ids inside the canonical
+ * algo_progress store instead of a disconnected silo.
+ */
+export const setRoadmapCompletedStages = (stageIds: number[]): void => {
+  const progress = readAlgoProgress();
+  progress[ROADMAP_COMPLETED_KEY] = Array.from(new Set(stageIds)).sort((a, b) => a - b);
+  progress.lastActiveAt = new Date().toISOString();
+  writeAlgoProgress(progress);
+  safeRemoveItem(LEGACY_ROADMAP_STORAGE_KEY);
+};
+
 export function saveQuizAttemptLocal(
   userId: string,
   quizId: string,


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes the disconnected progress tracking used by the DSA Learning Roadmap.

Previously, DSALearningRoadmap/index.tsx stored completed items exclusively under:

dsa_learning_roadmap_completed

This created a separate progress silo that was not synchronized with the application's existing algo_progress state.

The roadmap could therefore show an algorithm as incomplete even when the user had already completed it elsewhere in the application.

Fixes #3890 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
