### PR TITLE
test(TreeSandbox): fix failing tests by asserting on custom alert UI 

### DIFF
--- a/src/__tests__/components/TreeSandbox.test.tsx
+++ b/src/__tests__/components/TreeSandbox.test.tsx
@@ -52,11 +52,11 @@ describe('TreeSandbox Component & Translation Interpolation', () => {
     fireEvent.change(input, { target: { value: '10' } });
     fireEvent.click(insertBtn);
 
-    expect(alertSpy).toHaveBeenCalledWith('Key 10 already exists in the tree!');
-    expect(alertSpy.mock.calls[alertSpy.mock.calls.length - 1][0]).not.toContain('{key}');
+    const duplicateAlert = await screen.findByText('Key 10 already exists in the tree!');
+    expect(duplicateAlert).toBeInTheDocument();
   });
 
-  test('handles node deletion alerts with interpolated values', () => {
+  test('handles node deletion alerts with interpolated values', async () => {
     render(<TreeSandbox />);
 
     const input = screen.getByRole('spinbutton');
@@ -66,7 +66,7 @@ describe('TreeSandbox Component & Translation Interpolation', () => {
     fireEvent.change(input, { target: { value: '99' } });
     fireEvent.click(deleteBtn);
 
-    expect(alertSpy).toHaveBeenCalledWith('Key 99 does not exist in the tree!');
-    expect(alertSpy.mock.calls[alertSpy.mock.calls.length - 1][0]).not.toContain('{key}');
+    const deleteAlert = await screen.findByText('Key 99 does not exist in the tree!');
+    expect(deleteAlert).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Description
This PR resolves the failing unit tests for the `TreeSandbox` component. Previously, the tests were asserting against a `window.alert` spy. However, the component was refactored to use a custom in-app alert UI via the `showAlert` function and `alertMessage` state, which caused the spy assertions to fail. 

The tests have been updated to correctly await and query the DOM for the custom alert messages instead.

### Related Issues
Fixes #3941

### Changes
- Updated duplicate key insertion test in `TreeSandbox.test.tsx` to assert using `screen.findByText`.
- Updated missing key deletion test in `TreeSandbox.test.tsx` to assert using `screen.findByText`.

### Verification
- `npm run test -- src/__tests__/components/TreeSandbox.test.tsx` passes successfully.