### PR TITLE
fix: wrap onComplete in useRef and remove eslint-disable to fix stale closure and exhaustive-deps 

### DIFF
--- a/src/components/Quiz/AdaptiveQuizRunner.tsx
+++ b/src/components/Quiz/AdaptiveQuizRunner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { FaBrain, FaChevronRight, FaRedo } from "react-icons/fa";
 import { useAdaptiveQuiz } from "../../hooks/useAdaptiveQuiz";
 import { AdaptiveQuestion, MasteryLevel } from "../../utils/adaptiveQuiz";
@@ -51,20 +51,24 @@ const AdaptiveQuizRunner = ({ pool, onComplete }: Props) => {
   const [selected, setSelected] = useState<string | null>(null);
   const [reported, setReported] = useState(false);
 
+  // Keep a ref to the latest onComplete callback so the completion effect
+  // always calls the current version without needing it as a reactive dep.
+  const onCompleteRef = useRef(onComplete);
+  useEffect(() => { onCompleteRef.current = onComplete; }, [onComplete]);
+
   const correctCount = history.filter((h) => h.correct).length;
 
   useEffect(() => {
-    if (!isComplete || reported || !onComplete) return;
+    if (!isComplete || reported || !onCompleteRef.current) return;
     setReported(true);
-    onComplete({
+    onCompleteRef.current({
       masteryLevel,
       confidencePercent,
       questionsAsked: questionsAnswered,
       correctCount,
       abilityEstimate: history.length ? history[history.length - 1].abilityAfter : 2,
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isComplete, reported]);
+  }, [isComplete, reported, masteryLevel, confidencePercent, questionsAnswered, correctCount, history]);
 
   /** Submit the currently selected answer and advance. */
   const handleSubmit = () => {


### PR DESCRIPTION
fix #3949

### Pull Request Description

 removes the `eslint-disable-next-line react-hooks/exhaustive-deps` suppression on the `useEffect` in `AdaptiveQuizRunner.tsx` by wrapping `onComplete` in a `useRef`, ensuring the latest `onComplete` is always called without needing it as a reactive dependency.

### Type of Change

- 🐛 Bug fix

### Problem

The `useEffect` that calls `onComplete` had a `react-hooks/exhaustive-deps` suppression hiding missing dependencies: `masteryLevel`, `confidencePercent`, `questionsAnswered`, `correctCount`, `history`, and `onComplete`. The `reported` guard prevented double-firing, but suppressing the rule meant that if `onComplete` changed between renders (e.g. an inline arrow function passed from the parent), the effect would call a stale version of it. DeepSource also flagged the `eslint-disable` comment itself as a code smell.

### Fix

- Added a `onCompleteRef` using `useRef`, kept in sync with the latest `onComplete` via a separate `useEffect`.
- The completion `useEffect` now calls `onCompleteRef.current(...)` instead of `onComplete(...)` directly.
- Removed the `eslint-disable-next-line react-hooks/exhaustive-deps` comment - the effect's dependency array can now correctly include `masteryLevel`, `confidencePercent`, `questionsAnswered`, `correctCount`, and `history` without needing `onComplete` (since the ref sidesteps the staleness concern).
- The `reported` guard remains in place to prevent double-firing.

