### PR TITLE
fix: enforce mock exam timer using wall-clock time

### DIFF
--- a/src/__tests__/components/MockExamTimer.test.tsx
+++ b/src/__tests__/components/MockExamTimer.test.tsx
@@ -102,7 +102,7 @@ describe("MockExamTimer", () => {
       <MockExamTimer
         timeLimitSeconds={10}
         onTimeExpired={onTimeExpired}
-        isSubmitted={true}
+        isSubmitted
       />
     );
 

--- a/src/__tests__/components/MockExamTimer.test.tsx
+++ b/src/__tests__/components/MockExamTimer.test.tsx
@@ -52,10 +52,64 @@ describe("MockExamTimer", () => {
       jest.advanceTimersByTime(2000);
     });
 
+    expect(onTimeExpired).toHaveBeenCalled();
+  });
+
+  test("accounts for real elapsed time when tab was backgrounded", () => {
+    const onTimeExpired = jest.fn();
+    render(
+      <MockExamTimer
+        timeLimitSeconds={300}
+        onTimeExpired={onTimeExpired}
+        isSubmitted={false}
+      />
+    );
+
+    expect(screen.getByRole("timer")).toHaveTextContent("05:00");
+
+    // Simulate a 5-minute browser throttle (e.g. tab was in background).
+    // A naive decrementing timer would only lose 1 tick here, but a
+    // wall-clock timer correctly deducts 5 real minutes.
     act(() => {
-      jest.runAllTimers();
+      jest.advanceTimersByTime(5 * 60 * 1000);
     });
 
+    expect(screen.getByRole("timer")).toHaveTextContent("00:00");
     expect(onTimeExpired).toHaveBeenCalled();
+  });
+
+  test("calls onTick with seconds of time spent", () => {
+    const onTick = jest.fn();
+    render(
+      <MockExamTimer
+        timeLimitSeconds={100}
+        onTimeExpired={jest.fn()}
+        isSubmitted={false}
+        onTick={onTick}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(onTick).toHaveBeenLastCalledWith(3);
+  });
+
+  test("does not tick when submitted", () => {
+    const onTimeExpired = jest.fn();
+    render(
+      <MockExamTimer
+        timeLimitSeconds={10}
+        onTimeExpired={onTimeExpired}
+        isSubmitted={true}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(onTimeExpired).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -67,13 +67,13 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
 
   // Main countdown: wall-clock based so backgrounded tabs still lose real time.
   useEffect(() => {
-    if (isSubmitted) return;
-
-    recalc();
-
-    intervalRef.current = setInterval(() => {
+    if (!isSubmitted) {
       recalc();
-    }, 1000);
+
+      intervalRef.current = setInterval(() => {
+        recalc();
+      }, 1000);
+    }
 
     return () => {
       if (intervalRef.current) {
@@ -88,16 +88,16 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
   // When the user switches back to the tab, immediately snap to the correct time
   // instead of waiting for the next 1-second tick.
   useEffect(() => {
-    if (isSubmitted) return;
-
-    /** Snaps the displayed time to the wall-clock value when the tab regains focus. */
     const handleVisibility = () => {
       if (document.visibilityState === "visible") {
         recalc();
       }
     };
 
-    document.addEventListener("visibilitychange", handleVisibility);
+    if (!isSubmitted) {
+      document.addEventListener("visibilitychange", handleVisibility);
+    }
+
     return () => {
       document.removeEventListener("visibilitychange", handleVisibility);
     };

--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -88,6 +88,7 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
   // When the user switches back to the tab, immediately snap to the correct time
   // instead of waiting for the next 1-second tick.
   useEffect(() => {
+    /** Snaps the displayed time to the wall-clock value when the tab regains focus. */
     const handleVisibility = () => {
       if (document.visibilityState === "visible") {
         recalc();

--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -22,12 +22,13 @@ export function formatTime(seconds: number): string {
   return `${pad(mins)}:${pad(secs)}`;
 }
 
-export default function MockExamTimer({
+/** Countdown timer backed by a wall-clock deadline so backgrounded tabs still lose real time. */
+const MockExamTimer: React.FC<MockExamTimerProps> = ({
   timeLimitSeconds,
   onTimeExpired,
   isSubmitted,
   onTick,
-}: MockExamTimerProps) {
+}) => {
   const deadlineRef = useRef<number>(Date.now() + timeLimitSeconds * 1000);
   const [timeLeft, setTimeLeft] = useState<number>(timeLimitSeconds);
   const expiredRef = useRef<boolean>(false);
@@ -89,6 +90,7 @@ export default function MockExamTimer({
   useEffect(() => {
     if (isSubmitted) return;
 
+    /** Snaps the displayed time to the wall-clock value when the tab regains focus. */
     const handleVisibility = () => {
       if (document.visibilityState === "visible") {
         recalc();
@@ -96,7 +98,9 @@ export default function MockExamTimer({
     };
 
     document.addEventListener("visibilitychange", handleVisibility);
-    return () => document.removeEventListener("visibilitychange", handleVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
   }, [isSubmitted, recalc]);
 
   const isWarning = timeLeft > 0 && timeLeft <= 300; // < 5 mins
@@ -130,4 +134,6 @@ export default function MockExamTimer({
       </span>
     </div>
   );
-}
+};
+
+export default MockExamTimer;

--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -75,7 +75,7 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
       recalc();
     }, 1000);
 
-    return function cleanupInterval() {
+    return () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
@@ -98,7 +98,7 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
     };
 
     document.addEventListener("visibilitychange", handleVisibility);
-    return function cleanupVisibility() {
+    return () => {
       document.removeEventListener("visibilitychange", handleVisibility);
     };
   }, [isSubmitted, recalc]);

--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { FaClock, FaExclamationTriangle } from "react-icons/fa";
 
 interface MockExamTimerProps {
@@ -28,49 +28,76 @@ export default function MockExamTimer({
   isSubmitted,
   onTick,
 }: MockExamTimerProps) {
+  const deadlineRef = useRef<number>(Date.now() + timeLimitSeconds * 1000);
   const [timeLeft, setTimeLeft] = useState<number>(timeLimitSeconds);
   const expiredRef = useRef<boolean>(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Keep refs to the latest callbacks so the interval closure never goes stale.
-  // This means a new referentially-different onTick/onTimeExpired from the parent
-  // will NOT restart the interval — it simply updates what gets called on the
-  // next tick.
   const onTickRef = useRef(onTick);
   const onTimeExpiredRef = useRef(onTimeExpired);
   useEffect(() => { onTickRef.current = onTick; }, [onTick]);
   useEffect(() => { onTimeExpiredRef.current = onTimeExpired; }, [onTimeExpired]);
 
-  useEffect(() => {
-    setTimeLeft(timeLimitSeconds);
-    expiredRef.current = false;
+  // Recalculate remaining time from the wall-clock deadline.
+  const recalc = useCallback(() => {
+    const remaining = Math.max(0, Math.ceil((deadlineRef.current - Date.now()) / 1000));
+    setTimeLeft(remaining);
+
+    if (onTickRef.current) {
+      onTickRef.current(timeLimitSeconds - remaining);
+    }
+
+    if (remaining <= 0 && !expiredRef.current) {
+      expiredRef.current = true;
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      onTimeExpiredRef.current();
+    }
   }, [timeLimitSeconds]);
 
+  // Reset deadline when timeLimitSeconds changes (e.g. parent re-mounts the timer).
   useEffect(() => {
-    if (isSubmitted || timeLeft <= 0) return;
+    deadlineRef.current = Date.now() + timeLimitSeconds * 1000;
+    expiredRef.current = false;
+    setTimeLeft(timeLimitSeconds);
+  }, [timeLimitSeconds]);
 
-    const timer = setInterval(() => {
-      setTimeLeft((prev) => {
-        const next = prev - 1;
-        if (onTickRef.current) {
-          onTickRef.current(next);
-        }
+  // Main countdown: wall-clock based so backgrounded tabs still lose real time.
+  useEffect(() => {
+    if (isSubmitted) return;
 
-        if (next <= 0 && !expiredRef.current) {
-          expiredRef.current = true;
-          clearInterval(timer);
-          setTimeout(() => {
-            onTimeExpiredRef.current();
-          }, 0);
-          return 0;
-        }
-        return next;
-      });
+    recalc();
+
+    intervalRef.current = setInterval(() => {
+      recalc();
     }, 1000);
 
-    return () => clearInterval(timer);
-  // onTimeExpired and onTick intentionally excluded — refs keep them current
-  // without restarting the interval on every parent re-render.
-  }, [isSubmitted]); // eslint-disable-line react-hooks/exhaustive-deps
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  // recalc is stable (timeLimitSeconds only changes on reset, handled above).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSubmitted]);
+
+  // When the user switches back to the tab, immediately snap to the correct time
+  // instead of waiting for the next 1-second tick.
+  useEffect(() => {
+    if (isSubmitted) return;
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        recalc();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    return () => document.removeEventListener("visibilitychange", handleVisibility);
+  }, [isSubmitted, recalc]);
 
   const isWarning = timeLeft > 0 && timeLeft <= 300; // < 5 mins
   const isCritical = timeLeft > 0 && timeLeft <= 60;  // < 1 min

--- a/src/components/Quiz/MockExamTimer.tsx
+++ b/src/components/Quiz/MockExamTimer.tsx
@@ -75,7 +75,7 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
       recalc();
     }, 1000);
 
-    return () => {
+    return function cleanupInterval() {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
@@ -98,7 +98,7 @@ const MockExamTimer: React.FC<MockExamTimerProps> = ({
     };
 
     document.addEventListener("visibilitychange", handleVisibility);
-    return () => {
+    return function cleanupVisibility() {
       document.removeEventListener("visibilitychange", handleVisibility);
     };
   }, [isSubmitted, recalc]);


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes an issue where the Mock Exam Timer can effectively be paused by backgrounding the browser tab.

Previously, MockExamTimer.tsx relied on setInterval(..., 1000) and decremented timeLeft by one on every interval tick. Browsers throttle timers in inactive/background tabs, causing the countdown to advance slower than real elapsed time.

This could allow a user to extend a timed exam beyond its intended duration simply by switching tabs.

Fixes #3892 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
