### PR TITLE
fix: remove post-encoding truncation in sanitizeQuery to prevent broken HTML entities

### DIFF
--- a/src/utils/sanitizeQuery.ts
+++ b/src/utils/sanitizeQuery.ts
@@ -26,8 +26,9 @@ export function sanitizeQuery(query: string): string {
     return htmlEntities[char] || char;
   });
 
-  // 3. Ensure final sanitized output does not exceed 100 characters
-  return sanitized.slice(0, 100);
+  // 3. Return sanitized output — no second truncation to avoid cutting
+  //   HTML entities mid-entity (e.g. "&quo" from "&quot;")
+  return sanitized;
 }
 
 export default sanitizeQuery;


### PR DESCRIPTION
## Description
Removed the second `.slice(0, 100)` after HTML entity replacement in `sanitizeQuery.ts`.

### Problem
The function truncated input to 100 chars, then replaced special characters with HTML entities (which are longer), then truncated again to 100 chars. The second truncation could cut mid-entity (e.g. `&quo` from `&quot;`), corrupting search filters and triggering UI rendering errors.

### Fix
Removed the post-encoding truncation. The initial input truncation already caps length at 100 characters, and HTML entity encoding is for XSS safety, not length control.

## Related Issue
Closes #3923

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
