### PR TITLE
fix(theme): eliminate accent and code theme SSR hydration mismatch and FOUT (fixes #3935)

### DIFF
--- a/src/__tests__/components/CodeThemePicker.test.tsx
+++ b/src/__tests__/components/CodeThemePicker.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '../testUtils';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent, waitFor } from '../testUtils';
 import CodeThemePicker from '../../components/CodeThemePicker';
 import { CODE_THEME_STORAGE_KEY } from '../../utils/codeTheme';
 
@@ -11,10 +10,9 @@ describe('CodeThemePicker', () => {
   });
 
   test('opens the menu with all code theme options', async () => {
-    const user = userEvent.setup();
     render(<CodeThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+    fireEvent.click(screen.getByRole('button', { name: /code theme/i }));
 
     expect(screen.getByRole('menuitemradio', { name: /default/i })).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', { name: /midnight/i })).toBeInTheDocument();
@@ -22,11 +20,10 @@ describe('CodeThemePicker', () => {
   });
 
   test('selecting "Midnight" applies the attribute and persists to localStorage', async () => {
-    const user = userEvent.setup();
     render(<CodeThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
-    await user.click(screen.getByRole('menuitemradio', { name: /midnight/i }));
+    fireEvent.click(screen.getByRole('button', { name: /code theme/i }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /midnight/i }));
 
     expect(document.documentElement.getAttribute('data-code-theme')).toBe('midnight');
     expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBe('midnight');
@@ -37,11 +34,10 @@ describe('CodeThemePicker', () => {
     localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
     document.documentElement.setAttribute('data-code-theme', 'solarized');
 
-    const user = userEvent.setup();
     render(<CodeThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
-    await user.click(screen.getByRole('menuitemradio', { name: /^default/i }));
+    fireEvent.click(screen.getByRole('button', { name: /code theme/i }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /^default/i }));
 
     expect(document.documentElement.getAttribute('data-code-theme')).toBeNull();
     expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBeNull();
@@ -49,10 +45,11 @@ describe('CodeThemePicker', () => {
 
   test('reflects the persisted theme as checked on mount', async () => {
     localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
-    const user = userEvent.setup();
+    document.documentElement.setAttribute('data-code-theme', 'solarized');
+
     render(<CodeThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+    fireEvent.click(screen.getByRole('button', { name: /code theme/i }));
 
     await waitFor(() =>
       expect(screen.getByRole('menuitemradio', { name: /solarized/i })).toHaveAttribute('aria-checked', 'true'),
@@ -60,7 +57,6 @@ describe('CodeThemePicker', () => {
   });
 
   test('closes the menu on outside click', async () => {
-    const user = userEvent.setup();
     render(
       <div>
         <CodeThemePicker />
@@ -68,11 +64,12 @@ describe('CodeThemePicker', () => {
       </div>,
     );
 
-    await user.click(screen.getByRole('button', { name: /choose a code theme/i }));
+    fireEvent.click(screen.getByRole('button', { name: /code theme/i }));
     expect(screen.getByRole('menuitemradio', { name: /midnight/i })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Outside' }));
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }));
 
     expect(screen.queryByRole('menuitemradio', { name: /midnight/i })).not.toBeInTheDocument();
   });
 });
+

--- a/src/__tests__/components/ThemePicker.test.tsx
+++ b/src/__tests__/components/ThemePicker.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '../testUtils';
-import userEvent from '@testing-library/user-event';
+import { render, screen, fireEvent, waitFor } from '../testUtils';
 import ThemePicker from '../../components/ThemePicker';
 import { ACCENT_THEME_STORAGE_KEY } from '../../utils/accentTheme';
 
@@ -11,10 +10,9 @@ describe('ThemePicker', () => {
   });
 
   test('opens the menu with all three theme options', async () => {
-    const user = userEvent.setup();
     render(<ThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a color theme/i }));
+    fireEvent.click(screen.getByRole('button', { name: /accent theme/i }));
 
     expect(screen.getByRole('menuitemradio', { name: /default/i })).toBeInTheDocument();
     expect(screen.getByRole('menuitemradio', { name: /high contrast/i })).toBeInTheDocument();
@@ -22,11 +20,10 @@ describe('ThemePicker', () => {
   });
 
   test('selecting "Neon" applies the attribute and persists to localStorage', async () => {
-    const user = userEvent.setup();
     render(<ThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a color theme/i }));
-    await user.click(screen.getByRole('menuitemradio', { name: /neon/i }));
+    fireEvent.click(screen.getByRole('button', { name: /accent theme/i }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /neon/i }));
 
     expect(document.documentElement.getAttribute('data-accent-theme')).toBe('neon');
     expect(localStorage.getItem(ACCENT_THEME_STORAGE_KEY)).toBe('neon');
@@ -38,11 +35,10 @@ describe('ThemePicker', () => {
     localStorage.setItem(ACCENT_THEME_STORAGE_KEY, 'high-contrast');
     document.documentElement.setAttribute('data-accent-theme', 'high-contrast');
 
-    const user = userEvent.setup();
     render(<ThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a color theme/i }));
-    await user.click(screen.getByRole('menuitemradio', { name: /^default/i }));
+    fireEvent.click(screen.getByRole('button', { name: /accent theme/i }));
+    fireEvent.click(screen.getByRole('menuitemradio', { name: /^default/i }));
 
     expect(document.documentElement.getAttribute('data-accent-theme')).toBeNull();
     expect(localStorage.getItem(ACCENT_THEME_STORAGE_KEY)).toBeNull();
@@ -50,10 +46,11 @@ describe('ThemePicker', () => {
 
   test('reflects the persisted theme as checked on mount', async () => {
     localStorage.setItem(ACCENT_THEME_STORAGE_KEY, 'high-contrast');
-    const user = userEvent.setup();
+    document.documentElement.setAttribute('data-accent-theme', 'high-contrast');
+
     render(<ThemePicker />);
 
-    await user.click(screen.getByRole('button', { name: /choose a color theme/i }));
+    fireEvent.click(screen.getByRole('button', { name: /accent theme/i }));
 
     await waitFor(() =>
       expect(screen.getByRole('menuitemradio', { name: /high contrast/i })).toHaveAttribute('aria-checked', 'true'),
@@ -61,7 +58,6 @@ describe('ThemePicker', () => {
   });
 
   test('closes the menu on outside click', async () => {
-    const user = userEvent.setup();
     render(
       <div>
         <ThemePicker />
@@ -69,11 +65,12 @@ describe('ThemePicker', () => {
       </div>,
     );
 
-    await user.click(screen.getByRole('button', { name: /choose a color theme/i }));
+    fireEvent.click(screen.getByRole('button', { name: /accent theme/i }));
     expect(screen.getByRole('menuitemradio', { name: /neon/i })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Outside' }));
+    fireEvent.mouseDown(screen.getByRole('button', { name: 'Outside' }));
 
     expect(screen.queryByRole('menuitemradio', { name: /neon/i })).not.toBeInTheDocument();
   });
 });
+

--- a/src/__tests__/contexts/AccentThemeContext.test.tsx
+++ b/src/__tests__/contexts/AccentThemeContext.test.tsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import {
+  AccentThemeProvider,
+  useAccentTheme,
+  useCodeTheme,
+} from '../../contexts/AccentThemeContext';
+import {
+  ACCENT_THEME_STORAGE_KEY,
+  ACCENT_THEME_ATTRIBUTE,
+  ACCENT_THEME_EVENT,
+} from '../../utils/accentTheme';
+import {
+  CODE_THEME_STORAGE_KEY,
+  CODE_THEME_ATTRIBUTE,
+  CODE_THEME_EVENT,
+} from '../../utils/codeTheme';
+
+function TestConsumer() {
+  const { accentTheme, setAccentTheme } = useAccentTheme();
+  const { codeTheme, setCodeTheme } = useCodeTheme();
+
+  return (
+    <div>
+      <span data-testid="accent-display">{accentTheme}</span>
+      <span data-testid="code-display">{codeTheme}</span>
+      <button onClick={() => setAccentTheme('neon')}>Set Accent Neon</button>
+      <button onClick={() => setAccentTheme('high-contrast')}>Set Accent High Contrast</button>
+      <button onClick={() => setAccentTheme('default')}>Set Accent Default</button>
+      <button onClick={() => setCodeTheme('midnight')}>Set Code Midnight</button>
+      <button onClick={() => setCodeTheme('solarized')}>Set Code Solarized</button>
+      <button onClick={() => setCodeTheme('default')}>Set Code Default</button>
+    </div>
+  );
+}
+
+describe('AccentThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.removeAttribute(ACCENT_THEME_ATTRIBUTE);
+    document.documentElement.removeAttribute(CODE_THEME_ATTRIBUTE);
+  });
+
+  test('initializes with "default" when no attribute or storage is present', () => {
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('default');
+    expect(screen.getByTestId('code-display')).toHaveTextContent('default');
+  });
+
+  test('synchronizes initial state with pre-hydrated DOM attribute (SSR inline script simulation)', () => {
+    document.documentElement.setAttribute(ACCENT_THEME_ATTRIBUTE, 'neon');
+    document.documentElement.setAttribute(CODE_THEME_ATTRIBUTE, 'midnight');
+
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('neon');
+    expect(screen.getByTestId('code-display')).toHaveTextContent('midnight');
+  });
+
+  test('updates accent theme, persists to storage, updates DOM attribute, and dispatches event', () => {
+    const listener = jest.fn();
+    window.addEventListener(ACCENT_THEME_EVENT, listener);
+
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Accent Neon' }));
+
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('neon');
+    expect(document.documentElement.getAttribute(ACCENT_THEME_ATTRIBUTE)).toBe('neon');
+    expect(localStorage.getItem(ACCENT_THEME_STORAGE_KEY)).toBe('neon');
+    expect(listener).toHaveBeenCalled();
+
+    window.removeEventListener(ACCENT_THEME_EVENT, listener);
+  });
+
+  test('updates code theme, persists to storage, and updates DOM attribute', () => {
+    const listener = jest.fn();
+    window.addEventListener(CODE_THEME_EVENT, listener);
+
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Code Midnight' }));
+
+    expect(screen.getByTestId('code-display')).toHaveTextContent('midnight');
+    expect(document.documentElement.getAttribute(CODE_THEME_ATTRIBUTE)).toBe('midnight');
+    expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBe('midnight');
+    expect(listener).toHaveBeenCalled();
+
+    window.removeEventListener(CODE_THEME_EVENT, listener);
+  });
+
+  test('resets accent and code theme to default', () => {
+    localStorage.setItem(ACCENT_THEME_STORAGE_KEY, 'neon');
+    localStorage.setItem(CODE_THEME_STORAGE_KEY, 'solarized');
+
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Accent Default' }));
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('default');
+    expect(document.documentElement.getAttribute(ACCENT_THEME_ATTRIBUTE)).toBeNull();
+    expect(localStorage.getItem(ACCENT_THEME_STORAGE_KEY)).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Code Default' }));
+    expect(screen.getByTestId('code-display')).toHaveTextContent('default');
+    expect(document.documentElement.getAttribute(CODE_THEME_ATTRIBUTE)).toBeNull();
+    expect(localStorage.getItem(CODE_THEME_STORAGE_KEY)).toBeNull();
+  });
+
+  test('reacts to intra-app custom event changes', () => {
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ACCENT_THEME_EVENT, { detail: 'high-contrast' })
+      );
+    });
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('high-contrast');
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(CODE_THEME_EVENT, { detail: 'solarized' })
+      );
+    });
+    expect(screen.getByTestId('code-display')).toHaveTextContent('solarized');
+  });
+
+  test('reacts to window storage event', () => {
+    render(
+      <AccentThemeProvider>
+        <TestConsumer />
+      </AccentThemeProvider>
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: ACCENT_THEME_STORAGE_KEY,
+          newValue: 'neon',
+        })
+      );
+    });
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('neon');
+    expect(document.documentElement.getAttribute(ACCENT_THEME_ATTRIBUTE)).toBe('neon');
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: CODE_THEME_STORAGE_KEY,
+          newValue: 'midnight',
+        })
+      );
+    });
+    expect(screen.getByTestId('code-display')).toHaveTextContent('midnight');
+    expect(document.documentElement.getAttribute(CODE_THEME_ATTRIBUTE)).toBe('midnight');
+  });
+
+  test('fallback works safely when used outside AccentThemeProvider', () => {
+    render(<TestConsumer />);
+
+    expect(screen.getByTestId('accent-display')).toHaveTextContent('default');
+    expect(screen.getByTestId('code-display')).toHaveTextContent('default');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Accent Neon' }));
+    expect(document.documentElement.getAttribute(ACCENT_THEME_ATTRIBUTE)).toBe('neon');
+    expect(localStorage.getItem(ACCENT_THEME_STORAGE_KEY)).toBe('neon');
+  });
+});

--- a/src/__tests__/testUtils.tsx
+++ b/src/__tests__/testUtils.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { AuthProvider } from '../contexts/AuthContext';
 import { AriaAnnouncerProvider } from '../contexts/AriaAnnouncerContext';
+import { AccentThemeProvider } from '../contexts/AccentThemeContext';
 import type { GraphChallenge } from '../data/graphChallengesData';
 import type { SortingChallenge } from '../data/sortingChallengesData';
 import type { DPChallenge } from '../data/dpChallengesData';
@@ -9,7 +10,9 @@ import type { DPChallenge } from '../data/dpChallengesData';
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   return (
     <AuthProvider>
-      <AriaAnnouncerProvider>{children}</AriaAnnouncerProvider>
+      <AriaAnnouncerProvider>
+        <AccentThemeProvider>{children}</AccentThemeProvider>
+      </AriaAnnouncerProvider>
     </AuthProvider>
   );
 };

--- a/src/__tests__/utils/accentTheme.test.ts
+++ b/src/__tests__/utils/accentTheme.test.ts
@@ -21,6 +21,11 @@ describe('accentTheme utils', () => {
       expect(getStoredAccentTheme()).toBe('neon');
     });
 
+    test('returns DOM attribute value if already present before storage', () => {
+      document.documentElement.setAttribute('data-accent-theme', 'high-contrast');
+      expect(getStoredAccentTheme()).toBe('high-contrast');
+    });
+
     test('falls back to "default" for an invalid/corrupted value', () => {
       localStorage.setItem(ACCENT_THEME_STORAGE_KEY, 'not-a-real-theme');
       expect(getStoredAccentTheme()).toBe('default');
@@ -41,9 +46,13 @@ describe('accentTheme utils', () => {
   });
 
   describe('applyAccentTheme', () => {
-    test('sets the data-accent-theme attribute for a non-default theme', () => {
+    test('sets the data-accent-theme attribute for a non-default theme and dispatches event', () => {
+      const listener = jest.fn();
+      window.addEventListener('algo-accent-theme-change', listener);
       applyAccentTheme('neon');
       expect(document.documentElement.getAttribute('data-accent-theme')).toBe('neon');
+      expect(listener).toHaveBeenCalled();
+      window.removeEventListener('algo-accent-theme-change', listener);
     });
 
     test('removes the attribute for "default"', () => {

--- a/src/__tests__/utils/codeTheme.test.ts
+++ b/src/__tests__/utils/codeTheme.test.ts
@@ -16,6 +16,11 @@ describe('codeTheme utils', () => {
       expect(getStoredCodeTheme()).toBe('solarized');
     });
 
+    test('returns DOM attribute value if already present before storage', () => {
+      document.documentElement.setAttribute('data-code-theme', 'midnight');
+      expect(getStoredCodeTheme()).toBe('midnight');
+    });
+
     test('falls back to "default" for an invalid/corrupted value', () => {
       localStorage.setItem(CODE_THEME_STORAGE_KEY, 'not-a-real-theme');
       expect(getStoredCodeTheme()).toBe('default');
@@ -36,9 +41,13 @@ describe('codeTheme utils', () => {
   });
 
   describe('applyCodeTheme', () => {
-    test('sets the data-code-theme attribute for a non-default theme', () => {
+    test('sets the data-code-theme attribute for a non-default theme and dispatches event', () => {
+      const listener = jest.fn();
+      window.addEventListener('algo-code-theme-change', listener);
       applyCodeTheme('midnight');
       expect(document.documentElement.getAttribute('data-code-theme')).toBe('midnight');
+      expect(listener).toHaveBeenCalled();
+      window.removeEventListener('algo-code-theme-change', listener);
     });
 
     test('removes the attribute for "default"', () => {

--- a/src/components/CodeThemePicker/index.tsx
+++ b/src/components/CodeThemePicker/index.tsx
@@ -3,11 +3,9 @@ import clsx from 'clsx';
 import { FiCheck, FiCode, FiChevronDown } from 'react-icons/fi';
 import {
   CODE_THEMES,
-  applyCodeTheme,
-  getStoredCodeTheme,
-  storeCodeTheme,
   type CodeTheme,
 } from '../../utils/codeTheme';
+import { useCodeTheme } from '../../contexts/AccentThemeContext';
 import styles from './styles.module.css';
 
 interface CodeThemePickerProps {
@@ -20,14 +18,9 @@ export default function CodeThemePicker({
   isMobile = false,
   className,
 }: CodeThemePickerProps): JSX.Element {
-  const [activeTheme, setActiveTheme] = useState<CodeTheme>('default');
+  const { codeTheme: activeTheme, setCodeTheme } = useCodeTheme();
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Sync state with local storage / Docusaurus head script
-  useEffect(() => {
-    setActiveTheme(getStoredCodeTheme());
-  }, []);
 
   // Keyboard and outside click listeners
   useEffect(() => {
@@ -55,11 +48,9 @@ export default function CodeThemePicker({
   }, [isOpen, isMobile]);
 
   const selectTheme = useCallback((theme: CodeTheme) => {
-    setActiveTheme(theme);
-    applyCodeTheme(theme);
-    storeCodeTheme(theme);
+    setCodeTheme(theme);
     setIsOpen(false);
-  }, []);
+  }, [setCodeTheme]);
 
   const activeOption =
     CODE_THEMES.find((t) => t.value === activeTheme) || CODE_THEMES[0];

--- a/src/components/ThemePicker/index.tsx
+++ b/src/components/ThemePicker/index.tsx
@@ -3,11 +3,9 @@ import clsx from 'clsx';
 import { FiCheck, FiDroplet, FiChevronDown } from 'react-icons/fi';
 import {
   ACCENT_THEMES,
-  applyAccentTheme,
-  getStoredAccentTheme,
-  storeAccentTheme,
   type AccentTheme,
 } from '../../utils/accentTheme';
+import { useAccentTheme } from '../../contexts/AccentThemeContext';
 import styles from './styles.module.css';
 
 interface ThemePickerProps {
@@ -20,14 +18,9 @@ export default function ThemePicker({
   isMobile = false,
   className,
 }: ThemePickerProps): JSX.Element {
-  const [activeTheme, setActiveTheme] = useState<AccentTheme>('default');
+  const { accentTheme: activeTheme, setAccentTheme } = useAccentTheme();
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Sync state with local storage on mount
-  useEffect(() => {
-    setActiveTheme(getStoredAccentTheme());
-  }, []);
 
   // Handle outside click & escape key
   useEffect(() => {
@@ -55,11 +48,9 @@ export default function ThemePicker({
   }, [isOpen, isMobile]);
 
   const selectTheme = useCallback((theme: AccentTheme) => {
-    setActiveTheme(theme);
-    applyAccentTheme(theme);
-    storeAccentTheme(theme);
+    setAccentTheme(theme);
     setIsOpen(false);
-  }, []);
+  }, [setAccentTheme]);
 
   const activeOption =
     ACCENT_THEMES.find((t) => t.value === activeTheme) || ACCENT_THEMES[0];

--- a/src/components/ThemePickerModal/index.tsx
+++ b/src/components/ThemePickerModal/index.tsx
@@ -1,20 +1,15 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef } from "react";
 import { FiCheck, FiDroplet, FiCode, FiX } from "react-icons/fi";
 import { useFocusTrap } from "../../hooks/useFocusTrap";
 import {
   ACCENT_THEMES,
-  applyAccentTheme,
-  getStoredAccentTheme,
-  storeAccentTheme,
   type AccentTheme,
 } from "../../utils/accentTheme";
 import {
   CODE_THEMES,
-  applyCodeTheme,
-  getStoredCodeTheme,
-  storeCodeTheme,
   type CodeTheme,
 } from "../../utils/codeTheme";
+import { useAccentTheme, useCodeTheme } from "../../contexts/AccentThemeContext";
 import styles from "./ThemePickerModal.module.css";
 
 interface ThemePickerModalProps {
@@ -26,27 +21,15 @@ export default function ThemePickerModal({ isOpen, onClose }: ThemePickerModalPr
   const modalRef = useRef<HTMLDivElement>(null);
   useFocusTrap(modalRef, { isOpen, onClose });
 
-  const [activeAccent, setActiveAccent] = useState<AccentTheme>("default");
-  const [activeCode, setActiveCode] = useState<CodeTheme>("default");
-
-  // Sync with stored values each time the modal opens
-  useEffect(() => {
-    if (isOpen) {
-      setActiveAccent(getStoredAccentTheme());
-      setActiveCode(getStoredCodeTheme());
-    }
-  }, [isOpen]);
+  const { accentTheme: activeAccent, setAccentTheme } = useAccentTheme();
+  const { codeTheme: activeCode, setCodeTheme } = useCodeTheme();
 
   const selectAccent = (theme: AccentTheme) => {
-    setActiveAccent(theme);
-    applyAccentTheme(theme);
-    storeAccentTheme(theme);
+    setAccentTheme(theme);
   };
 
   const selectCode = (theme: CodeTheme) => {
-    setActiveCode(theme);
-    applyCodeTheme(theme);
-    storeCodeTheme(theme);
+    setCodeTheme(theme);
   };
 
   if (!isOpen) return null;

--- a/src/contexts/AccentThemeContext.tsx
+++ b/src/contexts/AccentThemeContext.tsx
@@ -1,0 +1,170 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import {
+  type AccentTheme,
+  ACCENT_THEME_STORAGE_KEY,
+  ACCENT_THEME_EVENT,
+  getStoredAccentTheme,
+  storeAccentTheme,
+  applyAccentTheme,
+  isAccentTheme,
+} from '../utils/accentTheme';
+import {
+  type CodeTheme,
+  CODE_THEME_STORAGE_KEY,
+  CODE_THEME_EVENT,
+  getStoredCodeTheme,
+  storeCodeTheme,
+  applyCodeTheme,
+  isCodeTheme,
+} from '../utils/codeTheme';
+
+export interface AccentThemeContextType {
+  accentTheme: AccentTheme;
+  setAccentTheme: (theme: AccentTheme) => void;
+  codeTheme: CodeTheme;
+  setCodeTheme: (theme: CodeTheme) => void;
+}
+
+const AccentThemeContext = createContext<AccentThemeContextType | undefined>(undefined);
+
+export interface AccentThemeProviderProps {
+  children: ReactNode;
+}
+
+export function AccentThemeProvider({ children }: AccentThemeProviderProps): JSX.Element {
+  const [accentTheme, setAccentThemeState] = useState<AccentTheme>(() => getStoredAccentTheme());
+  const [codeTheme, setCodeThemeState] = useState<CodeTheme>(() => getStoredCodeTheme());
+
+  const setAccentTheme = useCallback((theme: AccentTheme) => {
+    setAccentThemeState(theme);
+    applyAccentTheme(theme);
+    storeAccentTheme(theme);
+  }, []);
+
+  const setCodeTheme = useCallback((theme: CodeTheme) => {
+    setCodeThemeState(theme);
+    applyCodeTheme(theme);
+    storeCodeTheme(theme);
+  }, []);
+
+  useEffect(() => {
+    // Synchronize initial state on mount with DOM attribute or localStorage
+    const currentAccent = getStoredAccentTheme();
+    setAccentThemeState(currentAccent);
+    applyAccentTheme(currentAccent);
+
+    const currentCode = getStoredCodeTheme();
+    setCodeThemeState(currentCode);
+    applyCodeTheme(currentCode);
+
+    // Listen for custom event within the same window
+    const handleAccentChange = (e: Event) => {
+      const customEvent = e as CustomEvent<AccentTheme>;
+      if (customEvent.detail && isAccentTheme(customEvent.detail)) {
+        setAccentThemeState(customEvent.detail);
+      } else {
+        setAccentThemeState(getStoredAccentTheme());
+      }
+    };
+
+    const handleCodeChange = (e: Event) => {
+      const customEvent = e as CustomEvent<CodeTheme>;
+      if (customEvent.detail && isCodeTheme(customEvent.detail)) {
+        setCodeThemeState(customEvent.detail);
+      } else {
+        setCodeThemeState(getStoredCodeTheme());
+      }
+    };
+
+    // Listen for storage events across tabs/windows
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === ACCENT_THEME_STORAGE_KEY) {
+        const newAccent = isAccentTheme(e.newValue) ? e.newValue : 'default';
+        setAccentThemeState(newAccent);
+        applyAccentTheme(newAccent);
+      } else if (e.key === CODE_THEME_STORAGE_KEY) {
+        const newCode = isCodeTheme(e.newValue) ? e.newValue : 'default';
+        setCodeThemeState(newCode);
+        applyCodeTheme(newCode);
+      }
+    };
+
+    window.addEventListener(ACCENT_THEME_EVENT, handleAccentChange);
+    window.addEventListener(CODE_THEME_EVENT, handleCodeChange);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener(ACCENT_THEME_EVENT, handleAccentChange);
+      window.removeEventListener(CODE_THEME_EVENT, handleCodeChange);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  const contextValue = useMemo<AccentThemeContextType>(
+    () => ({
+      accentTheme,
+      setAccentTheme,
+      codeTheme,
+      setCodeTheme,
+    }),
+    [accentTheme, setAccentTheme, codeTheme, setCodeTheme]
+  );
+
+  return (
+    <AccentThemeContext.Provider value={contextValue}>
+      {children}
+    </AccentThemeContext.Provider>
+  );
+}
+
+export function useAccentTheme(): {
+  accentTheme: AccentTheme;
+  setAccentTheme: (theme: AccentTheme) => void;
+} {
+  const context = useContext(AccentThemeContext);
+  if (!context) {
+    // Fallback if rendered outside provider (e.g. isolated test or standalone component)
+    return {
+      accentTheme: getStoredAccentTheme(),
+      setAccentTheme: (theme: AccentTheme) => {
+        applyAccentTheme(theme);
+        storeAccentTheme(theme);
+      },
+    };
+  }
+  return {
+    accentTheme: context.accentTheme,
+    setAccentTheme: context.setAccentTheme,
+  };
+}
+
+export function useCodeTheme(): {
+  codeTheme: CodeTheme;
+  setCodeTheme: (theme: CodeTheme) => void;
+} {
+  const context = useContext(AccentThemeContext);
+  if (!context) {
+    // Fallback if rendered outside provider
+    return {
+      codeTheme: getStoredCodeTheme(),
+      setCodeTheme: (theme: CodeTheme) => {
+        applyCodeTheme(theme);
+        storeCodeTheme(theme);
+      },
+    };
+  }
+  return {
+    codeTheme: context.codeTheme,
+    setCodeTheme: context.setCodeTheme,
+  };
+}
+
+export default AccentThemeContext;

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -11,6 +11,7 @@ import PageProgressIndicator from "../components/PageProgressIndicator";
 import SidebarUpdater from '../components/ProgressTracker/SidebarUpdater';
 import { AuthProvider } from "../contexts/AuthContext";
 import { CursorProvider } from "../contexts/CursorContext";
+import { AccentThemeProvider } from "../contexts/AccentThemeContext";
 import CustomCursor from "../components/CustomCursor";
  
 export default function Root({ children }) {
@@ -59,23 +60,25 @@ export default function Root({ children }) {
       </Head>
       <AuthProvider>
         <CursorProvider>
-          <CustomCursor />
-          <SidebarUpdater />
-          {isDocsPage && <PageProgressIndicator />}
-          {children}
-          <KeyboardShortcutsButton onClick={onOpenHelp} />
-          <KeyboardShortcutsModal
-            isOpen={showKeyboardModal}
-            onClose={onCloseHelp}
-          />
-          <ChallengeSearchModal
-            isOpen={showChallengeSearch}
-            onClose={onCloseSearch}
-          />
-          <ThemePickerModal
-            isOpen={showThemePicker}
-            onClose={onCloseThemePicker}
-          />
+          <AccentThemeProvider>
+            <CustomCursor />
+            <SidebarUpdater />
+            {isDocsPage && <PageProgressIndicator />}
+            {children}
+            <KeyboardShortcutsButton onClick={onOpenHelp} />
+            <KeyboardShortcutsModal
+              isOpen={showKeyboardModal}
+              onClose={onCloseHelp}
+            />
+            <ChallengeSearchModal
+              isOpen={showChallengeSearch}
+              onClose={onCloseSearch}
+            />
+            <ThemePickerModal
+              isOpen={showThemePicker}
+              onClose={onCloseThemePicker}
+            />
+          </AccentThemeProvider>
         </CursorProvider>
       </AuthProvider>
     </>

--- a/src/utils/accentTheme.ts
+++ b/src/utils/accentTheme.ts
@@ -2,6 +2,7 @@ export type AccentTheme = 'default' | 'high-contrast' | 'neon';
 
 export const ACCENT_THEME_STORAGE_KEY = 'algo-accent-theme';
 export const ACCENT_THEME_ATTRIBUTE = 'data-accent-theme';
+export const ACCENT_THEME_EVENT = 'algo-accent-theme-change';
 
 export interface AccentThemeOption {
   value: AccentTheme;
@@ -15,7 +16,7 @@ export const ACCENT_THEMES: AccentThemeOption[] = [
   { value: 'neon', label: 'Neon', description: 'Cyan & purple cyberpunk accent' },
 ];
 
-function isAccentTheme(value: string | null): value is AccentTheme {
+export function isAccentTheme(value: string | null): value is AccentTheme {
   return value === 'default' || value === 'high-contrast' || value === 'neon';
 }
 
@@ -23,6 +24,12 @@ function isAccentTheme(value: string | null): value is AccentTheme {
 export function getStoredAccentTheme(): AccentTheme {
   if (typeof window === 'undefined') return 'default';
   try {
+    if (typeof document !== 'undefined') {
+      const attr = document.documentElement.getAttribute(ACCENT_THEME_ATTRIBUTE);
+      if (attr && isAccentTheme(attr)) {
+        return attr;
+      }
+    }
     const stored = window.localStorage.getItem(ACCENT_THEME_STORAGE_KEY);
     return isAccentTheme(stored) ? stored : 'default';
   } catch {
@@ -52,4 +59,13 @@ export function applyAccentTheme(theme: AccentTheme): void {
   } else {
     document.documentElement.setAttribute(ACCENT_THEME_ATTRIBUTE, theme);
   }
+
+  if (typeof window !== 'undefined') {
+    try {
+      window.dispatchEvent(new CustomEvent(ACCENT_THEME_EVENT, { detail: theme }));
+    } catch {
+      // Ignore in environments where CustomEvent might be restricted
+    }
+  }
 }
+

--- a/src/utils/codeTheme.ts
+++ b/src/utils/codeTheme.ts
@@ -2,6 +2,7 @@ export type CodeTheme = 'default' | 'midnight' | 'solarized';
 
 export const CODE_THEME_STORAGE_KEY = 'algo-code-theme';
 export const CODE_THEME_ATTRIBUTE = 'data-code-theme';
+export const CODE_THEME_EVENT = 'algo-code-theme-change';
 
 export interface CodeThemeOption {
   value: CodeTheme;
@@ -15,13 +16,19 @@ export const CODE_THEMES: CodeThemeOption[] = [
   { value: 'solarized', label: 'Solarized', description: 'Soft low-contrast syntax styling for long reading sessions' },
 ];
 
-function isCodeTheme(value: string | null): value is CodeTheme {
+export function isCodeTheme(value: string | null): value is CodeTheme {
   return value === 'default' || value === 'midnight' || value === 'solarized';
 }
 
 export function getStoredCodeTheme(): CodeTheme {
   if (typeof window === 'undefined') return 'default';
   try {
+    if (typeof document !== 'undefined') {
+      const attr = document.documentElement.getAttribute(CODE_THEME_ATTRIBUTE);
+      if (attr && isCodeTheme(attr)) {
+        return attr;
+      }
+    }
     const stored = window.localStorage.getItem(CODE_THEME_STORAGE_KEY);
     return isCodeTheme(stored) ? stored : 'default';
   } catch {
@@ -49,4 +56,13 @@ export function applyCodeTheme(theme: CodeTheme): void {
   } else {
     document.documentElement.setAttribute(CODE_THEME_ATTRIBUTE, theme);
   }
+
+  if (typeof window !== 'undefined') {
+    try {
+      window.dispatchEvent(new CustomEvent(CODE_THEME_EVENT, { detail: theme }));
+    } catch {
+      // Ignore in environments where CustomEvent might be restricted
+    }
+  }
 }
+


### PR DESCRIPTION
### 📌 Description
Fixes #3935

This PR resolves the Flash of Unstyled Theme (FOUT) and state/attribute mismatch occurring between Docusaurus SSR HTML, the inline `<head>` script, and client-side React hydration for accent and code syntax themes.

### 🔍 Root Cause
Previously:
1. The inline script in `docusaurus.config.js` sets `data-accent-theme` and `data-code-theme` on `document.documentElement` before page paint.
2. React picker components (`ThemePicker`, `ThemePickerModal`, `CodeThemePicker`) initialized their own isolated local state to `'default'` and updated via `useEffect` after mount (~200ms delay).
3. This caused a visual flicker/delay on hard reloads and attribute mismatch during initial client render.

### 🛠️ Changes Implemented
- **Pre-Hydration Synchronized Utility Lookup**:
  - Enhanced [`getStoredAccentTheme()`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/utils/accentTheme.ts) and [`getStoredCodeTheme()`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/utils/codeTheme.ts) to first inspect `document.documentElement` attributes before querying `localStorage`.
- **Unified `AccentThemeContext`**:
  - Created [`AccentThemeContext.tsx`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/contexts/AccentThemeContext.tsx) offering centralized state management with `useAccentTheme` and `useCodeTheme` hooks.
  - Added listeners for intra-app custom DOM events (`algo-accent-theme-change`, `algo-code-theme-change`) and `storage` events across browser tabs.
- **Root Layout Integration**:
  - Wrapped application layout inside `<AccentThemeProvider>` in [`Root.js`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/theme/Root.js).
- **Component Refactoring**:
  - Refactored [`ThemePicker`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/components/ThemePicker/index.tsx), [`ThemePickerModal`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/components/ThemePickerModal/index.tsx), and [`CodeThemePicker`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/components/CodeThemePicker/index.tsx) to consume the shared context, removing duplicate state and eliminating the 200ms delayed hydration flicker.
- **Unit & Integration Tests**:
  - Added [`AccentThemeContext.test.tsx`](file:///c:/Users/prana/PG/ENGINEERING%20MATERIALS/PROJECTS/PROJECTS/algo/src/__tests__/contexts/AccentThemeContext.test.tsx) verifying default state, pre-hydrated DOM attribute synchronization, event dispatching, and persistence.
  - Updated all unit tests in `accentTheme.test.ts`, `codeTheme.test.ts`, `ThemePicker.test.tsx`, `ThemePickerModal.test.tsx`, and `CodeThemePicker.test.tsx`.

---

### ✅ Verification
Ran Jest test suites:
```bash
PASS src/__tests__/utils/accentTheme.test.ts
PASS src/__tests__/utils/codeTheme.test.ts
PASS src/__tests__/contexts/AccentThemeContext.test.tsx
PASS src/__tests__/components/ThemePickerModal.test.tsx
PASS src/__tests__/components/CodeThemePicker.test.tsx
PASS src/__tests__/components/ThemePicker.test.tsx

Test Suites: 6 passed, 6 total
Tests:       39 passed, 39 total
