### PR TITLE
fix: wrap parseTelemetryData in useCallback to fix missing dependency

### DIFF
--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import { motion, AnimatePresence } from "framer-motion";
@@ -29,7 +29,7 @@ export default function ProfilePage() {
     recentTopics: []
   });
 
-  const parseTelemetryData = () => {
+  const parseTelemetryData = useCallback(() => {
     try {
       const saved = localStorage.getItem("algo_progress");
       if (saved) {
@@ -49,14 +49,14 @@ export default function ProfilePage() {
     } catch (error) {
       console.error("[Telemetry Engine] Error parsing local storage:", error);
     }
-  };
+  }, []);
 
   useEffect(() => {
     parseTelemetryData();
     const handleProgressUpdate = () => parseTelemetryData();
     window.addEventListener("progressUpdated", handleProgressUpdate);
     return () => window.removeEventListener("progressUpdated", handleProgressUpdate);
-  }, []);
+  }, [parseTelemetryData]);
 
   const joinDate = useMemo(() => {
     if (!user?.createdAt) {


### PR DESCRIPTION
Fix #3912

## Description

This PR addresses an issue in src/pages/profile.tsx where parseTelemetryData was being redefined on every render because it wasn't memoized. It was being called inside a useEffect but missing from its dependency array, which meant the progress updated event listener wasn't capturing the latest state properly.

## Changes Made

- Imported useCallback from react.
- Wrapped parseTelemetryData in useCallback(() => { ... }, []).
- Added parseTelemetryData to the useEffect dependency array so that ESLint's exhaustive-deps rule is satisfied and the event listener binds properly without recreating the function on every render.