### PR TITLE
feat: add adaptive difficulty mode for quizzes

### DIFF
--- a/src/__tests__/components/AdaptiveQuizRunner.test.tsx
+++ b/src/__tests__/components/AdaptiveQuizRunner.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen } from "../testUtils";
 import userEvent from "@testing-library/user-event";
-import AdaptiveQuizRunner, { AdaptiveQuizItem, AdaptiveQuizSummary } from "../../components/Quiz/AdaptiveQuizRunner";
+import AdaptiveQuizRunner, { AdaptiveQuizItem } from "../../components/Quiz/AdaptiveQuizRunner";
 
 const makePool = (n = 30): AdaptiveQuizItem[] => {
   const diffs = ["Easy", "Medium", "Hard"] as const;

--- a/src/__tests__/components/AdaptiveQuizRunner.test.tsx
+++ b/src/__tests__/components/AdaptiveQuizRunner.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { render, screen, within } from "../testUtils";
+import { render, screen } from "../testUtils";
 import userEvent from "@testing-library/user-event";
 import AdaptiveQuizRunner, { AdaptiveQuizItem, AdaptiveQuizSummary } from "../../components/Quiz/AdaptiveQuizRunner";
 
-function makePool(n = 30): AdaptiveQuizItem[] {
+const makePool = (n = 30): AdaptiveQuizItem[] => {
   const diffs = ["Easy", "Medium", "Hard"] as const;
   return Array.from({ length: n }, (_, i) => ({
     id: i,
@@ -13,7 +13,7 @@ function makePool(n = 30): AdaptiveQuizItem[] {
     answer: "Correct",
     explanation: "Because.",
   }));
-}
+};
 
 describe("AdaptiveQuizRunner", () => {
   test("renders the first question with difficulty badge and options", () => {
@@ -46,7 +46,7 @@ describe("AdaptiveQuizRunner", () => {
 
   test("a full session of correct answers completes, shows Advanced, and calls onComplete exactly once", async () => {
     const user = userEvent.setup();
-    const onComplete = jest.fn<void, [AdaptiveQuizSummary]>();
+    const onComplete = jest.fn();
     render(<AdaptiveQuizRunner pool={makePool()} onComplete={onComplete} />);
 
     let guard = 0;

--- a/src/__tests__/components/AdaptiveQuizRunner.test.tsx
+++ b/src/__tests__/components/AdaptiveQuizRunner.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render, screen, within } from "../testUtils";
+import userEvent from "@testing-library/user-event";
+import AdaptiveQuizRunner, { AdaptiveQuizItem, AdaptiveQuizSummary } from "../../components/Quiz/AdaptiveQuizRunner";
+
+function makePool(n = 30): AdaptiveQuizItem[] {
+  const diffs = ["Easy", "Medium", "Hard"] as const;
+  return Array.from({ length: n }, (_, i) => ({
+    id: i,
+    difficulty: diffs[i % 3],
+    question: `Question ${i}`,
+    options: ["Correct", "Wrong A", "Wrong B", "Wrong C"],
+    answer: "Correct",
+    explanation: "Because.",
+  }));
+}
+
+describe("AdaptiveQuizRunner", () => {
+  test("renders the first question with difficulty badge and options", () => {
+    render(<AdaptiveQuizRunner pool={makePool()} />);
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(/question \d+/i);
+    expect(screen.getByRole("radiogroup", { name: /smart quiz options/i })).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(4);
+  });
+
+  test("selecting an option and submitting advances to the next question", async () => {
+    const user = userEvent.setup();
+    render(<AdaptiveQuizRunner pool={makePool()} />);
+
+    const firstQuestionText = screen.getByRole("heading", { level: 3 }).textContent;
+    const options = screen.getAllByRole("radio");
+    await user.click(options[0]);
+
+    const submit = screen.getByRole("button", { name: /submit answer/i });
+    expect(submit).not.toBeDisabled();
+    await user.click(submit);
+
+    const nextQuestionText = screen.getByRole("heading", { level: 3 }).textContent;
+    expect(nextQuestionText).not.toBe(firstQuestionText);
+  });
+
+  test("submit is disabled until an option is selected", () => {
+    render(<AdaptiveQuizRunner pool={makePool()} />);
+    expect(screen.getByRole("button", { name: /submit answer/i })).toBeDisabled();
+  });
+
+  test("a full session of correct answers completes, shows Advanced, and calls onComplete exactly once", async () => {
+    const user = userEvent.setup();
+    const onComplete = jest.fn<void, [AdaptiveQuizSummary]>();
+    render(<AdaptiveQuizRunner pool={makePool()} onComplete={onComplete} />);
+
+    let guard = 0;
+    while (!screen.queryByText(/smart quiz complete/i) && guard < 30) {
+      const correctOption = screen.getByRole("radio", { name: /correct/i });
+      await user.click(correctOption);
+      await user.click(screen.getByRole("button", { name: /submit answer/i }));
+      guard++;
+    }
+
+    expect(guard).toBeLessThan(30);
+    expect(screen.getByText(/smart quiz complete/i)).toBeInTheDocument();
+    expect(screen.getByText("Advanced")).toBeInTheDocument();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete.mock.calls[0][0].masteryLevel).toBe("Advanced");
+  });
+
+  test("shows a graceful message when the pool is empty", () => {
+    render(<AdaptiveQuizRunner pool={[]} />);
+    expect(screen.getByText(/no questions available/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/hooks/useAdaptiveQuiz.test.ts
+++ b/src/__tests__/hooks/useAdaptiveQuiz.test.ts
@@ -2,10 +2,10 @@ import { act, renderHook } from "@testing-library/react";
 import { useAdaptiveQuiz } from "../../hooks/useAdaptiveQuiz";
 import { AdaptiveQuestion, DEFAULT_ADAPTIVE_CONFIG } from "../../utils/adaptiveQuiz";
 
-function makePool(n = 30): AdaptiveQuestion[] {
+const makePool = (n = 30): AdaptiveQuestion[] => {
   const diffs = ["Easy", "Medium", "Hard"] as const;
   return Array.from({ length: n }, (_, i) => ({ id: i, difficulty: diffs[i % 3] }));
-}
+};
 
 describe("useAdaptiveQuiz", () => {
   test("starts with a question and not complete", () => {

--- a/src/__tests__/hooks/useAdaptiveQuiz.test.ts
+++ b/src/__tests__/hooks/useAdaptiveQuiz.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { useAdaptiveQuiz } from "../../hooks/useAdaptiveQuiz";
+import { AdaptiveQuestion, DEFAULT_ADAPTIVE_CONFIG } from "../../utils/adaptiveQuiz";
+
+function makePool(n = 30): AdaptiveQuestion[] {
+  const diffs = ["Easy", "Medium", "Hard"] as const;
+  return Array.from({ length: n }, (_, i) => ({ id: i, difficulty: diffs[i % 3] }));
+}
+
+describe("useAdaptiveQuiz", () => {
+  test("starts with a question and not complete", () => {
+    const { result } = renderHook(() => useAdaptiveQuiz({ pool: makePool() }));
+    expect(result.current.currentQuestion).not.toBeNull();
+    expect(result.current.isComplete).toBe(false);
+    expect(result.current.questionsAnswered).toBe(0);
+  });
+
+  test("answering advances to a new question and updates questionsAnswered", () => {
+    const { result } = renderHook(() => useAdaptiveQuiz({ pool: makePool() }));
+    const firstQuestionId = result.current.currentQuestion?.id;
+
+    act(() => {
+      result.current.answer(true);
+    });
+
+    expect(result.current.questionsAnswered).toBe(1);
+    expect(result.current.currentQuestion?.id).not.toBe(firstQuestionId);
+  });
+
+  test("a session of correct answers eventually completes within maxQuestions", () => {
+    const { result } = renderHook(() => useAdaptiveQuiz({ pool: makePool() }));
+
+    let guard = 0;
+    while (!result.current.isComplete && guard < 100) {
+      act(() => {
+        result.current.answer(true);
+      });
+      guard++;
+    }
+
+    expect(guard).toBeLessThan(100);
+    expect(result.current.isComplete).toBe(true);
+    expect(result.current.currentQuestion).toBeNull();
+    expect(result.current.questionsAnswered).toBeLessThanOrEqual(DEFAULT_ADAPTIVE_CONFIG.maxQuestions);
+    expect(result.current.masteryLevel).toBe("Advanced");
+  });
+
+  test("reset() clears progress and can swap in a new pool", () => {
+    const { result } = renderHook(() => useAdaptiveQuiz({ pool: makePool(6) }));
+
+    act(() => {
+      result.current.answer(true);
+      result.current.answer(true);
+    });
+    expect(result.current.questionsAnswered).toBe(2);
+
+    act(() => {
+      result.current.reset(makePool(10));
+    });
+
+    expect(result.current.questionsAnswered).toBe(0);
+    expect(result.current.currentQuestion).not.toBeNull();
+  });
+
+  test("answer() is a no-op once the session is already complete", () => {
+    const { result } = renderHook(() =>
+      useAdaptiveQuiz({
+        pool: makePool(3),
+        config: { minQuestions: 1, maxQuestions: 3, confidenceThreshold: 0.99, stabilityWindow: 1, stabilityTolerance: 1 },
+      })
+    );
+
+    act(() => {
+      result.current.answer(true);
+      result.current.answer(true);
+      result.current.answer(true);
+    });
+    expect(result.current.isComplete).toBe(true);
+    const answeredBefore = result.current.questionsAnswered;
+
+    act(() => {
+      result.current.answer(true);
+    });
+    expect(result.current.questionsAnswered).toBe(answeredBefore);
+  });
+});

--- a/src/__tests__/pages/BinaryTreeQuiz.test.tsx
+++ b/src/__tests__/pages/BinaryTreeQuiz.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render, screen } from "../testUtils";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("../../utils/supabaseClient", () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockResolvedValue({ data: [], error: null }),
+      insert: jest.fn().mockReturnThis(),
+    })),
+  },
+}));
+
+import BinaryTreeQuiz from "../../pages/quizzes/binary-tree";
+
+function loginAsTestUser() {
+  window.localStorage.setItem("quiz_userId", "test-user-id");
+  window.localStorage.setItem("quiz_username", "TestUser");
+}
+
+describe("BinaryTreeQuiz page — smart quiz mode integration", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  test("renders the login gate when no session is stored", () => {
+    render(<BinaryTreeQuiz />);
+    expect(screen.getByText(/tree space initialize/i)).toBeInTheDocument();
+  });
+
+  test("renders standard mode by default once logged in, with a mode toggle", () => {
+    loginAsTestUser();
+    render(<BinaryTreeQuiz />);
+    expect(screen.getByRole("button", { name: /^standard$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /smart quiz/i })).toBeInTheDocument();
+    // Standard mode shows the fixed-progress question index (Evaluation Node Index).
+    expect(screen.getByText(/evaluation node index/i)).toBeInTheDocument();
+  });
+
+  test("switching to Smart Quiz mode renders the adaptive runner instead of the fixed question flow", async () => {
+    loginAsTestUser();
+    const user = userEvent.setup();
+    render(<BinaryTreeQuiz />);
+
+    await user.click(screen.getByRole("button", { name: /smart quiz/i }));
+
+    expect(screen.getByText(/smart quiz · question 1/i)).toBeInTheDocument();
+    expect(screen.queryByText(/evaluation node index/i)).not.toBeInTheDocument();
+  });
+
+  test("switching back to Standard mode restores the fixed question flow", async () => {
+    loginAsTestUser();
+    const user = userEvent.setup();
+    render(<BinaryTreeQuiz />);
+
+    await user.click(screen.getByRole("button", { name: /smart quiz/i }));
+    await user.click(screen.getByRole("button", { name: /^standard$/i }));
+
+    expect(screen.getByText(/evaluation node index/i)).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/pages/BinaryTreeQuiz.test.tsx
+++ b/src/__tests__/pages/BinaryTreeQuiz.test.tsx
@@ -16,10 +16,10 @@ jest.mock("../../utils/supabaseClient", () => ({
 
 import BinaryTreeQuiz from "../../pages/quizzes/binary-tree";
 
-function loginAsTestUser() {
+const loginAsTestUser = () => {
   window.localStorage.setItem("quiz_userId", "test-user-id");
   window.localStorage.setItem("quiz_username", "TestUser");
-}
+};
 
 describe("BinaryTreeQuiz page — smart quiz mode integration", () => {
   beforeEach(() => {

--- a/src/__tests__/utils/adaptiveQuiz.test.ts
+++ b/src/__tests__/utils/adaptiveQuiz.test.ts
@@ -1,0 +1,119 @@
+import {
+  createInitialAdaptiveState,
+  recordAnswer,
+  selectNextQuestion,
+  shouldStop,
+  getMasteryLevel,
+  getConfidencePercent,
+  DEFAULT_ADAPTIVE_CONFIG,
+  AdaptiveQuestion,
+  AdaptiveState,
+  AdaptiveConfig,
+} from "../../utils/adaptiveQuiz";
+
+function makePool(n = 30): AdaptiveQuestion[] {
+  const diffs = ["Easy", "Medium", "Hard"] as const;
+  return Array.from({ length: n }, (_, i) => ({ id: i, difficulty: diffs[i % 3] }));
+}
+
+function runSession(
+  answerFn: (q: AdaptiveQuestion, state: AdaptiveState) => boolean,
+  config: AdaptiveConfig = DEFAULT_ADAPTIVE_CONFIG,
+  poolSize = 30
+) {
+  const pool = makePool(poolSize);
+  let state = createInitialAdaptiveState();
+  const askedDifficulties: string[] = [];
+  let guard = 0;
+  while (!shouldStop(state, pool.length, config)) {
+    guard++;
+    if (guard > 1000) throw new Error("Session did not terminate");
+    const q = selectNextQuestion(state, pool);
+    if (!q) break;
+    askedDifficulties.push(q.difficulty);
+    const correct = answerFn(q, state);
+    state = recordAnswer(state, q, correct);
+  }
+  return { state, askedDifficulties };
+}
+
+describe("adaptiveQuiz engine", () => {
+  test("a learner who always answers correctly ends Advanced, within bounds", () => {
+    const { state, askedDifficulties } = runSession(() => true);
+    expect(state.history.length).toBeGreaterThanOrEqual(DEFAULT_ADAPTIVE_CONFIG.minQuestions);
+    expect(state.history.length).toBeLessThanOrEqual(DEFAULT_ADAPTIVE_CONFIG.maxQuestions);
+    expect(getMasteryLevel(state)).toBe("Advanced");
+    expect(getConfidencePercent(state)).toBeGreaterThanOrEqual(60);
+    expect(askedDifficulties.slice(-2)).toContain("Hard");
+  });
+
+  test("a learner who always answers incorrectly ends Developing", () => {
+    const { state, askedDifficulties } = runSession(() => false);
+    expect(getMasteryLevel(state)).toBe("Developing");
+    expect(askedDifficulties.slice(-2)).toContain("Easy");
+  });
+
+  test("a learner who aces Easy/Medium but always misses Hard ends Proficient, not Advanced", () => {
+    const { state } = runSession((q) => q.difficulty !== "Hard");
+    expect(getMasteryLevel(state)).toBe("Proficient");
+  });
+
+  test("an adversarial alternating answer pattern still terminates within maxQuestions", () => {
+    let i = 0;
+    const { state } = runSession(() => {
+      i++;
+      return i % 2 === 0;
+    });
+    expect(state.history.length).toBeLessThanOrEqual(DEFAULT_ADAPTIVE_CONFIG.maxQuestions);
+  });
+
+  test("an unreachable confidence threshold still stops at the hard maxQuestions ceiling", () => {
+    const strictConfig: AdaptiveConfig = {
+      minQuestions: 3,
+      maxQuestions: 8,
+      confidenceThreshold: 0.0001,
+      stabilityWindow: 4,
+      stabilityTolerance: 0.35,
+    };
+    const { state } = runSession(() => Math.random() < 0.5, strictConfig);
+    expect(state.history.length).toBe(8);
+  });
+
+  test("never ends before minQuestions even with a trivially loose confidence threshold", () => {
+    const looseConfig: AdaptiveConfig = {
+      minQuestions: 6,
+      maxQuestions: 20,
+      confidenceThreshold: 0.99,
+      stabilityWindow: 4,
+      stabilityTolerance: 0.35,
+    };
+    const { state } = runSession(() => true, looseConfig);
+    expect(state.history.length).toBeGreaterThanOrEqual(6);
+    expect(state.history.length).toBeLessThanOrEqual(20);
+  });
+
+  test("a small pool never asks more questions than it has, and asks at least one", () => {
+    const { state } = runSession(() => true, DEFAULT_ADAPTIVE_CONFIG, 4);
+    expect(state.history.length).toBeLessThanOrEqual(4);
+    expect(state.history.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("no question is ever repeated within a single session", () => {
+    const { state } = runSession(() => Math.random() < 0.5);
+    const ids = state.history.map((h) => h.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("selectNextQuestion returns null once every question has been answered", () => {
+    const pool = makePool(3);
+    let state = createInitialAdaptiveState();
+    for (const q of pool) state = recordAnswer(state, q, true);
+    expect(selectNextQuestion(state, pool)).toBeNull();
+  });
+
+  test("getMasteryLevel and getConfidencePercent are pure functions of state", () => {
+    const state = createInitialAdaptiveState();
+    expect(getMasteryLevel(state)).toBe("Proficient");
+    expect(getConfidencePercent(state)).toBe(0);
+  });
+});

--- a/src/__tests__/utils/adaptiveQuiz.test.ts
+++ b/src/__tests__/utils/adaptiveQuiz.test.ts
@@ -11,16 +11,16 @@ import {
   AdaptiveConfig,
 } from "../../utils/adaptiveQuiz";
 
-function makePool(n = 30): AdaptiveQuestion[] {
+const makePool = (n = 30): AdaptiveQuestion[] => {
   const diffs = ["Easy", "Medium", "Hard"] as const;
   return Array.from({ length: n }, (_, i) => ({ id: i, difficulty: diffs[i % 3] }));
-}
+};
 
-function runSession(
+const runSession = (
   answerFn: (q: AdaptiveQuestion, state: AdaptiveState) => boolean,
   config: AdaptiveConfig = DEFAULT_ADAPTIVE_CONFIG,
   poolSize = 30
-) {
+) => {
   const pool = makePool(poolSize);
   let state = createInitialAdaptiveState();
   const askedDifficulties: string[] = [];
@@ -35,7 +35,7 @@ function runSession(
     state = recordAnswer(state, q, correct);
   }
   return { state, askedDifficulties };
-}
+};
 
 describe("adaptiveQuiz engine", () => {
   test("a learner who always answers correctly ends Advanced, within bounds", () => {

--- a/src/__tests__/utils/adaptiveQuiz.test.ts
+++ b/src/__tests__/utils/adaptiveQuiz.test.ts
@@ -28,10 +28,10 @@ const runSession = (
   while (!shouldStop(state, pool.length, config)) {
     guard++;
     if (guard > 1000) throw new Error("Session did not terminate");
-    const q = selectNextQuestion(state, pool);
-    if (!q) break;
-    askedDifficulties.push(q.difficulty);
-    const correct = answerFn(q, state);
+    const question = selectNextQuestion(state, pool);
+    if (!question) break;
+    askedDifficulties.push(question.difficulty);
+    const correct = answerFn(question, state);
     state = recordAnswer(state, q, correct);
   }
   return { state, askedDifficulties };

--- a/src/components/Quiz/AdaptiveQuizRunner.tsx
+++ b/src/components/Quiz/AdaptiveQuizRunner.tsx
@@ -1,0 +1,187 @@
+import React, { useEffect, useState } from "react";
+import { FaBrain, FaChevronRight, FaRedo } from "react-icons/fa";
+import { useAdaptiveQuiz } from "../../hooks/useAdaptiveQuiz";
+import { AdaptiveQuestion, MasteryLevel } from "../../utils/adaptiveQuiz";
+
+export interface AdaptiveQuizItem extends AdaptiveQuestion {
+  question: string;
+  options: string[];
+  answer: string;
+  explanation?: string;
+}
+
+export interface AdaptiveQuizSummary {
+  masteryLevel: MasteryLevel;
+  confidencePercent: number;
+  questionsAsked: number;
+  correctCount: number;
+  abilityEstimate: number;
+}
+
+interface Props {
+  pool: AdaptiveQuizItem[];
+  onComplete?: (summary: AdaptiveQuizSummary) => void;
+}
+
+const DIFFICULTY_BADGE: Record<string, string> = {
+  Easy: "bg-emerald-500/10 text-emerald-600 border-emerald-500/20",
+  Medium: "bg-amber-500/10 text-amber-800 dark:text-amber-400 border-amber-500/20",
+  Hard: "bg-rose-500/10 text-rose-800 dark:text-rose-400 border-rose-500/20",
+};
+
+const MASTERY_BADGE: Record<MasteryLevel, string> = {
+  Developing: "bg-rose-500/10 text-rose-800 dark:text-rose-400 border-rose-500/20",
+  Proficient: "bg-amber-500/10 text-amber-800 dark:text-amber-400 border-amber-500/20",
+  Advanced: "bg-emerald-500/10 text-emerald-600 border-emerald-500/20",
+};
+
+/**
+ * A "smart quiz" session: question difficulty adjusts in real time from the
+ * last few answers (computerized-adaptive-test style), and the session ends
+ * early once confidence in the user's mastery level is statistically
+ * reached — rather than always working through the full fixed question set.
+ *
+ * This is distinct from spaced repetition (which resurfaces missed
+ * questions across days/sessions); this operates entirely within one
+ * sitting and never repeats a question.
+ */
+export default function AdaptiveQuizRunner({ pool, onComplete }: Props) {
+  const { currentQuestion, questionsAnswered, confidencePercent, isComplete, masteryLevel, answer, history } =
+    useAdaptiveQuiz<AdaptiveQuizItem>({ pool });
+  const [selected, setSelected] = useState<string | null>(null);
+  const [reported, setReported] = useState(false);
+
+  const correctCount = history.filter((h) => h.correct).length;
+
+  useEffect(() => {
+    if (!isComplete || reported || !onComplete) return;
+    setReported(true);
+    onComplete({
+      masteryLevel,
+      confidencePercent,
+      questionsAsked: questionsAnswered,
+      correctCount,
+      abilityEstimate: history.length ? history[history.length - 1].abilityAfter : 2,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isComplete, reported]);
+
+  const handleSubmit = () => {
+    if (!currentQuestion || !selected) return;
+    answer(selected === currentQuestion.answer);
+    setSelected(null);
+  };
+
+  if (pool.length === 0) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400 text-center py-6">
+        No questions available for a smart quiz session.
+      </p>
+    );
+  }
+
+  if (isComplete) {
+    return (
+      <div className="space-y-4 text-center py-6">
+        <FaBrain className="mx-auto text-3xl text-primary-dark" />
+        <h3 className="text-lg font-bold text-slate-900 dark:text-white m-0">Smart Quiz Complete</h3>
+        <p className="text-sm text-slate-500 dark:text-slate-400 m-0">
+          Ended after {questionsAnswered} question{questionsAnswered === 1 ? "" : "s"} — confidence in your
+          mastery level reached {confidencePercent}%.
+        </p>
+        <div>
+          <span
+            className={`inline-block text-xs font-mono font-bold uppercase tracking-wider px-3 py-1 rounded border border-solid ${MASTERY_BADGE[masteryLevel]}`}
+          >
+            {masteryLevel}
+          </span>
+        </div>
+        <p className="text-sm text-slate-600 dark:text-slate-300 m-0">
+          {correctCount} / {questionsAnswered} correct
+        </p>
+      </div>
+    );
+  }
+
+  if (!currentQuestion) {
+    return (
+      <p className="text-sm text-slate-500 dark:text-slate-400 text-center py-6">
+        No questions available for a smart quiz session.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between text-[11px] font-mono text-slate-500 dark:text-slate-400">
+        <span className="inline-flex items-center gap-1.5">
+          <FaBrain className="text-primary-dark" /> Smart Quiz · Question {questionsAnswered + 1}
+        </span>
+        <span>Confidence: {confidencePercent}%</span>
+      </div>
+
+      <div className="space-y-3 text-left">
+        <span
+          className={`text-[10px] font-mono font-bold uppercase tracking-wider px-2 py-0.5 rounded border border-solid ${DIFFICULTY_BADGE[currentQuestion.difficulty]}`}
+        >
+          {currentQuestion.difficulty}
+        </span>
+        <h3 className="text-base md:text-lg font-bold text-slate-900 dark:text-white m-0 leading-relaxed font-sans">
+          {currentQuestion.question}
+        </h3>
+      </div>
+
+      <div className="grid grid-cols-1 gap-3 pt-2" role="radiogroup" aria-label="Smart Quiz Options">
+        {currentQuestion.options.map((option, index) => {
+          const isSelected = selected === option;
+          return (
+            <button
+              key={index}
+              onClick={() => setSelected(option)}
+              role="radio"
+              aria-checked={isSelected}
+              className={`w-full text-left p-4 rounded-xl border border-solid transition-all text-xs md:text-sm font-semibold tracking-wide cursor-pointer flex items-center justify-between min-h-[54px] ${
+                isSelected
+                  ? "bg-primary-dark border-primary-dark text-white shadow-xs"
+                  : "bg-slate-50 dark:bg-slate-950 border-slate-200/80 dark:border-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-900"
+              }`}
+            >
+              <span>{option}</span>
+              <div
+                className={`w-4 h-4 rounded-full border border-solid flex items-center justify-center shrink-0 ${
+                  isSelected ? "border-white bg-white/20" : "border-slate-300 dark:border-slate-700"
+                }`}
+              >
+                {isSelected && <div className="w-1.5 h-1.5 bg-white rounded-full" />}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <button
+        onClick={handleSubmit}
+        disabled={!selected}
+        className={`w-full py-3.5 px-4 rounded-xl text-xs font-bold tracking-wider uppercase border-none transition-all flex items-center justify-center gap-2 min-h-[48px] ${
+          selected
+            ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900 hover:opacity-90 cursor-pointer shadow-xs"
+            : "bg-slate-100 text-slate-400 dark:bg-slate-950 dark:text-slate-600 cursor-not-allowed"
+        }`}
+      >
+        Submit Answer
+        <FaChevronRight className="text-[10px]" />
+      </button>
+    </div>
+  );
+}
+
+export function AdaptiveQuizRestartButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 text-xs font-bold px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-900 text-slate-600 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+    >
+      <FaRedo size={11} /> Restart Smart Quiz
+    </button>
+  );
+}

--- a/src/components/Quiz/AdaptiveQuizRunner.tsx
+++ b/src/components/Quiz/AdaptiveQuizRunner.tsx
@@ -45,7 +45,7 @@ const MASTERY_BADGE: Record<MasteryLevel, string> = {
  * questions across days/sessions); this operates entirely within one
  * sitting and never repeats a question.
  */
-export default function AdaptiveQuizRunner({ pool, onComplete }: Props) {
+const AdaptiveQuizRunner = ({ pool, onComplete }: Props) => {
   const { currentQuestion, questionsAnswered, confidencePercent, isComplete, masteryLevel, answer, history } =
     useAdaptiveQuiz<AdaptiveQuizItem>({ pool });
   const [selected, setSelected] = useState<string | null>(null);
@@ -66,6 +66,7 @@ export default function AdaptiveQuizRunner({ pool, onComplete }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isComplete, reported]);
 
+  /** Submit the currently selected answer and advance. */
   const handleSubmit = () => {
     if (!currentQuestion || !selected) return;
     answer(selected === currentQuestion.answer);
@@ -136,7 +137,7 @@ export default function AdaptiveQuizRunner({ pool, onComplete }: Props) {
           const isSelected = selected === option;
           return (
             <button
-              key={index}
+              key={option}
               onClick={() => setSelected(option)}
               role="radio"
               aria-checked={isSelected}
@@ -173,9 +174,10 @@ export default function AdaptiveQuizRunner({ pool, onComplete }: Props) {
       </button>
     </div>
   );
-}
+};
 
-export function AdaptiveQuizRestartButton({ onClick }: { onClick: () => void }) {
+/** Button that restarts the adaptive quiz session. */
+const AdaptiveQuizRestartButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <button
       onClick={onClick}
@@ -184,4 +186,7 @@ export function AdaptiveQuizRestartButton({ onClick }: { onClick: () => void }) 
       <FaRedo size={11} /> Restart Smart Quiz
     </button>
   );
-}
+};
+
+export { AdaptiveQuizRestartButton };
+export default AdaptiveQuizRunner;

--- a/src/components/Quiz/AdaptiveQuizRunner.tsx
+++ b/src/components/Quiz/AdaptiveQuizRunner.tsx
@@ -133,7 +133,7 @@ const AdaptiveQuizRunner = ({ pool, onComplete }: Props) => {
       </div>
 
       <div className="grid grid-cols-1 gap-3 pt-2" role="radiogroup" aria-label="Smart Quiz Options">
-        {currentQuestion.options.map((option, index) => {
+        {currentQuestion.options.map((option) => {
           const isSelected = selected === option;
           return (
             <button

--- a/src/hooks/useAdaptiveQuiz.ts
+++ b/src/hooks/useAdaptiveQuiz.ts
@@ -1,0 +1,89 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  AdaptiveConfig,
+  AdaptiveQuestion,
+  AdaptiveState,
+  DEFAULT_ADAPTIVE_CONFIG,
+  MasteryLevel,
+  createInitialAdaptiveState,
+  getConfidencePercent,
+  getMasteryLevel,
+  recordAnswer,
+  selectNextQuestion,
+  shouldStop,
+} from "../utils/adaptiveQuiz";
+
+export interface UseAdaptiveQuizOptions<T extends AdaptiveQuestion> {
+  pool: T[];
+  config?: Partial<AdaptiveConfig>;
+}
+
+export interface UseAdaptiveQuizResult<T extends AdaptiveQuestion> {
+  /** The question to show right now, or null once the session has ended. */
+  currentQuestion: T | null;
+  /** How many questions have been answered so far. */
+  questionsAnswered: number;
+  /** Current best guess at the user's ability, on a 1 (Easy) .. 3 (Hard) scale. */
+  abilityEstimate: number;
+  /** 0-100: how statistically confident the engine is in the mastery estimate right now. */
+  confidencePercent: number;
+  /** Whether the session has ended (either by confidence or by hitting maxQuestions). */
+  isComplete: boolean;
+  /** Final mastery bucket — meaningful once isComplete is true, but available throughout as a live estimate. */
+  masteryLevel: MasteryLevel;
+  /** Records the answer to currentQuestion and advances to the next question (or ends the session). */
+  answer: (correct: boolean) => void;
+  /** Resets the session back to the start, optionally against a new pool. */
+  reset: (nextPool?: T[]) => void;
+  /** Full answer-by-answer history, useful for a results breakdown. */
+  history: AdaptiveState["history"];
+}
+
+/**
+ * Runs an adaptive ("smart") quiz session over the given question pool.
+ * Distinct from spaced repetition (which resurfaces missed questions across
+ * days/sessions): this operates entirely within a single sitting, picking
+ * the next question's difficulty from the last few answers and ending the
+ * session early once confidence in the user's mastery level is reached,
+ * rather than always working through a fixed-length question set.
+ */
+export function useAdaptiveQuiz<T extends AdaptiveQuestion>({
+  pool,
+  config,
+}: UseAdaptiveQuizOptions<T>): UseAdaptiveQuizResult<T> {
+  const resolvedConfig: AdaptiveConfig = useMemo(
+    () => ({ ...DEFAULT_ADAPTIVE_CONFIG, ...config }),
+    [config]
+  );
+
+  const [state, setState] = useState<AdaptiveState>(createInitialAdaptiveState);
+  const [activePool, setActivePool] = useState<T[]>(pool);
+
+  const isComplete = shouldStop(state, activePool.length, resolvedConfig);
+  const currentQuestion = isComplete ? null : selectNextQuestion(state, activePool);
+
+  const answer = useCallback(
+    (correct: boolean) => {
+      if (!currentQuestion) return;
+      setState((prev) => recordAnswer(prev, currentQuestion, correct));
+    },
+    [currentQuestion]
+  );
+
+  const reset = useCallback((nextPool?: T[]) => {
+    setState(createInitialAdaptiveState());
+    if (nextPool) setActivePool(nextPool);
+  }, []);
+
+  return {
+    currentQuestion,
+    questionsAnswered: state.history.length,
+    abilityEstimate: state.abilityEstimate,
+    confidencePercent: getConfidencePercent(state),
+    isComplete,
+    masteryLevel: getMasteryLevel(state),
+    answer,
+    reset,
+    history: state.history,
+  };
+}

--- a/src/hooks/useAdaptiveQuiz.ts
+++ b/src/hooks/useAdaptiveQuiz.ts
@@ -47,10 +47,10 @@ export interface UseAdaptiveQuizResult<T extends AdaptiveQuestion> {
  * session early once confidence in the user's mastery level is reached,
  * rather than always working through a fixed-length question set.
  */
-export function useAdaptiveQuiz<T extends AdaptiveQuestion>({
+export const useAdaptiveQuiz = <T extends AdaptiveQuestion>({
   pool,
   config,
-}: UseAdaptiveQuizOptions<T>): UseAdaptiveQuizResult<T> {
+}: UseAdaptiveQuizOptions<T>): UseAdaptiveQuizResult<T> => {
   const resolvedConfig: AdaptiveConfig = useMemo(
     () => ({ ...DEFAULT_ADAPTIVE_CONFIG, ...config }),
     [config]
@@ -86,4 +86,4 @@ export function useAdaptiveQuiz<T extends AdaptiveQuestion>({
     reset,
     history: state.history,
   };
-}
+};

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -219,6 +219,7 @@ const BinaryTreeQuiz: React.FC = () => {
     }
   };
 
+  /** Forward smart-quiz results to the attempt logger. */
   const handleSmartQuizComplete = (summary: AdaptiveQuizSummary) => {
     submitAttempt(userId, summary.correctCount, summary.questionsAsked, timeSpent);
   };

--- a/src/pages/quizzes/binary-tree.tsx
+++ b/src/pages/quizzes/binary-tree.tsx
@@ -12,12 +12,14 @@ import {
   FaCheckCircle, 
   FaTimesCircle, 
   FaChevronRight, 
-  FaHistory 
+  FaHistory,
+  FaBrain
 } from "react-icons/fa";
 
 import QuestionProgress from "../../components/Quiz/QuestionProgress";
 import QuestionNavigator from "../../components/Quiz/QuestionNavigator";
 import QuizResultActions from "../../components/Quiz/QuizResultActions";
+import AdaptiveQuizRunner, { AdaptiveQuizSummary } from "../../components/Quiz/AdaptiveQuizRunner";
 
 interface BTQuestion {
   id: number;
@@ -141,6 +143,7 @@ const BinaryTreeQuiz: React.FC = () => {
   const [timeSpent, setTimeSpent] = useState(0);
   const { attempts, isLoading, fetchAttempts, submitAttempt, setAttempts } = useQuizData({ quizId: "binary-tree" });
   const [isMounted, setIsMounted] = useState(false);
+  const [quizMode, setQuizMode] = useState<"standard" | "smart">("standard");
 
   
   useEffect(() => {
@@ -216,6 +219,10 @@ const BinaryTreeQuiz: React.FC = () => {
     }
   };
 
+  const handleSmartQuizComplete = (summary: AdaptiveQuizSummary) => {
+    submitAttempt(userId, summary.correctCount, summary.questionsAsked, timeSpent);
+  };
+
   const handleRetry = () => {
     setCurrentQuestion(0);
     setShowResult(false);
@@ -288,17 +295,46 @@ const BinaryTreeQuiz: React.FC = () => {
                 MONITORING POOL NODE: <strong className="text-slate-900 dark:text-white uppercase font-sans tracking-wide">{username}</strong>
               </span>
             </div>
-            <button 
-              onClick={handleLogout} 
-              className="flex items-center gap-2 px-3 py-1.5 rounded-xl border border-solid border-rose-200 dark:border-rose-950/40 bg-rose-500/5 hover:bg-rose-500/10 text-rose-800 dark:text-rose-400 text-xs font-bold transition-all cursor-pointer"
-            >
-              <FaSignOutAlt /> Flush Session Data
-            </button>
+            <div className="flex items-center gap-3">
+              <div className="flex items-center rounded-xl border border-solid border-slate-200 dark:border-slate-800 p-0.5 bg-slate-50 dark:bg-slate-950">
+                <button
+                  onClick={() => setQuizMode("standard")}
+                  disabled={showResult}
+                  className={`px-3 py-1.5 rounded-lg text-[11px] font-bold uppercase tracking-wide transition-all border-none cursor-pointer ${
+                    quizMode === "standard"
+                      ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                      : "bg-transparent text-slate-500 dark:text-slate-400"
+                  }`}
+                >
+                  Standard
+                </button>
+                <button
+                  onClick={() => setQuizMode("smart")}
+                  disabled={showResult}
+                  className={`px-3 py-1.5 rounded-lg text-[11px] font-bold uppercase tracking-wide transition-all border-none cursor-pointer inline-flex items-center gap-1.5 ${
+                    quizMode === "smart"
+                      ? "bg-slate-900 text-white dark:bg-white dark:text-slate-900"
+                      : "bg-transparent text-slate-500 dark:text-slate-400"
+                  }`}
+                >
+                  <FaBrain size={11} /> Smart Quiz
+                </button>
+              </div>
+              <button 
+                onClick={handleLogout} 
+                className="flex items-center gap-2 px-3 py-1.5 rounded-xl border border-solid border-rose-200 dark:border-rose-950/40 bg-rose-500/5 hover:bg-rose-500/10 text-rose-800 dark:text-rose-400 text-xs font-bold transition-all cursor-pointer"
+              >
+                <FaSignOutAlt /> Flush Session Data
+              </button>
+            </div>
           </div>
 
           {/* Interactive Shell Frame */}
           <div className="bg-white dark:bg-slate-900 border border-solid border-slate-200 dark:border-slate-800/80 rounded-2xl p-6 md:p-8 shadow-xs">
             
+            {quizMode === "smart" ? (
+              <AdaptiveQuizRunner pool={QUESTIONS} onComplete={handleSmartQuizComplete} />
+            ) : (
             <AnimatePresence mode="wait">
               {!showResult ? (
                 <motion.div
@@ -463,6 +499,7 @@ const BinaryTreeQuiz: React.FC = () => {
                 </motion.div>
               )}
             </AnimatePresence>
+            )}
 
             {/* Run-History Logs Table Component */}
             {attempts.length > 0 && (

--- a/src/utils/adaptiveQuiz.ts
+++ b/src/utils/adaptiveQuiz.ts
@@ -1,0 +1,155 @@
+export type Difficulty = "Easy" | "Medium" | "Hard";
+
+export interface AdaptiveQuestion {
+  id: string | number;
+  difficulty: Difficulty;
+}
+
+export interface AdaptiveAnswerRecord {
+  id: string | number;
+  difficulty: Difficulty;
+  correct: boolean;
+  /** Ability estimate immediately after this answer — lets shouldStop look at recent trend stability. */
+  abilityAfter: number;
+}
+
+export interface AdaptiveState {
+  /** Estimated ability on a 1 (Easy) .. 3 (Hard) scale. Starts neutral at 2 (Medium). */
+  abilityEstimate: number;
+  /** Shrinks toward 0 as answers accumulate; how "unsure" we still are about the estimate. */
+  uncertainty: number;
+  history: AdaptiveAnswerRecord[];
+}
+
+export interface AdaptiveConfig {
+  /** Never end the session before this many questions, however confident. Default 6. */
+  minQuestions: number;
+  /** Hard ceiling — always end by this many questions even if confidence is never reached. */
+  maxQuestions: number;
+  /** Once uncertainty drops to/below this, mastery confidence is considered statistically reached. */
+  confidenceThreshold: number;
+  /** How many of the most recent answers must show a stable estimate before stopping early. */
+  stabilityWindow: number;
+  /** Max allowed ability swing across the stability window to count as "stable". */
+  stabilityTolerance: number;
+}
+
+export const DEFAULT_ADAPTIVE_CONFIG: AdaptiveConfig = {
+  minQuestions: 6,
+  maxQuestions: 12,
+  confidenceThreshold: 0.22,
+  stabilityWindow: 4,
+  stabilityTolerance: 0.35,
+};
+
+const DIFFICULTY_VALUE: Record<Difficulty, number> = { Easy: 1, Medium: 2, Hard: 3 };
+const MIN_ABILITY = 1;
+const MAX_ABILITY = 3;
+const MIN_UNCERTAINTY = 0.08;
+const UNCERTAINTY_DECAY = 0.85;
+/** How far a single answer can move the ability estimate at maximum uncertainty (session start). */
+const BASE_STEP = 0.9;
+
+export function createInitialAdaptiveState(): AdaptiveState {
+  return { abilityEstimate: 2, uncertainty: 1, history: [] };
+}
+
+/** Pure update: given the previous state and one new answer, returns the next state. */
+export function recordAnswer(
+  state: AdaptiveState,
+  question: AdaptiveQuestion,
+  correct: boolean
+): AdaptiveState {
+  const direction = correct ? 1 : -1;
+  // Bigger corrections early (high uncertainty), smaller/finer corrections later —
+  // this is what makes the estimate converge instead of oscillating forever.
+  const step = direction * state.uncertainty * BASE_STEP;
+  const nextAbility = clamp(state.abilityEstimate + step, MIN_ABILITY, MAX_ABILITY);
+  const nextUncertainty = Math.max(MIN_UNCERTAINTY, state.uncertainty * UNCERTAINTY_DECAY);
+
+  return {
+    abilityEstimate: nextAbility,
+    uncertainty: nextUncertainty,
+    history: [
+      ...state.history,
+      { id: question.id, difficulty: question.difficulty, correct, abilityAfter: nextAbility },
+    ],
+  };
+}
+
+/**
+ * Picks the next question whose difficulty best matches the current ability
+ * estimate, from whatever hasn't been asked yet. Ties (equally-close
+ * difficulty) are broken deterministically-but-unpredictably via a simple
+ * seeded shuffle of the tied candidates, so two users with an identical
+ * answer pattern don't always see the exact same question order.
+ */
+export function selectNextQuestion<T extends AdaptiveQuestion>(
+  state: AdaptiveState,
+  pool: T[]
+): T | null {
+  const answeredIds = new Set(state.history.map((h) => h.id));
+  const remaining = pool.filter((q) => !answeredIds.has(q.id));
+  if (remaining.length === 0) return null;
+
+  let bestDistance = Infinity;
+  for (const q of remaining) {
+    const distance = Math.abs(DIFFICULTY_VALUE[q.difficulty] - state.abilityEstimate);
+    if (distance < bestDistance) bestDistance = distance;
+  }
+  const tied = remaining.filter(
+    (q) => Math.abs(DIFFICULTY_VALUE[q.difficulty] - state.abilityEstimate) === bestDistance
+  );
+
+  // Deterministic-but-varied tie-break: rotate by how many questions have
+  // been answered so far, so repeated ties don't always resolve the same way.
+  const pick = tied[state.history.length % tied.length];
+  return pick;
+}
+
+/**
+ * Whether the session can end now. Ends when either:
+ *  - the hard question-count ceiling is hit, or
+ *  - the minimum question count has been met, uncertainty has decayed to/
+ *    below the threshold, AND the ability estimate has actually been
+ *    *stable* over the last few answers (not just "many rounds have
+ *    passed") — this second condition is what makes the early stop
+ *    statistically meaningful rather than a fixed-schedule guess: a
+ *    learner whose recent answers keep swinging the estimate around
+ *    (e.g. acing every difficulty except one) is deliberately kept in
+ *    the session longer so that weak spot gets sampled properly.
+ */
+export function shouldStop(
+  state: AdaptiveState,
+  poolSize: number,
+  config: AdaptiveConfig = DEFAULT_ADAPTIVE_CONFIG
+): boolean {
+  const answered = state.history.length;
+  if (answered >= Math.min(config.maxQuestions, poolSize)) return true;
+  if (answered < config.minQuestions) return false;
+  if (state.uncertainty > config.confidenceThreshold) return false;
+
+  const window = state.history.slice(-config.stabilityWindow);
+  if (window.length < Math.min(config.stabilityWindow, config.minQuestions)) return false;
+  const abilities = window.map((h) => h.abilityAfter);
+  const swing = Math.max(...abilities) - Math.min(...abilities);
+  return swing <= config.stabilityTolerance;
+}
+
+export type MasteryLevel = "Developing" | "Proficient" | "Advanced";
+
+export function getMasteryLevel(state: AdaptiveState): MasteryLevel {
+  if (state.abilityEstimate < 1.67) return "Developing";
+  if (state.abilityEstimate < 2.5) return "Proficient";
+  return "Advanced";
+}
+
+/** 0-100 display value: how statistically confident we are in the mastery estimate. */
+export function getConfidencePercent(state: AdaptiveState): number {
+  const raw = 1 - (state.uncertainty - MIN_UNCERTAINTY) / (1 - MIN_UNCERTAINTY);
+  return Math.round(clamp(raw, 0, 1) * 100);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/src/utils/adaptiveQuiz.ts
+++ b/src/utils/adaptiveQuiz.ts
@@ -42,6 +42,11 @@ export const DEFAULT_ADAPTIVE_CONFIG: AdaptiveConfig = {
   stabilityTolerance: 0.35,
 };
 
+/** Clamp a number between min and max (inclusive). */
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.min(max, Math.max(min, value));
+};
+
 const DIFFICULTY_VALUE: Record<Difficulty, number> = { Easy: 1, Medium: 2, Hard: 3 };
 const MIN_ABILITY = 1;
 const MAX_ABILITY = 3;
@@ -150,9 +155,4 @@ export const getMasteryLevel = (state: AdaptiveState): MasteryLevel => {
 export const getConfidencePercent = (state: AdaptiveState): number => {
   const raw = 1 - (state.uncertainty - MIN_UNCERTAINTY) / (1 - MIN_UNCERTAINTY);
   return Math.round(clamp(raw, 0, 1) * 100);
-};
-
-/** Clamp a number between min and max (inclusive). */
-const clamp = (value: number, min: number, max: number): number => {
-  return Math.min(max, Math.max(min, value));
 };

--- a/src/utils/adaptiveQuiz.ts
+++ b/src/utils/adaptiveQuiz.ts
@@ -50,16 +50,17 @@ const UNCERTAINTY_DECAY = 0.85;
 /** How far a single answer can move the ability estimate at maximum uncertainty (session start). */
 const BASE_STEP = 0.9;
 
-export function createInitialAdaptiveState(): AdaptiveState {
+/** Create a fresh adaptive state at the session start. */
+export const createInitialAdaptiveState = (): AdaptiveState => {
   return { abilityEstimate: 2, uncertainty: 1, history: [] };
-}
+};
 
 /** Pure update: given the previous state and one new answer, returns the next state. */
-export function recordAnswer(
+export const recordAnswer = (
   state: AdaptiveState,
   question: AdaptiveQuestion,
-  correct: boolean
-): AdaptiveState {
+  correct: boolean,
+): AdaptiveState => {
   const direction = correct ? 1 : -1;
   // Bigger corrections early (high uncertainty), smaller/finer corrections later —
   // this is what makes the estimate converge instead of oscillating forever.
@@ -75,7 +76,7 @@ export function recordAnswer(
       { id: question.id, difficulty: question.difficulty, correct, abilityAfter: nextAbility },
     ],
   };
-}
+};
 
 /**
  * Picks the next question whose difficulty best matches the current ability
@@ -84,10 +85,10 @@ export function recordAnswer(
  * seeded shuffle of the tied candidates, so two users with an identical
  * answer pattern don't always see the exact same question order.
  */
-export function selectNextQuestion<T extends AdaptiveQuestion>(
+export const selectNextQuestion = <T extends AdaptiveQuestion>(
   state: AdaptiveState,
-  pool: T[]
-): T | null {
+  pool: T[],
+): T | null => {
   const answeredIds = new Set(state.history.map((h) => h.id));
   const remaining = pool.filter((q) => !answeredIds.has(q.id));
   if (remaining.length === 0) return null;
@@ -105,7 +106,7 @@ export function selectNextQuestion<T extends AdaptiveQuestion>(
   // been answered so far, so repeated ties don't always resolve the same way.
   const pick = tied[state.history.length % tied.length];
   return pick;
-}
+};
 
 /**
  * Whether the session can end now. Ends when either:
@@ -119,11 +120,11 @@ export function selectNextQuestion<T extends AdaptiveQuestion>(
  *    (e.g. acing every difficulty except one) is deliberately kept in
  *    the session longer so that weak spot gets sampled properly.
  */
-export function shouldStop(
+export const shouldStop = (
   state: AdaptiveState,
   poolSize: number,
-  config: AdaptiveConfig = DEFAULT_ADAPTIVE_CONFIG
-): boolean {
+  config: AdaptiveConfig = DEFAULT_ADAPTIVE_CONFIG,
+): boolean => {
   const answered = state.history.length;
   if (answered >= Math.min(config.maxQuestions, poolSize)) return true;
   if (answered < config.minQuestions) return false;
@@ -134,22 +135,24 @@ export function shouldStop(
   const abilities = window.map((h) => h.abilityAfter);
   const swing = Math.max(...abilities) - Math.min(...abilities);
   return swing <= config.stabilityTolerance;
-}
+};
 
 export type MasteryLevel = "Developing" | "Proficient" | "Advanced";
 
-export function getMasteryLevel(state: AdaptiveState): MasteryLevel {
+/** Map the continuous ability estimate to a discrete mastery bucket. */
+export const getMasteryLevel = (state: AdaptiveState): MasteryLevel => {
   if (state.abilityEstimate < 1.67) return "Developing";
   if (state.abilityEstimate < 2.5) return "Proficient";
   return "Advanced";
-}
+};
 
 /** 0-100 display value: how statistically confident we are in the mastery estimate. */
-export function getConfidencePercent(state: AdaptiveState): number {
+export const getConfidencePercent = (state: AdaptiveState): number => {
   const raw = 1 - (state.uncertainty - MIN_UNCERTAINTY) / (1 - MIN_UNCERTAINTY);
   return Math.round(clamp(raw, 0, 1) * 100);
-}
+};
 
-function clamp(value: number, min: number, max: number): number {
+/** Clamp a number between min and max (inclusive). */
+const clamp = (value: number, min: number, max: number): number => {
   return Math.min(max, Math.max(min, value));
-}
+};


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR introduces an Adaptive Difficulty Quiz Mode that dynamically adjusts question difficulty and quiz length based on the learner's recent performance.

Unlike the existing fixed-length quiz flow, Smart Quiz continuously evaluates answers and selects the next appropriate difficulty level. The session can finish early when there is enough evidence to estimate the learner's mastery, or continue with additional questions when confidence is still low.

This feature is separate from spaced repetition: spaced repetition schedules previously seen questions across future sessions, while adaptive mode changes the difficulty and length of the current quiz session.

Fixes #3906 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
