### PR TITLE
bug: Bookmark Toggle Fails to Notify Open Views Causing Same-Tab Desynchronization in Favorites Page (#3924)

### DIFF
--- a/src/components/BookmarkButton/index.tsx
+++ b/src/components/BookmarkButton/index.tsx
@@ -36,8 +36,18 @@ export default function BookmarkButton({ title, path }: Props): JSX.Element {
 
   useEffect(() => {
     if (!path || typeof window === 'undefined') return;
-    const items = getItemsFromStorage();
-    setBookmarked(items.some((item) => item.path === path));
+    const checkState = () => {
+      const items = getItemsFromStorage();
+      setBookmarked(items.some((item) => item.path === path));
+    };
+    checkState();
+
+    window.addEventListener('bookmarksUpdated', checkState);
+    window.addEventListener('storage', checkState);
+    return () => {
+      window.removeEventListener('bookmarksUpdated', checkState);
+      window.removeEventListener('storage', checkState);
+    };
   }, [path]);
 
   const toggleBookmark = (e?: React.MouseEvent) => {
@@ -59,6 +69,7 @@ export default function BookmarkButton({ title, path }: Props): JSX.Element {
 
       localStorage.setItem(PRIMARY_STORAGE_KEY, JSON.stringify(items));
       localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(items));
+      window.dispatchEvent(new CustomEvent('bookmarksUpdated'));
       setBookmarked(!exists);
     } catch {
       setBookmarked((v) => !v);

--- a/src/pages/favorites.tsx
+++ b/src/pages/favorites.tsx
@@ -68,14 +68,19 @@ function FavoritesContent() {
   useEffect(() => {
     loadFavorites();
 
+    const handleUpdate = () => loadFavorites();
     const handleStorageChange = (e: StorageEvent) => {
-      if (e.key === STORAGE_KEY || e.key === LEGACY_STORAGE_KEY) {
+      if (e.key === STORAGE_KEY || e.key === LEGACY_STORAGE_KEY || !e.key) {
         loadFavorites();
       }
     };
 
     window.addEventListener("storage", handleStorageChange);
-    return () => window.removeEventListener("storage", handleStorageChange);
+    window.addEventListener("bookmarksUpdated", handleUpdate);
+    return () => {
+      window.removeEventListener("storage", handleStorageChange);
+      window.removeEventListener("bookmarksUpdated", handleUpdate);
+    };
   }, []);
 
   const handleRemove = (path: string) => {
@@ -85,6 +90,7 @@ function FavoritesContent() {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
       localStorage.setItem(LEGACY_STORAGE_KEY, JSON.stringify(updated));
       window.dispatchEvent(new Event("storage"));
+      window.dispatchEvent(new CustomEvent("bookmarksUpdated"));
     } catch (err) {
       console.warn("[Favorites] Failed to save updated favorites:", err);
     }
@@ -97,6 +103,7 @@ function FavoritesContent() {
       localStorage.setItem(STORAGE_KEY, "[]");
       localStorage.setItem(LEGACY_STORAGE_KEY, "[]");
       window.dispatchEvent(new Event("storage"));
+      window.dispatchEvent(new CustomEvent("bookmarksUpdated"));
     } catch (err) {
       console.warn("[Favorites] Failed to clear favorites:", err);
     }


### PR DESCRIPTION
## 📥 Pull Request

### Description

This PR fixes a same-tab state desynchronization issue between `BookmarkButton` components and the `/favorites` page (`src/pages/favorites.tsx`).

Previously, toggling `BookmarkButton` wrote updated bookmarks to `localStorage`, but did not dispatch a custom event. Because native browser `storage` events are only sent to other browser tabs, toggling a bookmark on a documentation page was not reflected on the Favorites page in the same tab until a manual page refresh.

**Solution:**
- Added custom `'bookmarksUpdated'` event dispatching in `BookmarkButton/index.tsx` when bookmarks are toggled.
- Added event listeners for `'bookmarksUpdated'` in `favorites.tsx` and `BookmarkButton/index.tsx` so state updates reactively across all open components in the current tab without needing a page reload.

Fixes #3924

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
