### PR TITLE
fix: store SearchBar setTimeout in useRef to prevent memory leak on unmount

### DIFF
--- a/src/pages/books/index.tsx
+++ b/src/pages/books/index.tsx
@@ -1,4 +1,4 @@
-import React, { JSX, useState, useMemo, useEffect } from 'react';
+import React, { JSX, useState, useMemo, useEffect, useRef } from 'react';
 import Layout from '@theme/Layout';
 import clsx from 'clsx';
 import Head from "@docusaurus/Head";
@@ -262,9 +262,18 @@ const SearchBar = () => {
   const history = useHistory();
   const location = useLocation();
   const [value, setValue] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   useEffect(() => {
     setValue(readSearchName(location.search));
   }, [location]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
   return (
     <div className={styles.searchContainer}>
       <input
@@ -286,7 +295,8 @@ const SearchBar = () => {
             search: newSearch.toString(),
             state: prepareUserState(),
           });
-          setTimeout(() => {
+          if (timerRef.current) clearTimeout(timerRef.current);
+          timerRef.current = setTimeout(() => {
             document.getElementById('searchbar')?.focus();
           }, 0);
         }}


### PR DESCRIPTION
Fix #3884

## Description

This PR addresses a DeepSource blocking reliability issue where `SearchBar` in `src/pages/books/index.tsx` was using a bare `setTimeout` without any cleanup. If the component unmounted before the timeout fired, it would attempt to refocus a detached DOM node.

## Changes Made

- Imported `useRef` to store the timeout reference (`timerRef`).
- Added a `useEffect` hook with a cleanup function to call `clearTimeout(timerRef.current)` on component unmount.
- Ensured any existing timeouts are cleared before setting a new one inside the `onInput` event handler.