### PR TITLE
fix: convert useTOCHighlightObserver to const arrow function to resolve JS-0067

### DIFF
--- a/src/hooks/useTOCHighlightObserver.ts
+++ b/src/hooks/useTOCHighlightObserver.ts
@@ -11,7 +11,7 @@ export interface TOCHighlightObserverConfig {
  * Custom hook to dynamically highlight current section in Table of Contents while scrolling.
  * Uses IntersectionObserver API to track visible document headings in real-time.
  */
-export function useTOCHighlightObserver(config: TOCHighlightObserverConfig | undefined): void {
+const useTOCHighlightObserver = (config: TOCHighlightObserverConfig | undefined): void => {
   useEffect(() => {
     if (typeof window === 'undefined' || typeof document === 'undefined') {
       return;
@@ -153,4 +153,6 @@ export function useTOCHighlightObserver(config: TOCHighlightObserverConfig | und
       window.removeEventListener('resize', handleScroll);
     };
   }, [config]);
-}
+};
+
+export { useTOCHighlightObserver };


### PR DESCRIPTION
fix #3947 

**Problem**
useTOCHighlightObserver was declared with export function - DeepSource flags
this as JS-0067 (unexpected function declaration in global scope).

**Fix**
Converted to a const arrow function with the existing JSDoc retained above it
and a separate named export at the bottom of the file.

**Testing**
tsc --noEmit confirms no errors in useTOCHighlightObserver.ts.
