### PR TITLE
test(adaptiveQuiz): fix undefined variable 'q'

### DIFF
--- a/src/__tests__/utils/adaptiveQuiz.test.ts
+++ b/src/__tests__/utils/adaptiveQuiz.test.ts
@@ -32,7 +32,7 @@ const runSession = (
     if (!question) break;
     askedDifficulties.push(question.difficulty);
     const correct = answerFn(question, state);
-    state = recordAnswer(state, q, correct);
+    state = recordAnswer(state, question, correct);
   }
   return { state, askedDifficulties };
 };


### PR DESCRIPTION

### Description
This PR resolves a TypeScript error (`TS2304`) in `src/__tests__/utils/adaptiveQuiz.test.ts` that occurred due to a typo in the variable name (`q` instead of `question`) when calling `recordAnswer`.

### Related Issues
Fixes #3940

### Changes
- Updated `q` to `question` on line 35 of `adaptiveQuiz.test.ts`.

### Verification
- `npm run test -- src/__tests__/utils/adaptiveQuiz.test.ts` passes successfully.
- TypeScript compiler (`tsc --noEmit`) validates without errors in the affected file.