### PR TITLE
fix: replace bare window.setTimeout with useRef cleanup and fix JS-0067 in PublicProfileSettingsCard

### DIFF
--- a/src/components/PublicProfileSettingsCard.tsx
+++ b/src/components/PublicProfileSettingsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { 
   FiShare2, 
@@ -50,7 +50,8 @@ const sectionFields: SectionField[] = [
   },
 ];
 
-export default function PublicProfileSettingsCard() {
+/** Card component for editing and saving public profile visibility settings, with clipboard copy support. */
+const PublicProfileSettingsCard = (): React.ReactElement => {
   const [settings, setSettings] = useState(() => 
     getPublicProfileSettings() || {
       isPublic: false,
@@ -64,6 +65,8 @@ export default function PublicProfileSettingsCard() {
     }
   );
   const [copyMessage, setCopyMessage] = useState("");
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => { if (copyTimerRef.current) clearTimeout(copyTimerRef.current); }, []);
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
 
   const profileUrl = typeof window !== "undefined" && settings.username.trim()
@@ -104,10 +107,12 @@ export default function PublicProfileSettingsCard() {
       }
 
       setCopyMessage(`${label} copied!`);
-      window.setTimeout(() => setCopyMessage(""), 2500);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopyMessage(""), 2500);
     } catch {
       setCopyMessage(`Unable to copy ${label}`);
-      window.setTimeout(() => setCopyMessage(""), 2500);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopyMessage(""), 2500);
     }
   };
 
@@ -350,4 +355,6 @@ export default function PublicProfileSettingsCard() {
       </div>
     </motion.div>
   );
-}
+};
+
+export default PublicProfileSettingsCard;


### PR DESCRIPTION
fix #3909

**Problem**
PublicProfileSettingsCard had three DeepSource blocking issues:
1. Two bare window.setTimeout(() => setCopyMessage(""), 2500) calls - no useRef,
   no clearTimeout cleanup. If the component unmounts before 2.5s, setCopyMessage
   fires on a detached component.
2. export default function declaration - triggers JS-0067.
3. Missing JSDoc on the component - triggers JS-D1001.

**Fix**
- Added copyTimerRef (useRef) with a useEffect cleanup to safely cancel the
  pending timer on unmount.
- Replaced both window.setTimeout calls with clearTimeout + ref-tracked setTimeout.
- Converted export default function to a const arrow function with JSDoc and
  a separate export default.
- Added useRef to React imports.

**Testing**
tsc --noEmit confirms no errors in PublicProfileSettingsCard.tsx.
