### PR TITLE
bug: HTML Entity Truncation & Search Parameter Corruption in sanitizeQuery Utility (#3923)

### DIFF
--- a/src/utils/sanitizeQuery.ts
+++ b/src/utils/sanitizeQuery.ts
@@ -10,7 +10,7 @@ export function sanitizeQuery(query: string): string {
     return '';
   }
 
-  // 1. Input length validation - cap input to 100 characters
+  // 1. Input length validation - cap raw input to 100 characters
   const trimmedQuery = query.slice(0, 100);
 
   // 2. HTML entity encoding to prevent XSS script injection
@@ -26,8 +26,8 @@ export function sanitizeQuery(query: string): string {
     return htmlEntities[char] || char;
   });
 
-  // 3. Ensure final sanitized output does not exceed 100 characters
-  return sanitized.slice(0, 100);
+  return sanitized;
 }
 
 export default sanitizeQuery;
+


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR resolves an issue in `sanitizeQuery.ts` where character-level length truncation was performed AFTER HTML entity substitution.

Previously, `sanitizeQuery` ran `sanitized.slice(0, 100)` at the end of the function. When a 98-character string containing special characters (e.g., quotes `"` or `<`) was sanitized, single characters expanded into multi-character entities (`&quot;`, `&lt;`). Truncating the string afterwards cut off entity boundaries (leaving malformed output like `&qu`), corrupting search filter URLs and causing UI rendering issues.

**Solution:**
- Perform input length validation (`query.slice(0, 100)`) on the raw input string before entity substitution.
- Remove post-substitution character slicing so HTML entity tokens are preserved intact.

Fixes #3923

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
