### PR TITLE
fix: remove console.error, fix bare setTimeout and JS-0067 in profile pages

### DIFF
--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -20,7 +20,8 @@ interface TelemetryStats {
   recentTopics: string[];
 }
 
-export default function ProfilePage() {
+/** Profile page — developer identity dashboard with telemetry, streak, and public profile settings. */
+const ProfilePage = (): React.ReactElement => {
   const { user, isAuthenticated, logout } = useAuth();
   const [activeTab, setActiveTab] = useState<DashboardTab>("overview");
 
@@ -46,8 +47,8 @@ export default function ProfilePage() {
 
         setTelemetry({ completedCount: totalMastered, recentTopics: topics });
       }
-    } catch (error) {
-      console.error("[Telemetry Engine] Error parsing local storage:", error);
+    } catch {
+      // localStorage parse failed — telemetry stays at default zero state.
     }
   };
 
@@ -437,4 +438,6 @@ export default function ProfilePage() {
       </main>
     </Layout>
   );
-}
+};
+
+export default ProfilePage;

--- a/src/pages/u/[username]/badge.tsx
+++ b/src/pages/u/[username]/badge.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useRef } from 'react';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
@@ -19,11 +19,14 @@ function extractUsername(pathname: string): string {
 
 type BadgeStyle = 'for-the-badge' | 'flat' | 'flat-square' | 'plastic';
 
-export default function PublicProfileBadgePage() {
+/** Badge page — renders customizable embeddable Shields.io badges for a public Algo profile at /u/:username/badge. */
+const PublicProfileBadgePage = (): React.ReactElement => {
   const location = useLocation();
   const username = useMemo(() => extractUsername(location.pathname), [location.pathname]);
   
   const [copiedFormat, setCopiedFormat] = useState<'markdown' | 'html' | 'url' | null>(null);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current); }, []);
   const [activeTab, setActiveTab] = useState<'preview' | 'embed'>('preview');
   
   // Customization controls
@@ -51,9 +54,10 @@ export default function PublicProfileBadgePage() {
     try {
       await navigator.clipboard.writeText(text);
       setCopiedFormat(format);
-      setTimeout(() => setCopiedFormat(null), 2000);
-    } catch (err) {
-      console.error('Failed to copy code snippet:', err);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopiedFormat(null), 2000);
+    } catch {
+      // Clipboard write failed silently — user can manually select and copy.
     }
   };
 
@@ -301,4 +305,6 @@ export default function PublicProfileBadgePage() {
       </main>
     </Layout>
   );
-}
+};
+
+export default PublicProfileBadgePage;

--- a/src/pages/u/[username]/index.tsx
+++ b/src/pages/u/[username]/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useMemo, useState, useEffect, useRef } from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import { useLocation } from "@docusaurus/router";
@@ -21,12 +21,15 @@ function getUsernameFromPathname(pathname: string): string {
   return segments[segments.length - 1] || "";
 }
 
-export default function PublicProfilePage() {
+/** Public profile page — renders a user's public telemetry snapshot at /u/:username. */
+const PublicProfilePage = (): React.ReactElement => {
   const location = useLocation();
   const username = useMemo(() => getUsernameFromPathname(location.pathname), [
     location.pathname,
   ]);
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current); }, []);
   const [origin, setOrigin] = useState("https://ajay-dhangar.github.io");
 
   useEffect(() => {
@@ -55,9 +58,10 @@ export default function PublicProfilePage() {
     try {
       await navigator.clipboard.writeText(badgeMarkdown);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error("Failed to copy badge text:", err);
+      if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current);
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard write failed — user can manually copy the badge markdown below.
     }
   };
 
@@ -354,4 +358,6 @@ export default function PublicProfilePage() {
       </main>
     </Layout>
   );
-}
+};
+
+export default PublicProfilePage;


### PR DESCRIPTION
fix #3908

**Problem**
Three files introduced in the profile/public-profile feature had multiple
DeepSource blocking issues:

1. console.error calls in profile.tsx, u/[username]/index.tsx, u/[username]/badge.tsx
   - DeepSource hygiene rule (same as #3870, #3871)
2. export default function declarations in all three files - JS-0067
3. Bare setTimeout without useRef cleanup in index.tsx and badge.tsx - reliability issue

**Fix**
- Removed all 3 console.error calls; errors are already handled gracefully by
  try/catch with fallback state, so the logs add no production value
- Converted all three export default function declarations to const arrow
  functions with JSDoc comments and separate default exports
- Added copiedTimerRef useRef + useEffect cleanup to index.tsx and badge.tsx
  to safely clear pending timers on unmount

**Testing**
tsc --noEmit confirms no errors in any of the three files.
No console.* calls remain.
